### PR TITLE
add testing section fragments for refactoring about/links pages

### DIFF
--- a/tests/fragments/en/about.html
+++ b/tests/fragments/en/about.html
@@ -1,0 +1,50 @@
+<div id="hiddenContentFrame" class="about">
+<div class="shrinker">
+<div class="pandaAbout">
+<h2>About Red Pandas</h2>
+<h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
+<p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
+<p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
+<p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+<h2>Surprising Red Panda Facts</h2>
+<ul>
+<li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
+<li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
+</ul>
+<img class="aboutFocus" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+<h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
+<ul>
+<li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
+<li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
+</ul>
+<img class="twinFocus" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+<img class="twinFocus" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+<h5 class="caption">Marimo and a bamboo root (left,&nbsp;📷&nbsp;yossi929), and the apple twins Melody and Jazz (right,&nbsp;📷&nbsp;nakacchi_desu)</h5>
+<ul>
+<li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
+<li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
+<li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their their mating and breeding schedule shifts by six months to match the seasons.</li>
+</ul>
+<img class="aboutFocus" src="https://www.instagram.com/p/BQkZPmwhZIu/media/?size=l" alt="Marumi and Gin, fun with mom" />
+<h5 class="caption">Marumi the Mom-terrorizer! <a href="https://www.instagram.com/sina_dw/">(📷&nbsp;sina_dw)</a></h5>
+<ul>
+<li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
+<li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
+<li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
+</ul>
+<img class="twinFocus" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+<img class="twinFocus" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+<h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
+<ul>
+<li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
+</ul>
+
+</div><!-- pandaAbout -->
+</div><!-- shrinker -->     
+</div><!-- contentFrame -->

--- a/tests/fragments/en/links.html
+++ b/tests/fragments/en/links.html
@@ -1,0 +1,63 @@
+<div id="hiddenContentFrame" class="links">
+<div class="shrinker">
+<div class="pandaLinks">
+<h2>Red Panda Community</h2>
+<ul class="linkList heart">
+<li><a href="https://www.redpandanetwork.org">Red Panda Network</a></li>
+<li><a href="https://redpandazine.com">Red Pandazine</a></li>
+</ul>
+
+<h2>Zoos Focused on Red Pandas</h2>
+<p>There are many zoos represented in this dataset, but some of them are hotspots for seeing Red Pandas.</p>
+
+<ul class="linkList panda">
+<li><a href="http://www.chausuyama.com/">Chausuyama Zoo</a></li>
+<li><a href="http://www.city.ichikawa.lg.jp/zoo/index.html">Ichikawa Zoo</a></li>
+<li><a href="https://www.city.sabae.fukui.jp/nishiyama_zoo/">Nishiyama Zoo</a></li>
+<li><a href="http://www.tokyo-zoo.net/zoo/tama/">Tama Zoo</a></li>
+<li><a href="http://www.nhdzoo.jp/">Nihondaira Zoo</a></li>
+<li><a href="http://tohoku-safaripark.co.jp/">Tohoku Safari Park</a></li>
+<li><a href="https://www.city.chiba.jp/zoo/">Chiba Zoological Park</a></li>
+</ul>
+
+<h2>Red Pandas on Instagram</h2>
+<p>Without this list of dedicated Instagram red panda fans and their collected lineage data, this site would not exist.</p>
+
+<ul class="linkList multiColumn bamboo">
+<!-- Populate this automatically in the future -->
+<li><a href="https://www.instagram.com/miis_98/">miis_98</a></li>
+<li><a href="https://www.instagram.com/yuka0714_0307/">yuka_0714_0307</a></li>
+<li><a href="https://www.instagram.com/fetorus_mami/">fetorus_mami</a></li>
+<li><a href="https://www.instagram.com/hanamaru_redpanda/">hanamaru_redpanda</a></li>
+<li><a href="https://www.instagram.com/_rifa_p/">_rifa_p</a></li>
+<li><a href="https://www.instagram.com/lsdar13/">lsdar13</a></li>
+<li><a href="https://www.instagram.com/love__mitarashi/">love__mitarashi</a></li>
+<li><a href="https://www.instagram.com/minatomirai215/">minatomirai215</a></li>
+<li><a href="https://www.instagram.com/kotata_513/">kotata_513</a></li>
+<li><a href="https://www.instagram.com/yossi929/">yossi929</a></li>
+<li><a href="https://www.instagram.com/craig_craig_craig/">craig_craig_craig</a></li>
+<li><a href="https://www.instagram.com/panda.daisuki/">panda.daisuki</a></li>
+<li><a href="https://www.instagram.com/masumilky/">masumilky</a></li>
+<li><a href="https://www.instagram.com/tabechum/">tabechum</a></li>
+<li><a href="https://www.instagram.com/daniele.tokyo/">daniele.tokyo</a></li>
+<li><a href="https://www.instagram.com/framereim/">framereim</a></li>
+<li><a href="https://www.instagram.com/firefoxpanda88/">firefoxpanda88</a></li>
+<li><a href="https://www.instagram.com/cattail.sapporo/">cattail.sapporo</a></li>
+<li><a href="https://www.instagram.com/makimaru18/">makimaru18</a></li>
+<li><a href="https://www.instagram.com/gloryeui/">gloryeui</a></li>
+<li><a href="https://www.instagram.com/simasima_sippo/">simasima_sippo</a></li>
+<li><a href="https://www.instagram.com/kinkinkin0826/">kinkinkin0826</a></li>
+</ul>
+
+<h2>Special Thanks</h2>
+<ul class="linkList heart">
+<li><a href="https://www.instagram.com/daniele.tokyo/">daniele.tokyo</a>, my wise English life-raft in Japan</li>
+<li><a href="https://www.instagram.com/firefoxpanda88/">firefoxpanda88</a>, for being a kind and supportive friend</li>
+<li><a href="https://www.instagram.com/cattail.sapporo/">cattail.sapporo</a>, your love for pandas spreads far and wide!</li>
+<li><a href="http://blog.livedoor.jp/miyanomayu3/archives/cat_57622.html">miyanomayu</a>, for growing my heart three sizes.</li>
+<li>To red panda supporters worldwide: <u>thank you for visiting</u> 😊</li>
+</ul>
+
+</div><!-- pandaLinks -->
+</div><!-- shrinker -->     
+</div><!-- contentFrame -->

