### PR TITLE
Single photo links

### DIFF
--- a/search/js/pandas.js
+++ b/search/js/pandas.js
@@ -677,7 +677,7 @@ Pandas.profilePhoto = function(animal, index) {
   }, {});
   // If photo.(index) not in the photos dict, choose one of the available keys
   // at random from the set of remaining valid images.
-  var choice = "photos." + index.toString(); 
+  var choice = "photo." + index.toString(); 
   if (photos[choice] == undefined) {
     var space = Object.keys(photos).length;
     var index = Math.floor(Math.random() * space);

--- a/search/js/query.js
+++ b/search/js/query.js
@@ -18,6 +18,14 @@ Query.env.preserve_case = false;
 // However, other output modes are supported based on the supplied types.
 // The "credit" search results in a spread of photos credited to a particular user.
 Query.env.output = "entities";
+// If a URI indicates a specific photo, indicate which one here.
+Query.env.specific = undefined;
+// Reset query environment back to defaults, typically after a search is run
+Query.env.clear = function() {
+  Query.env.preserve_case = false;
+  Query.env.output = "entities";
+  Query.env.specific = undefined;
+}
 
 /*
     Operator Definitions and aliases, organized into stages (processing order), and then
@@ -290,7 +298,8 @@ Query.hashlink = function(input) {
       (input.split("/").length == 4)) {
     // go-link for a panda result with a chosen photo.
     var uri_items = input.slice(7);
-    var [ panda, _, photo ] = uri_items.split("/");
+    var [ panda, _, photo_id ] = uri_items.split("/");
+    Query.env.specific = photo_id;
     return Query.resolver.subject(panda, "panda", L.display);    
   } else if ((input.indexOf("#panda/") == 0) &&
              (input.split("/").length == 2)) {

--- a/search/js/show.js
+++ b/search/js/show.js
@@ -342,8 +342,7 @@ function outputSearchResultPhotos(results) {
   var header = Show.credit(Query.env.credit, content_divs.length, L.display);
   content_divs.unshift(header);
   // HACK: revert to results mode
-  Query.env.output = "entities";
-  Query.env.preserve_case = false;
+  Query.env.clear();
   return content_divs;
 }
 
@@ -580,7 +579,8 @@ Show.routes = {
 // be displayed in an information card about the panda, including its zoo and
 // its relatives.
 Show.acquirePandaInfo = function(animal, language) {
-  var picture = Pandas.profilePhoto(animal, "random");   // TODO: all photos for carousel
+  var photo_index = Query.env.specific == undefined ? "random" : Query.env.specific;
+  var picture = Pandas.profilePhoto(animal, photo_index);   // TODO: all photos for carousel
   var bundle = {
             "age": Pandas.age(animal, language),
        "birthday": Pandas.birthday(animal, language),


### PR DESCRIPTION
Enables URIs of the form `#panda/23/photo/1` to allow linking to specific results with a specific photo. This will be necessary for things like photo carousels later on.