### PR TITLE
Photo reflow

### DIFF
--- a/js/show.js
+++ b/js/show.js
@@ -1612,6 +1612,8 @@ Show.photoSwap = function(photo, desired_index) {
   // Actually replace the photo.
   // photo.parentNode.replaceChild(new_photo, photo);
   photo.src = new_photo.src;
+  photo.id = new_photo.id;
+  photo.className = new_photo.className;
   Show.displayPhotoTouch(new_photo);
   var photo_info = Pandas.profilePhoto(animal, new_index);
   // Replace the animal credit info

--- a/js/show.js
+++ b/js/show.js
@@ -1045,8 +1045,7 @@ Show.displayEmptyResult = function(language) {
 }
 
 // Male and female icons next to pandas used for panda links.
-// This uses unlocalized m/f/unknown gender values, and displays
-// an alien face if the gender is not determined as a joke
+// This uses unlocalized m/f/unknown gender values
 Show.displayChildIcon = function(gender) {
   if (Object.values(Pandas.def.gender.Male).indexOf(gender) != -1) {
     return Show.emoji.boy;
@@ -1610,8 +1609,10 @@ Show.photoSwap = function(photo, desired_index) {
   } else {
     return;  // No carousel, no need to actually swap photos
   }
-  // Actually replace the photo
-  photo.parentNode.replaceChild(new_photo, photo);
+  // Actually replace the photo.
+  // TODO: do a replacement of an image in a tag
+  // photo.parentNode.replaceChild(new_photo, photo);
+  photo.src = new_photo.src;
   Show.displayPhotoTouch(new_photo);
   var photo_info = Pandas.profilePhoto(animal, new_index);
   // Replace the animal credit info

--- a/js/show.js
+++ b/js/show.js
@@ -1610,7 +1610,6 @@ Show.photoSwap = function(photo, desired_index) {
     return;  // No carousel, no need to actually swap photos
   }
   // Actually replace the photo.
-  // TODO: do a replacement of an image in a tag
   // photo.parentNode.replaceChild(new_photo, photo);
   photo.src = new_photo.src;
   Show.displayPhotoTouch(new_photo);


### PR DESCRIPTION
This finally fixes the reflow issues I had with image swaps. The key was not replacing the IMG element outright, but changing the class/id/params of the existing image element. 

There are still bugs that could be fixed to make image preloading a little quicker, but I want to get this fix out there since it improves things so much on iPhone (the Safari browser in particular).