### PR TITLE
rewrite field defaults to support fallback for photo.N or video.N

### DIFF
--- a/build.py
+++ b/build.py
@@ -51,6 +51,7 @@ class RedPandaGraph:
         self.panda_files = []
         self.photo = {}
         self.photo["credit"] = {}
+        self.photo["max"] = 0
         self.vertices = []
         self.zoos = []
         self.zoo_files = []
@@ -199,6 +200,7 @@ class RedPandaGraph:
         export['_totals'] = {}
         export['_photo'] = {}
         export['_photo']['credit'] = self.photo['credit']
+        export['_photo']['entity_max'] = self.photo['max']
         export['_totals']['zoos'] = len(self.zoos)
         export['_totals']['pandas'] = self.sum_pandas()
         with open(destpath, 'wb') as wfh:
@@ -307,6 +309,11 @@ class RedPandaGraph:
                     self.photo["credit"][author] = self.photo["credit"][author] + 1
                 else:
                     self.photo["credit"][author] = 1
+                # Track what the max number of panda photos an object has is
+                test_count = int(field[0].split(".")[1])
+                if test_count > self.photo["max"]:
+                    self.photo["max"] = test_count
+                # Accept the data and continue
                 panda_vertex[field[0]] = field[1]
             else:
                 # Accept the data and move along

--- a/search/js/pandas.js
+++ b/search/js/pandas.js
@@ -92,6 +92,7 @@ Pandas.def.animal = {
   "video.3": "images/no-panda.jpg",
   "video.4": "images/no-panda.jpg",
   "video.5": "images/no-panda.jpg",
+  "species": "-1",
   "zoo": "0"
 }
 
@@ -255,10 +256,8 @@ Pandas.def.zoo = {
   "jp.address": "Googleマップのアドレスが記録されていません",
   "jp.location": "市区町村の情報が表示されていない",
   "jp.name": "動物園が見つかりません",
-  "photo.1": "No Photo Listed",
-  "photo.2": "No Photo Listed",
-  "video.1": "No Video Listed",
-  "video.2": "No Video Listed",
+  "photo": "No Photo Listed",
+  "video": "No Video Listed",
   "website": "https://www.worldwildlife.org/"
 }
 
@@ -606,7 +605,17 @@ Pandas.date = function(animal, field, language) {
 // Given a field that doesn't have language information associated with it,
 // return either the field if it exists, or some reasonable default.
 Pandas.field = function(animal, field) {
-  return animal[field] == undefined ? Pandas.def.animal[field] : animal[field];
+  if (animal[field] != undefined) {
+    return animal[field];
+  } else if (Pandas.def.animal[field] != undefined ) {
+    return Pandas.def.animal[field];
+  } else if (field.indexOf("photo.") == 0) {
+    return Pandas.def.animal["photo.1"];
+  } else if (field.indexOf("video.") == 0) {
+    return Pandas.def.animal["video.1"];
+  } else {
+    return undefined;
+  }
 }
 
 // Given an animal and a language, return the proper gender string.


### PR DESCRIPTION
Minor redpanda.json schema change to record what the max number of photos per entity is. This lets us iterate across all possible "photos.N" items in the dataset, for indexing by contributor, or for selecting a random photo.