--- a/tests/fragments/jp/about.html
+++ b/tests/fragments/jp/about.html
@@ -1,0 +1,33 @@
+<div id="hiddenContentFrame" class="about">
+<div class="shrinker">
+<div class="pandaAbout">
+<h2>なぜレッサーパンダ?</h2>
+<h4><a href="https://www.instagram.com/firefoxpanda88/">✍️ firefoxpanda88</a></h4>
+
+<p>レッサーパンダの魅力・・・それはなんといっても姿かたち、そして仕草が愛らしいことだと思います。
+私は地球上で最も美しい生き物だとすら思っています。
+でも、一言で「愛らしい、美しい」といってしまうには、あまりにも物足りない気がしてしまいます。
+なぜならば、すべてのレッサーパンダに個性があり、それぞれに魅力的だからです。
+野性味あふれる孤高な雰囲気のコ、甘えん坊なコ、イタズラ好きなコ・・・とても書ききれないほど、本当に様々ですよね。</p>
+
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/JXffNYvofFw" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+<p>さて、ここで、私がレッサーパンダ追いとなったきっかけの一つを紹介しましょう。
+初めて足を運ぶ動物園で初めて出会ったレッサーパンダなのに
+「どうしても初めて会った気がしない」
+という不思議な出来事がありました。
+レッサーパンダファンの方ならもうお分かりだと思いますが・・・
+ほかに特徴のよく似たコを知っていたのです。
+帰って調べてみると、そのコたちは姉妹だったんです！
+そこからは動物園に直接通わずともネットの画像などで似ているコを見つけては調べ・・・を繰り返し、気が付けば家系を追うようになっていました。
+そうこうするうちに、会いたいコがどんどん増えてきて、いろんな動物園に通うようになりました。（まだまだとても通いきれていませんが）</p>
+
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/Mnfw3xe6c6Y" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+<p>こちらの　RED PANDA FINDER では、両親や兄弟などのリンクもあるので、それをたどってまずはお気に入りのコの家族、そしてそのまた家族・・・と思いをはせてみるのはいかがでしょうか？</p>
+
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/Qw6rtOPdBBw" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+</div><!-- pandaAbout -->
+</div><!-- shrinker -->     
+</div><!-- contentFrame -->

