### PR TITLE
Utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /export
+**.pyc
+__pycache__

--- a/build.py
+++ b/build.py
@@ -9,27 +9,7 @@ import json
 import os
 import sys
 
-PANDA_PATH = "./pandas"
-OUTPUT_PATH = "./export/redpanda.json"
-ZOO_PATH = "./zoos" 
-
-class DateConsistencyError(ValueError):
-    pass
-
-class DateFormatError(ValueError):
-    pass
-
-class GenderFormatError(ValueError):
-    pass
-
-class IdError(KeyError):
-    pass
-
-class LinkError(IndexError):
-    pass
-
-class NameFormatError(ValueError):
-    pass
+from shared import *
 
 class RedPandaGraph:
     """Class with the redpanda database and format/consistency checks.

--- a/manage.py
+++ b/manage.py
@@ -10,16 +10,57 @@ import json
 import os
 import sys
 
-from shared import *
+from shared import PANDA_PATH, ZOO_PATH
 
-def renumber_photos(data_file):
+def find_next_photo_index(panda_file, start_point, stop_point):
+    """
+    Given we deleted pandas from a dataset entry, find the next available photo
+    to move to the first available spot.
+    """
+    photo_index = start_point
+    panda = configparser.ConfigParser()
+    panda.read(panda_file)
+    photo_option = "photo." + start_point
+    while panda.has_option("panda", photo_option) == False:
+        photo_index = photo_index + 1
+        photo_option = "photo." + photo_index
+        # If start point went beyond the last photo, return zero
+        if photo_index > stop_point:
+            return 0
+    return start_point
+
+def renumber_panda_photos(panda_file, stop_point):
     """
     Given a file that's just had photos removed from it, renumber all the
     remaining photos so that there are no gaps.
     """
-    pass
+    start_index = 1
+    photo_index = start_index
+    panda = configparser.ConfigParser()
+    panda.read(panda_file)
+    while photo_index <= stop_point:
+        # If a photo doesn't exist, find the next photo that exists and swap its value
+        photo_option = "photo." + photo_index
+        photo_author = photo_option + ".author"
+        photo_link = photo_option + ".link"
+        if panda.has_option("panda", photo_option) == False:
+            next_index = find_next_photo_index(panda_file, photo_index, stop_point)
+            if next_index > 0:
+                next_option = "photo." + next_index
+                next_author = next_option + ".author"
+                next_link = next_option + ".link"
+                panda.set("panda", photo_option, panda.get("panda", next_option))
+                panda.set("panda", photo_author, panda.get("panda", next_author))
+                panda.set("panda", photo_link, panda.get("panda", next_link))
+                panda.remove_option("panda", next_option)
+                panda.remove_option("panda", next_section)
+                panda.remove_option("panda", next_link)
+            else:
+                # We're done processing photos if there are none to renumber
+                break
+        photo_index = photo_index + 1
 
-def remove_photos(author):
+def remove_panda_photos(author):
     """
     Occasionally users will remove or rename their photo files online.
     For cases where the original files cannot be recovered, it may be
