### PR TITLE
Set Carson's birthplace to Lincoln Children's Zoo

### DIFF
--- a/pandas/0067_woodland-park/0311_carson.txt
+++ b/pandas/0067_woodland-park/0311_carson.txt
@@ -1,7 +1,7 @@
 [panda]
 _id: 311
 birthday: 2014/6/30
-birthplace: unknown
+birthplace: 80
 children: none
 en.name: Carson
 en.nicknames: none  

--- a/zoos/united states/0080_lincoln-childrens-zoo.txt
+++ b/zoos/united states/0080_lincoln-childrens-zoo.txt
@@ -1,0 +1,9 @@
+[zoo]
+_id: 80
+en.address: 1222 S 27th St, Lincoln, NE 68502
+en.location: Lincoln, NE, USA
+en.name: Lincoln Children's Zoo
+flag: USA
+language.order: en
+map: https://goo.gl/maps/5kHk6aS6A2R2
+website: https://www.lincolnzoo.org/


### PR DESCRIPTION
# Sources

- First postings sighted: https://www.facebook.com/lincolnchildrenszoo/photos/a.92084936159/10152271252716160/?type=1&theater
- Carson (and his sister Willa) given their names: https://www.facebook.com/lincolnchildrenszoo/photos/world-meet-carson-willa-the-red-panda-twins-the-names-carson-willa-were-submitte/10152338141666160/

# Gaps

I couldn't find Japanese information about the Lincoln Children's Zoo on Wikipedia to be able to properly translate the name of the zoo, so I omitted Japanese data for the zoo. (I managed to translate everything else, but figured adding only the location data there by itself wouldn't be useful.)
