### PR TITLE
fix bug in credit searches

### DIFF
--- a/js/query.js
+++ b/js/query.js
@@ -224,7 +224,7 @@ Query.rules = {
 */
 Query.actions = {
   "type": function(env, capture) {
-    var type = capture;
+    var type = capture.replace(" ", "");   // Support zeroary types
     // Don't adjust case for author searches. Switch to "photo credit" output mode
     if (Query.ops.type.credit.includes(type)) {
       Query.env.preserve_case = true;

--- a/tests/js/query.js
+++ b/tests/js/query.js
@@ -224,7 +224,7 @@ Query.rules = {
 */
 Query.actions = {
   "type": function(env, capture) {
-    var type = capture;
+    var type = capture.replace(" ", "");   // Support zeroary types
     // Don't adjust case for author searches. Switch to "photo credit" output mode
     if (Query.ops.type.credit.includes(type)) {
       Query.env.preserve_case = true;


### PR DESCRIPTION
When adding zeroary operators, I do a check for non-end-of-line that eats a space character. That space was getting appended to the end of whatever the first word in a search query would be, and was screwing up checks for the `credit` type. This broke `credit` searches ever since I added the `babies` operator.