--- a/tests/fragments/jp/links.html
+++ b/tests/fragments/jp/links.html
@@ -1,0 +1,61 @@
+<div id="hiddenContentFrame" class="links">
+<div class="shrinker">
+<div class="pandaLinks">
+<h2>レッサーパンダの共同体</h2>
+<ul class="linkList heart">
+<li><a href="https://www.redpandanetwork.org">Red Panda Network</a></li>
+<li><a href="https://redpandazine.com">Red Pandazine</a></li>
+</ul>
+
+<h2>レッサーパンダの動物園</h2>
+
+<ul class="linkList panda">
+<li><a href="http://www.chausuyama.com/">Chausuyama Zoo</a></li>
+<li><a href="http://www.city.ichikawa.lg.jp/zoo/index.html">Ichikawa Zoo</a></li>
+<li><a href="https://www.city.sabae.fukui.jp/nishiyama_zoo/">Nishiyama Zoo</a></li>
+<li><a href="http://www.tokyo-zoo.net/zoo/tama/">Tama Zoo</a></li>
+<li><a href="http://www.nhdzoo.jp/">Nihondaira Zoo</a></li>
+<li><a href="http://tohoku-safaripark.co.jp/">Tohoku Safari Park</a></li>
+<li><a href="https://www.city.chiba.jp/zoo/">Chiba Zoological Park</a></li>
+</ul>
+
+<h2>Instagram レッサーパンダ</h2>
+
+<ul class="linkList multiColumn bamboo">
+<!-- Populate this automatically in the future -->
+<li><a href="https://www.instagram.com/miis_98/">miis_98</a></li>
+<li><a href="https://www.instagram.com/yuka0714_0307/">yuka_0714_0307</a></li>
+<li><a href="https://www.instagram.com/fetorus_mami/">fetorus_mami</a></li>
+<li><a href="https://www.instagram.com/hanamaru_redpanda/">hanamaru_redpanda</a></li>
+<li><a href="https://www.instagram.com/_rifa_p/">_rifa_p</a></li>
+<li><a href="https://www.instagram.com/lsdar13/">lsdar13</a></li>
+<li><a href="https://www.instagram.com/love__mitarashi/">love__mitarashi</a></li>
+<li><a href="https://www.instagram.com/minatomirai215/">minatomirai215</a></li>
+<li><a href="https://www.instagram.com/kotata_513/">kotata_513</a></li>
+<li><a href="https://www.instagram.com/yossi929/">yossi929</a></li>
+<li><a href="https://www.instagram.com/craig_craig_craig/">craig_craig_craig</a></li>
+<li><a href="https://www.instagram.com/panda.daisuki/">panda.daisuki</a></li>
+<li><a href="https://www.instagram.com/masumilky/">masumilky</a></li>
+<li><a href="https://www.instagram.com/tabechum/">tabechum</a></li>
+<li><a href="https://www.instagram.com/daniele.tokyo/">daniele.tokyo</a></li>
+<li><a href="https://www.instagram.com/framereim/">framereim</a></li>
+<li><a href="https://www.instagram.com/firefoxpanda88/">firefoxpanda88</a></li>
+<li><a href="https://www.instagram.com/cattail.sapporo/">cattail.sapporo</a></li>
+<li><a href="https://www.instagram.com/makimaru18/">makimaru18</a></li>
+<li><a href="https://www.instagram.com/gloryeui/">gloryeui</a></li>
+<li><a href="https://www.instagram.com/simasima_sippo/">simasima_sippo</a></li>
+<li><a href="https://www.instagram.com/kinkinkin0826/">kinkinkin0826</a></li>
+</ul>
+
+<h2>感佩</h2>
+<ul class="linkList heart">
+<li><a href="https://www.instagram.com/daniele.tokyo/">daniele.tokyo</a></li>
+<li><a href="https://www.instagram.com/firefoxpanda88/">firefoxpanda88</a></li>
+<li><a href="https://www.instagram.com/cattail.sapporo/">cattail.sapporo</a></li>
+<li><a href="http://blog.livedoor.jp/miyanomayu3/archives/cat_57622.html">miyanomayu</a></li>
+<li>レッサーパンダのオタク: <u>本当に、ありがとうございました</u> 😊</li>
+</ul>
+
+</div><!-- pandaLinks -->
+</div><!-- shrinker -->     
+</div><!-- contentFrame -->

--- a/tests/js/show.js
+++ b/tests/js/show.js
@@ -200,7 +200,7 @@ function checkHashes() {
 
 // Fetch the about page contents
 function fetchAboutPage() {
-  var base = "https://redpandafinder.com/fragments/";
+  var base = "https://redpandafinder.com/tests/fragments/";
   var specific = L.display + "/about.html";
   var fetch_url = base + specific;
   var request = new XMLHttpRequest();
@@ -216,7 +216,7 @@ function fetchAboutPage() {
 
 // Fetch the links page contents
 function fetchLinksPage() {
-  var base = "https://redpandafinder.com/fragments/";
+  var base = "https://redpandafinder.com/tests/fragments/";
   var specific = L.display + "/links.html";
   var fetch_url = base + specific;
   var request = new XMLHttpRequest();


### PR DESCRIPTION
Now that these fragments have test versions, I can iterate per-push until the menus and buttons work properly. I'd do this on a test-repo but I'm hoping it shouldn't be more than one or two passes before the fragments look correct.