@@ -28,13 +69,49 @@ def remove_photos(author):
     Given a author (typically an Instagram username), remove their photos
     from every panda or zoo data entry.
     """
-    # Enter the pandas and zoos subdirectories.
-    # If photo.?.author matches author, remove all photo.?. values.
-    # Then renumber the remaining contents
-    pass
+    start_index = 1
+    photo_index = start_index
+    panda = configparser.ConfigParser()
+    # Enter the pandas subdirectories
+    for root, dirs, files in os.walk(PANDA_PATH):
+        for filename in files:
+            panda.read(filename)
+            photo_option = "photo." + photo_index 
+            author_option = photo_option + ".author"
+            author_link = photo_option + ".link"
+            # Look at all available photo fields for a panda, until we get to
+            # the Nth photo that doesn't exist 
+            while panda.has_option("panda", author_option):
+                panda_author = panda.get("panda", "photo." + photo_index + ".author")
+                if author == panda_author:
+                    panda.remove_option("panda", photo_option)
+                    panda.remove_option("panda", author_option)
+                    panda.remove_option("panda", author_link)
+                photo_index = photo_index + 1
+                photo_option = "photo." + photo_index 
+                author_option = photo_option + ".author"
+                author_link = photo_option + ".link"
+            # Done removing photos? Renumber the ones that are still there
+            renumber_panda_photos(filename, photo_index)
+
+def remove_zoo_photos(author):
+    """
+    Zoos only have a single photo recorded for each one.
+    """
+    zoo = configparser.ConfigParser()
+    # Enter the zoo subdirectories
+    for root, dirs, files in os.walk(ZOO_PATH):
+        for filename in files:
+            zoo.read(filename)
+            zoo_author = zoo.get("zoo", "photo.author")
+            if zoo_author == author:
+                zoo.remove_option("zoo", "photo") 
+                zoo.remove_option("zoo", "photo.author") 
+                zoo.remove_option("zoo", "photo.link") 
 
 if __name__ == '__main__':
     """Choose a utility funciton."""
     if len(sys.argv) == 3:
         if sys.argv[1] == "--remove-photos":
-            remove_photos(sys.argv[2])
+            remove_panda_photos(sys.argv[2])
+            remove_zoo_photos(sys.argv[2])

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+# This Red Panda Lineage dataset management tool is useful for doing sweeping dataset
+# revisions, such as ensuring that a field exists in each panda or zoo file, or removing
+# photos taken by a specific credited author.
+
+import configparser
+import datetime
+import json
+import os
+import sys
+
+from shared import *
+
+def renumber_photos(data_file):
+    """
+    Given a file that's just had photos removed from it, renumber all the
+    remaining photos so that there are no gaps.
+    """
+    pass
+
+def remove_photos(author):
+    """
+    Occasionally users will remove or rename their photo files online.
+    For cases where the original files cannot be recovered, it may be
+    simpler to remove photos by an author and add them back later.
+
+    Given a author (typically an Instagram username), remove their photos
+    from every panda or zoo data entry.
+    """
+    # Enter the pandas and zoos subdirectories.
+    # If photo.?.author matches author, remove all photo.?. values.
+    # Then renumber the remaining contents
+    pass
+
+if __name__ == '__main__':
+    """Choose a utility funciton."""
+    if len(sys.argv) == 3:
+        if sys.argv[1] == "--remove-photos":
+            remove_photos(sys.argv[2])

--- a/manage.py
+++ b/manage.py
@@ -5,59 +5,71 @@
 # photos taken by a specific credited author.
 
 import configparser
-import datetime
-import json
 import os
+import re
 import sys
 
+from collections import OrderedDict
 from shared import PANDA_PATH, ZOO_PATH
 
-def find_next_photo_index(panda_file, start_point, stop_point):
+def fetch_next_photo_index(config, start_point, stop_point):
     """
-    Given we deleted pandas from a dataset entry, find the next available photo
-    to move to the first available spot.
+    Given we deleted pandas from a dataset entry, find the first available hole in
+    the list of photos, and the next available photo to move into that hole.
     """
     photo_index = start_point
-    panda = configparser.ConfigParser()
-    panda.read(panda_file)
-    photo_option = "photo." + start_point
-    while panda.has_option("panda", photo_option) == False:
+    photo_option = "photo." + str(photo_index)
+    is_photo = config.has_option("panda", photo_option)
+    if is_photo == True:
+        # Find the first hole (slot without a photo)
+        while is_photo == True:
+            photo_index = photo_index + 1
+            photo_option = "photo." + str(photo_index)
+            is_photo = config.has_option("panda", photo_option)
+            if photo_index > stop_point:
+                return 0
+    # Now that we're in holes, find the next valid photo
+    while is_photo == False:
         photo_index = photo_index + 1
-        photo_option = "photo." + photo_index
+        photo_option = "photo." + str(photo_index)
+        is_photo = config.has_option("panda", photo_option)
         # If start point went beyond the last photo, return zero
         if photo_index > stop_point:
             return 0
-    return start_point
+    print("DEBUG photo-fetch: " + str(photo_index) + ": " + config.get("panda", photo_option))
+    return photo_index
 
-def renumber_panda_photos(panda_file, stop_point):
+def renumber_panda_photos(config, stop_point):
     """
     Given a file that's just had photos removed from it, renumber all the
     remaining photos so that there are no gaps.
     """
     start_index = 1
     photo_index = start_index
-    panda = configparser.ConfigParser()
-    panda.read(panda_file)
     while photo_index <= stop_point:
         # If a photo doesn't exist, find the next photo that exists and swap its value
-        photo_option = "photo." + photo_index
+        photo_option = "photo." + str(photo_index)
         photo_author = photo_option + ".author"
         photo_link = photo_option + ".link"
-        if panda.has_option("panda", photo_option) == False:
-            next_index = find_next_photo_index(panda_file, photo_index, stop_point)
-            if next_index > 0:
-                next_option = "photo." + next_index
-                next_author = next_option + ".author"
-                next_link = next_option + ".link"
-                panda.set("panda", photo_option, panda.get("panda", next_option))
-                panda.set("panda", photo_author, panda.get("panda", next_author))
-                panda.set("panda", photo_link, panda.get("panda", next_link))
-                panda.remove_option("panda", next_option)
-                panda.remove_option("panda", next_section)
-                panda.remove_option("panda", next_link)
-            else:
-                # We're done processing photos if there are none to renumber
-                break
+        # print("DEBUG COUNTER: " + str(photo_index))
+        if config.has_option("panda", photo_option) == False:
+            next_index = fetch_next_photo_index(config, photo_index, stop_point)
+            next_option = "photo." + str(next_index)
+            next_author = next_option + ".author"
+            next_link = next_option + ".link"
+            print("DEBUG RENUMBER CHECK: current photo: " + photo_option + " -- next index: " + str(next_index))
+            if config.has_option("panda", next_option) == True:
+                print("DEBUG RENUMBER: " + next_option + " -> " + photo_option)
+                if config.has_option("panda", next_option):
+                    print("DEBUG pre-remove: " + next_option + " : " + config.get("panda", next_option))
+                config.set("panda", photo_option, config.get("panda", next_option))
+                config.set("panda", photo_author, config.get("panda", next_author))
+                config.set("panda", photo_link, config.get("panda", next_link))
+                config.remove_option("panda", next_option)
+                config.remove_option("panda", next_author)
+                config.remove_option("panda", next_link)
+                if config.has_option("panda", next_option):
+                    print("DEBUG post-remove: " + next_option + " : " + config.get("panda", next_option))
         photo_index = photo_index + 1
 
 def remove_panda_photos(author):
@@ -70,48 +82,81 @@ def remove_panda_photos(author):
     from every panda or zoo data entry.
     """
     start_index = 1
