### PR TITLE
Fix Woodland Park Zoo website URL

### DIFF
--- a/zoos/united states/0067_woodland-park.txt
+++ b/zoos/united states/0067_woodland-park.txt
@@ -9,4 +9,4 @@ jp.location: シアトル ワシントン
 jp.name: 森林公園動物園
 language.order: en, jp
 map: https://goo.gl/maps/4WtXGc1ZGnp
-website: https://nationalzoo.si.edu/
+website: https://www.zoo.org/


### PR DESCRIPTION
The original URL for the Woodland Park Zoo (`0067_woodland-park.txt`) was to the National Zoo (`0049_national-zoo-smithsonian.txt`).