-    photo_index = start_index
-    panda = configparser.ConfigParser()
+    removals = 0
     # Enter the pandas subdirectories
     for root, dirs, files in os.walk(PANDA_PATH):
         for filename in files:
-            panda.read(filename)
-            photo_option = "photo." + photo_index 
+            photo_index = start_index
+            path = root + os.sep + filename
+            config = configparser.ConfigParser(default_section="panda")
+            config.read(path, encoding="utf-8")
+            photo_option = "photo." + str(photo_index)
             author_option = photo_option + ".author"
             author_link = photo_option + ".link"
             # Look at all available photo fields for a panda, until we get to
             # the Nth photo that doesn't exist 
-            while panda.has_option("panda", author_option):
-                panda_author = panda.get("panda", "photo." + photo_index + ".author")
+            while config.has_option("panda", author_option) == True:
+                panda_author = config.get("panda", "photo." + str(photo_index) + ".author")
                 if author == panda_author:
-                    panda.remove_option("panda", photo_option)
-                    panda.remove_option("panda", author_option)
-                    panda.remove_option("panda", author_link)
+                    print("DEBUG REMOVE: " + path + " -- " + panda_author + " -- " + photo_option)
+                    config.remove_option("panda", photo_option)
+                    config.remove_option("panda", author_option)
+                    config.remove_option("panda", author_link)
+                    removals = removals + 1
                 photo_index = photo_index + 1
-                photo_option = "photo." + photo_index 
+                photo_option = "photo." + str(photo_index)
                 author_option = photo_option + ".author"
                 author_link = photo_option + ".link"
-            # Done removing photos? Renumber the ones that are still there
-            renumber_panda_photos(filename, photo_index)
+            # Next, renumber the ones that are still there
+            if removals > 0:
+                renumber_panda_photos(config, photo_index)
+            # Done? Let's write config
+            write_config(config, "panda", path)
+
 
 def remove_zoo_photos(author):
     """
     Zoos only have a single photo recorded for each one.
     """
-    zoo = configparser.ConfigParser()
+    config = configparser.ConfigParser(default_section="zoo")
     # Enter the zoo subdirectories
     for root, dirs, files in os.walk(ZOO_PATH):
         for filename in files:
-            zoo.read(filename)
+            path = root + os.sep + filename
+            config.read(path, encoding="utf-8")
             zoo_author = zoo.get("zoo", "photo.author")
             if zoo_author == author:
-                zoo.remove_option("zoo", "photo") 
-                zoo.remove_option("zoo", "photo.author") 
-                zoo.remove_option("zoo", "photo.link") 
+                config.remove_option("zoo", "photo") 
+                config.remove_option("zoo", "photo.author") 
+                config.remove_option("zoo", "photo.link")
+            # Done with removals?
+            write_config(config, "zoo", path)
+
+def strings_number_sensitive(input):
+    """
+    If there's a number in the filename, translate it to its equivalent ASCII value. This way, the
+    sorting of the number is preserved, rather than treating the digits like characters themselves
+    """
+    components = input[0].split(".")
+    output = []
+    for val in components:
+        if val.isdigit():
+            val = chr(int(val))
+        output.append(val)
+    return ".".join(output)
+
+def write_config(config, section, path):
+    """
+    Write the config file out, in alphabetical sorted order just as they are read in.
+    """
+    with open(path, 'w', encoding='utf-8') as wfh:
+        # Sort the sections before writing
+        config._defaults = OrderedDict(sorted(config._defaults.items(), key=strings_number_sensitive))
+        config.write(wfh)
 
 if __name__ == '__main__':
     """Choose a utility funciton."""
     if len(sys.argv) == 3:
         if sys.argv[1] == "--remove-photos":
             remove_panda_photos(sys.argv[2])
-            remove_zoo_photos(sys.argv[2])
+            # remove_zoo_photos(sys.argv[2])

--- a/manage.py
+++ b/manage.py
@@ -36,7 +36,6 @@ def fetch_next_photo_index(config, start_point, stop_point):
         # If start point went beyond the last photo, return zero
         if photo_index > stop_point:
             return 0
-    print("DEBUG photo-fetch: " + str(photo_index) + ": " + config.get("panda", photo_option))
     return photo_index
 
 def renumber_panda_photos(config, stop_point):
@@ -51,25 +50,18 @@ def renumber_panda_photos(config, stop_point):
         photo_option = "photo." + str(photo_index)
         photo_author = photo_option + ".author"
         photo_link = photo_option + ".link"
-        # print("DEBUG COUNTER: " + str(photo_index))
         if config.has_option("panda", photo_option) == False:
             next_index = fetch_next_photo_index(config, photo_index, stop_point)
             next_option = "photo." + str(next_index)
             next_author = next_option + ".author"
             next_link = next_option + ".link"
-            print("DEBUG RENUMBER CHECK: current photo: " + photo_option + " -- next index: " + str(next_index))
             if config.has_option("panda", next_option) == True:
-                print("DEBUG RENUMBER: " + next_option + " -> " + photo_option)
-                if config.has_option("panda", next_option):
-                    print("DEBUG pre-remove: " + next_option + " : " + config.get("panda", next_option))
                 config.set("panda", photo_option, config.get("panda", next_option))
                 config.set("panda", photo_author, config.get("panda", next_author))
                 config.set("panda", photo_link, config.get("panda", next_link))
                 config.remove_option("panda", next_option)
                 config.remove_option("panda", next_author)
                 config.remove_option("panda", next_link)
-                if config.has_option("panda", next_option):
-                    print("DEBUG post-remove: " + next_option + " : " + config.get("panda", next_option))
         photo_index = photo_index + 1
 
 def remove_panda_photos(author):
@@ -98,7 +90,7 @@ def remove_panda_photos(author):
             while config.has_option("panda", author_option) == True:
                 panda_author = config.get("panda", "photo." + str(photo_index) + ".author")
                 if author == panda_author:
-                    print("DEBUG REMOVE: " + path + " -- " + panda_author + " -- " + photo_option)
+                    # print("DEBUG REMOVE: " + path + " -- " + panda_author + " -- " + photo_option)
                     config.remove_option("panda", photo_option)
                     config.remove_option("panda", author_option)
                     config.remove_option("panda", author_link)

--- a/shared.py
+++ b/shared.py
@@ -1,0 +1,23 @@
+# Shared Python information for the Red Panda Lineage scripts
+
+PANDA_PATH = "./pandas"
+OUTPUT_PATH = "./export/redpanda.json"
+ZOO_PATH = "./zoos" 
+
+class DateConsistencyError(ValueError):
+    pass
+
+class DateFormatError(ValueError):
+    pass
+
+class GenderFormatError(ValueError):
+    pass
+
+class IdError(KeyError):
+    pass
+
+class LinkError(IndexError):
+    pass
+
+class NameFormatError(ValueError):
+    pass


### PR DESCRIPTION
Added and tested a tool that will let me remove entire users' photos from the dataset as needed.

Sometimes people shuffle things around in Instagram. It used to futz RPF up really badly, but with the helper script (`manage.py --remote-photos <username>`) it will be a little better. Obviously this script could easily footgun data but that's why we have Git and branches. :+1: