### PR TITLE
Refactor layout 2

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -528,14 +528,14 @@ div.parents, div.litter, div.siblings, div.children, div.names {
 
 /* Add these after an element to guarantee that its display will force a new flex line.
    On Firefox, CSS "page-break-after" works for this, but on Chrome it does not. */
-hr.flexDivider {
+hr.divider {
     display: block;
     width: 100%;
     border: 0px solid;
     margin: 0 0 0 0;
 }
 
-hr.flexDivider.onlyMobile {
+hr.divider.onlyMobile {
     display: none;
 }
 
@@ -976,17 +976,23 @@ div.photoSample h5.caption.familyTitle {
         flex-wrap: wrap;
     }
 
+    div.family.multiColumn {
+        display: block;
+        column-count: 2;
+        column-gap: 10px;
+    }
+
     div.parents, div.litter, div.siblings, div.children, div.names {
         text-align: left;
         flex-grow: 1;   /* Expand out things to simulate column gap in the lists */
         padding-left: 0px;
     }
 
-    hr.flexDivider.onlyDesktop {
+    hr.divider.onlyDesktop {
         display: none;
     }
 
-    hr.flexDivider.onlyMobile {
+    hr.divider.onlyMobile {
         display: block;
     }
 

--- a/css/panda.css
+++ b/css/panda.css
@@ -555,14 +555,16 @@ ul.pandaList, ul.linkList {
 
 ul.pandaList.double {
     column-count: 2;
-    /* column-width: 6.4em; */
     column-gap: 10px;   /* Same as left padding */
 }
 
 ul.pandaList.triple {
     column-count: 3;
-    /* column-width: 6.4em; */
     column-gap: 10px;   /* Same as left padding */
+}
+
+ul.pandaList.double.onlyMobile, ul.pandaList.triple.onlyMobile {
+    column-count: 1;
 }
 
 ul.pandaList.flat {
@@ -1021,6 +1023,16 @@ div.photoSample h5.caption.familyTitle {
     ul.pandaList.double, ul.pandaList.triple, ul.pandaList.flat {
         width: auto;   /* Fill available space in flex */
         height: auto;   /* And account for names in a li that are really long */
+    }
+
+    ul.pandaList.double.onlyMobile {
+        column-count: 2;
+        column-gap: 10px;
+    }
+
+    ul.pandaList.triple.onlyMobile {
+        column-count: 3;
+        column-gap: 10px;
     }
 
     /* On small screens, not enough room */

--- a/css/panda.css
+++ b/css/panda.css
@@ -545,6 +545,14 @@ div.parents.singleton, div.litter.singleton, div.siblings.singleton, div.childre
     flex-grow: 1;
 }
 
+div.parents.double, div.litter.double, div.siblings.double, div.children.double {
+    width: 50%;
+}
+
+div.parents.triple, div.litter.triple, div.siblings.triple, div.children.triple {
+    width: 75%;
+}
+
 ul.pandaList, ul.linkList {
     text-align: left;
     list-style: none;
@@ -986,6 +994,11 @@ div.photoSample h5.caption.familyTitle {
         text-align: left;
         flex-grow: 1;   /* Expand out things to simulate column gap in the lists */
         padding-left: 0px;
+    }
+
+    div.parents.double, div.litter.double, div.siblings.double, div.children.double,
+    div.parents.triple, div.litter.triple, div.siblings.triple, div.children.triple {
+        width: auto;
     }
 
     hr.divider.onlyDesktop {

--- a/css/panda.css
+++ b/css/panda.css
@@ -546,11 +546,11 @@ div.parents.singleton, div.litter.singleton, div.siblings.singleton, div.childre
 }
 
 div.parents.double, div.litter.double, div.siblings.double, div.children.double {
-    width: 50%;
+    /* width: 40%; */   /* No winning the width game here */
 }
 
 div.parents.triple, div.litter.triple, div.siblings.triple, div.children.triple {
-    width: 75%;
+    /* width: 80%; */   /* No winning the width game here */
 }
 
 ul.pandaList, ul.linkList {

--- a/js/layout.js
+++ b/js/layout.js
@@ -48,6 +48,15 @@ Layout.between = function(test, a, b, mode) {
   }
 }
 
+/* Create a divider. This is a horizontal rule element with 100% width. 
+   Works great for breaking the flow of either a flex box or a multiColumn box */
+Layout.divider = function(className) {
+  var breaker = document.createElement('hr');
+  breaker.className = "divider";
+  breaker.classList.add(className);
+  return breaker;
+}
+
 /* Take a div list, and apply flatten classes to it. When adding a flattened class,
    we need to add a line-break entity afterwards, and bump the flex box display
    order of subsequent inserted divs. */
@@ -61,14 +70,6 @@ Layout.flatten = function(div, mode) {
     div.childNodes[1].classList.add("flat");
   }
   return div;
-}
-
-/* Create a flex divider. This is a horizontal rule element with 100% width. */
-Layout.flexDivider = function(className) {
-  var breaker = document.createElement('hr');
-  breaker.className = "flexDivider";
-  breaker.classList.add(className);
-  return breaker;
 }
 
 /* Take a div list, and apply a column-mode class to it. */
@@ -223,7 +224,7 @@ Layout.L.arrangement.children = undefined;
 // TODO: this may be the basis of a basic layout which takes arguments:
 // flattenTop, multiColumn, others.
 // Take all inputs and display as straight columns.
-Layout.L.arrangement.columns = function() {
+Layout.L.arrangement.columns = function(nobreak=false) {
   // Specific list values that exist (this["parents"] = HTMLElement, ...)
   var lists = this.list_default.map(x => this[x]).filter(x => x != undefined);
   // Add line breaks after every two columns, and add order values to every item
@@ -232,8 +233,8 @@ Layout.L.arrangement.columns = function() {
     cur_list.style.order = this.boxOrder++;
     this.family.append(cur_list);
     this.distance++;
-    if (this.distance == 2) {
-      var breaker = Layout.flexDivider("onlyMobile");
+    if ((this.distance == 2) && (nobreak != true)) {
+      var breaker = Layout.divider("onlyMobile");
       breaker.style.order = this.boxOrder++;
       this.family.append(breaker);
       this.resetCounters("breakers");
@@ -272,7 +273,7 @@ Layout.L.arrangement.oneMultiColumn = function(columns=0, breaker_mode="both", c
     this.family.append(cur_list);
     this.distance++;
     if ((this.distance == 2) || (this.dividerMode != false)) {
-      var breaker = Layout.flexDivider(breaking_style);
+      var breaker = Layout.divider(breaking_style);
       breaker.style.order = this.boxOrder++;
       this.family.append(breaker);
       this.resetCounters("breakers");
@@ -312,7 +313,7 @@ Layout.L.arrangement.allMultiColumns = function(columns=0, breaker_mode="both", 
     this.family.append(cur_list);
     this.distance++;
     if ((this.distance == 2) || (this.dividerMode != false)) {
-      var breaker = Layout.flexDivider(breaking_style);
+      var breaker = Layout.divider(breaking_style);
       breaker.style.order = this.boxOrder++;
       this.family.append(breaker);
       this.resetCounters("breakers");
@@ -345,7 +346,7 @@ Layout.L.arrangement.flatten = function(mode="onlyMobile") {
     this.family.append(cur_list);
     this.distance++;
     if ((this.distance == 2) || (this.dividerMode != false)) {
-      var breaker = Layout.flexDivider("onlyMobile");
+      var breaker = Layout.divider("onlyMobile");
       breaker.style.order = this.boxOrder++;
       this.family.append(breaker);
       this.resetCounters("breakers");
@@ -391,7 +392,7 @@ Layout.L.arrangement.flattenPlusMultiColumn = function(columns=0, breaker_mode="
     this.distance++;
     // Add a divider unless we've just processed the final column
     if (((this.distance == 2) || (this.dividerMode != false)) && (i != lists.length - 1)) {
-      var breaker = Layout.flexDivider(breaking_style);
+      var breaker = Layout.divider(breaking_style);
       breaker.style.order = this.boxOrder++;
       this.family.append(breaker);
       this.resetCounters("breakers");
@@ -413,8 +414,15 @@ Layout.L.arrangement.shortMultiColumn = function(columns, mode="both") {
 // kick the little ones out and let the longer column run. If a fourth column
 // appears, display it underneath the long column. This is easier done using
 // a multicolumn-flow for divs, instead of the normal flex flow.
-Layout.L.arrangement.longRun = function() {
-  return;
+// FOR NOW, THIS IS MOBILE ONLY and will default to columns otherwise.
+Layout.L.arrangement.longRun = function(mode="onlyMobile") {
+  this.family.classList.add("multiColumn");
+  if (mode == "onlyMobile") {
+    return this.columns(nobreak = true);
+  } else {
+    return this.columns();
+  }
+  // TODO: balance columns better by swapping places?
 }
 
 // Where the last column displayed in the order must be the longest on mobile
@@ -490,7 +498,7 @@ Layout.L.arrangement.div3_0_0_3_0 = function() { return this.columns() }
 Layout.L.arrangement.div4_2_2_0_0 = function() { return this.columns() }
 // Four list items. Two in one category and singles
 // TODO: long run, since flatten mode is ambiguous with ordering
-// Layout.L.arrangement.div4_2_1_1_0 = function() { return this.longRun("onlyMobile") }
+Layout.L.arrangement.div4_2_1_1_0 = function() { return this.longRun("onlyMobile") }
 // Four list items. Three in one category
 Layout.L.arrangement.div4_0_0_3_1 = function() { return this.columns() }
 // Four list items. All in one category. Longer lists will get multiColumn'ed
@@ -499,9 +507,9 @@ Layout.L.arrangement.div4_0_0_4_0 = function() { return this.columns() }
 Layout.L.arrangement.div5_2_0_3_0 = function() { return this.columns() }
 // Five list items. Two parents and a two/one split.
 // TODO: consider flattenTop for this style of layout
-Layout.L.arrangement.div5_2_2_1_0 = function() { return this.columns() }
+Layout.L.arrangement.div5_2_2_1_0 = function() { return this.longRun("onlyMobile") }
 // Five list items. Two parents and three other columns
-Layout.L.arrangement.div5_2_1_1_1 = function() { return this.columns() }
+Layout.L.arrangement.div5_2_1_1_1 = function() { return this.longRun("onlyMobile") }
 // Five list items. Four in one list, and a fifth
 Layout.L.arrangement.div5_0_0_4_1 = function() { return this.columns() }
 // Six list items. Two parents and others in a single column
@@ -561,7 +569,7 @@ Layout.L.arrangement.div9_2_2_5_0 = function() { return this.oneMultiColumn(2) }
 Layout.L.arrangement.div9_2_1_6_0 = function() { return this.oneMultiColumn(2) }
 // Nine list items, but a single column of three looks out of place here.
 // TODO: IMPLEMENT
-// Layout.L.arrangement.div9_0_0_6_3 = Layout.L.arrangement.shortMultiColumn(2);
+// Layout.L.arrangement.div9_0_0_6_3 = function() { return this.Layout.L.arrangement.shortMultiColumn(2);
 Layout.L.arrangement.div9_2_0_7_0 = function() { return this.flattenPlusMultiColumn(2) };
 Layout.L.arrangement.div9_0_0_8_1 = function() { return this.flattenPlusMultiColumn(3) };
 // Ten list items. Parents and balanced elsewhere

--- a/js/layout.js
+++ b/js/layout.js
@@ -253,6 +253,7 @@ Layout.L.arrangement.multiColumn = function(columns, breaker_mode="both", column
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
+    cur_list.style.order = this.boxOrder++;
     var list_name = order[i];
     var list_len = this.num[list_name];
     // What the multicolumn split should be
@@ -283,6 +284,7 @@ Layout.L.arrangement.flatten = function(mode="onlyMobile") {
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
+    cur_list.style.order = this.boxOrder++;
     // Flatten the first list
     if (i == 0) {
       Layout.flatten(cur_list, mode);
@@ -293,7 +295,6 @@ Layout.L.arrangement.flatten = function(mode="onlyMobile") {
       cur_list.classList.add("singleton");
       this.dividerMode = mode;
     }
-    cur_list.style.order = this.boxOrder++;
     this.family.append(cur_list);
     this.distance++;
     if ((this.distance == 2) || (this.dividerMode != false)) {
@@ -414,7 +415,8 @@ Layout.L.arrangement.addFlexDivider = function(mainDiv) {
 
 // Find the longest column
 Layout.L.arrangement.largestColumn = function() {
-  return Object.keys(this.num).reduce(function(a, b){return obj[a] > obj[b] ? a : b });
+  var num = this.num;   /* Annoying scoping */
+  return Object.keys(num).reduce(function(a, b){return num[a] > num[b] ? num[a] : num[b] });
 }
 
 // Clear state after doing a layout operation. Partial clears are useful

--- a/js/layout.js
+++ b/js/layout.js
@@ -185,16 +185,19 @@ Layout.L.layoutFamily = function() {
     // If small number of siblings or children
     if (this.checks.manyChildrenNoSiblings() || this.checks.manySiblingsNoChildren()) {
       this.parents = Layout.flatten(this.parents, onlyMobile=true);
+      this.arrangement.dividerMode = "mobileOnly";
     }
     // If no litter column on mobile, and five or more children or siblings, 
     // flatten the parents before doing others
     if (this.checks.parentsButNoLitter() && this.checks.singleLongChildrenOrSiblingsList()) {
       this.parents = Layout.flatten(this.parents, onlyMobile=true);
+      this.arrangement.dividerMode = "mobileOnly";
     }
     // If no litter column, and two short columns of children and siblings, 
     // flatten the parents before doing others
     if (this.checks.parentsButNoLitter() && this.checks.twoShortChildrenAndSiblingsLists()) {
       this.parents = Layout.flatten(this.parents, onlyMobile=true);
+      this.arrangement.dividerMode = "mobileOnly";
     }
     // Append parents div to the family display
     this.family.appendChild(this.parents);
@@ -310,7 +313,7 @@ Layout.L.arrangement.columns = function() {
     }
   }
   // Return distance/flexBreaker counters to default values
-  this.arrangement.reset();
+  this.reset();
 }
 
 // Take the longest column and make into a multicolumn list.
@@ -342,7 +345,7 @@ Layout.L.arrangement.multiColumn = function(columns, mode="both") {
     }
   }
   // Return distance/flexBreaker counters to default values
-  this.arrangement.reset();
+  this.reset();
 }
 
 // Flatten a single column (the first one) both on mobile and desktop
@@ -371,7 +374,7 @@ Layout.L.arrangement.flatten = function(mode="onlyMobile") {
     }
   }
   // Return distance/flexBreaker counters to default values
-  this.arrangement.reset();
+  this.reset();
 }
 
 // Combination of flattenTop and multiColumn.

--- a/js/layout.js
+++ b/js/layout.js
@@ -527,10 +527,11 @@ Layout.L.arrangement.verticalBalance = function() {
 // after adding a divider, so support that as the default.
 Layout.L.arrangement.resetCounters = function(mode="partial") {
   if (mode=="all") {
-    Layout.L.arrangement.boxOrder = 0;
+    this.boxOrder = 0;
+    this.list_order = this.list_default;
   }
-  Layout.L.arrangement.distance = 0;
-  Layout.L.arrangement.dividerMode = false;
+  this.distance = 0;
+  this.dividerMode = false;
 }
 
 // In the cutoff list that describes how many columns to use, find the first value

--- a/js/layout.js
+++ b/js/layout.js
@@ -60,6 +60,24 @@ Layout.multiColumn = function(div, columnCount=2) {
   return div;
 }
 
+/* Create all permutations of an input string. This is used to determine the
+   arrangements of parents and children in the layout function */
+Layout.permutations = function(input) {
+  var results = [];
+  if (input.length == 1) {
+    return input;
+  }
+  for (var i = 0; i < input.length; i++) {
+    var firstVal = input[i];
+    var valsLeft = input.slice(0, i).concat(input.slice(i + 1));
+    var innerPermutations = this.permutations(valsLeft);
+    for (var j = 0; j < innerPermutations.length; j++) {
+      results.push([firstVal].concat(innerPermutations[j]));
+    }
+  }
+  return results;
+}
+
 /* Swap the target column with the destination column. On mobile, include logic
     that pushes the swapped column up to be even with the swapped column. */
 Layout.swapColumn = function(target, destination, height_adjust, destination_cnt) {
@@ -120,7 +138,7 @@ Layout.L.count = function(p=0, l=0, s=0, c=0) {
 Layout.L.layout = function() {
   // Given the counts and sum, create a function name to call as an index
   var sum = (this.num.parents + this.num.litter + this.num.siblings + this.num.children).toString();
-  var orders = this.permutations(this.arrangement.list_order);
+  var orders = Layout.permutations(this.arrangement.list_order);
   // Find the name of an arrangement function based on the lits counts.
   // divn_parentcnt_littercnt_siblingcnt_childcnt => example: div6_2_1_3_0
   var arrange_id = undefined;
@@ -232,24 +250,6 @@ Layout.L.num.parents = 0;
 Layout.L.num.litter = 0;
 Layout.L.num.siblings = 0;
 Layout.L.num.children = 0;
-
-/* Create all permutations of an input string. This is used to determine the
-   arrangements of parents and children in the layout function */
-Layout.permutations = function(input) {
-  var results = [];
-  if (input.length == 1) {
-    return input;
-  }
-  for (var i = 0; i < input.length; i++) {
-    var firstVal = input[i];
-    var valsLeft = input.slice(0, i).concat(input.slice(i + 1));
-    var innerPermutations = this.permutations(valsLeft);
-    for (var j = 0; j < innerPermutations.length; j++) {
-      results.push([firstVal].concat(innerPermutations[j]));
-    }
-  }
-  return results;
-}
 
 /* All details of creating new content and arranging that content happens in the 
    arrangement object. */

--- a/js/layout.js
+++ b/js/layout.js
@@ -220,7 +220,7 @@ Layout.L.arrangement.children = undefined;
 // Take all inputs and display as straight columns.
 Layout.L.arrangement.columns = function() {
   // Specific list values that exist (this["parents"] = HTMLElement, ...)
-  var lists = this.list_order.map(x => this[x]).filter(x => x != undefined);
+  var lists = this.list_default.map(x => this[x]).filter(x => x != undefined);
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
@@ -247,9 +247,9 @@ Layout.L.arrangement.multiColumn = function(columns, breaker_mode="both", column
   // a multicolumn, or just in the normal flow of adding columns
   var breaking_style = breaker_mode;
   // The list order we're dealing with (strings "parents", "litter")
-  var order = this.list_order.map(x => this[x] != undefined);
+  var order = this.list_default.map(x => this[x] != undefined);
   // Specific list values that exist (this["parents"] = HTMLElement, ...)
-  var lists = this.list_order.map(x => this[x]).filter(x => x != undefined);
+  var lists = this.list_default.map(x => this[x]).filter(x => x != undefined);
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
@@ -279,7 +279,7 @@ Layout.L.arrangement.multiColumn = function(columns, breaker_mode="both", column
 // Flatten a single column (the first one) both on mobile and desktop
 Layout.L.arrangement.flatten = function(mode="onlyMobile") {
   // Specific list values that exist (this["parents"] = HTMLElement, ...)
-  var lists = this.list_order.map(x => this[x]).filter(x => x != undefined);
+  var lists = this.list_default.map(x => this[x]).filter(x => x != undefined);
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
@@ -314,7 +314,7 @@ Layout.L.arrangement.flattenPlusMultiColumn = function(columns, breaker_mode="bo
   // a multicolumn, or just in the normal flow of adding columns
   var breaking_style = breaker_mode;
   // Specific list values that exist (this["parents"] = HTMLElement, ...)
-  var lists = this.list_order.map(x => this[x]).filter(x => x != undefined);
+  var lists = this.list_default.map(x => this[x]).filter(x => x != undefined);
   // Add line breaks after every two columns, and add order values to every item
   for (let i = 0; i < lists.length; i++) {
     var cur_list = lists[i];
@@ -420,7 +420,7 @@ Layout.L.arrangement.largestColumn = function() {
 // Clear state after doing a layout operation. Partial clears are useful
 // after adding a divider, so support that as the default.
 Layout.L.arrangement.resetCounters = function(mode="partial") {
-  if (mode="all") {
+  if (mode=="all") {
     Layout.L.arrangement.boxOrder = 0;
   }
   Layout.L.arrangement.distance = 0;

--- a/js/layout.js
+++ b/js/layout.js
@@ -646,7 +646,7 @@ Layout.L.arrangement.div10_2_2_5_1 = function() { return this.flattenPlusMultiCo
 Layout.L.arrangement.div10_2_1_5_2 = function() { return this.longRun("onlyMobile") };
 // Ten list items. Balanced lists and a muticolumn
 // TODO: On mobile, flatten all the short columns.
-Layout.L.arrangement.div10_2_2_6_0 = function() { return this.allMultiColumns(2, "onlyMobile", "onlyMobile") };
+Layout.L.arrangement.div10_2_2_6_0 = function() { return this.oneMultiColumn(2, "onlyMobile", "onlyMobile") };
 // Ten list items. Sneak the singles down the left
 Layout.L.arrangement.div10_2_1_6_1 = function() { return this.longRun("onlyMobile") };
 // Ten list items. Too long to be a long run.

--- a/js/layout.js
+++ b/js/layout.js
@@ -13,24 +13,24 @@ var Layout = {};   /* Namespace */
 Layout.L = {};   /* Prototype */
 
 Layout.init = function(family, info, parents, litter, siblings, children) {
-    var layout = Object.create(Layout.L);
-    // Set up item counts, since this is easier than pulling them from HTML.
-    // Either both parents are displayed (one as undefined), or neither.
-    if ((info.dad != undefined) || (info.mom != undefined)) {
-        layout.num.parents = 2;
-    }
-    layout.num.litter = info.litter.length;
-    layout.num.siblings = info.siblings.length;
-    layout.num.children = info.children.length;
-    // Make sure children objects checks can see this object's counts
-    layout.checks.num = layout.num;
-    // Set up the divs themselves
-    layout.family = layout.arrangement.family = family;
-    layout.parents = layout.arrangement.parents = parents;
-    layout.litter = layout.arrangement.litter = litter;
-    layout.siblings = layout.arrangement.siblings = siblings;
-    layout.children = layout.arrangement.children = children;
-    return layout;
+  var layout = Object.create(Layout.L);
+  // Set up item counts, since this is easier than pulling them from HTML.
+  // Either both parents are displayed (one as undefined), or neither.
+  if ((info.dad != undefined) || (info.mom != undefined)) {
+      layout.num.parents = 2;
+  }
+  layout.num.litter = info.litter.length;
+  layout.num.siblings = info.siblings.length;
+  layout.num.children = info.children.length;
+  // Make sure children objects checks can see this object's counts
+  layout.checks.num = layout.num;
+  // Set up the divs themselves
+  layout.family = layout.arrangement.family = family;
+  layout.parents = layout.arrangement.parents = parents;
+  layout.litter = layout.arrangement.litter = litter;
+  layout.siblings = layout.arrangement.siblings = siblings;
+  layout.children = layout.arrangement.children = children;
+  return layout;
 }
 
 /* Create a flex divider. This is a horizontal rule element with 100% width. */

--- a/js/layout.js
+++ b/js/layout.js
@@ -76,9 +76,11 @@ Layout.flatten = function(div, mode) {
 Layout.multiColumn = function(div, columnCount=2, extraStyle=undefined) {
   if (columnCount == 2) {
     div.childNodes[1].classList.add("double");
+    div.classList.add("double");
   }
   if (columnCount == 3) {
     div.childNodes[1].classList.add("triple");
+    div.classList.add("triple");
   }
   if (extraStyle != undefined) {
     div.childNodes[1].classList.add(extraStyle);
@@ -478,7 +480,8 @@ Layout.L.arrangement.verticalBalance = function() {
   // Ordering permutations we want to try. 
   var valid_list = this.list_default.filter(x => this.num[x] != 0);
   // Always keep parents first, or whatever the earliest valid entry is
-  var permutations = Layout.permutations(valid_list).filter(x => x[0] == valid_list[0] && x[1] == valid_list[1]);
+  var permutations = Layout.permutations(valid_list).filter(x => x[0] == valid_list[0] && 
+                                                            (x[1] == valid_list[1]));
   // How many lines worth of space do we count the gap between lists?
   // Two lines, since it's spacing and a column header
   var between_list_pad = 2;
@@ -621,7 +624,7 @@ Layout.L.arrangement.div9_2_2_3_3 = function() { return this.columns() };
 Layout.L.arrangement.div9_2_1_5_1 = function() { return this.longRun("onlyMobile") };
 // Nine list items. A long column goes multiColumn. 
 // On mobile the broader multicolumn lists should shrink down to two columns
-Layout.L.arrangement.div9_2_2_5_0 = function() { return this.oneMultiColumn(2) };
+Layout.L.arrangement.div9_2_2_5_0 = function() { return this.oneMultiColumn(2, "onlyMobile", "onlyMobile") };
 Layout.L.arrangement.div9_2_1_6_0 = function() { return this.oneMultiColumn(2) };
 // Nine list items, but a single column of three looks out of place here.
 // TODO: IMPLEMENT
@@ -636,6 +639,8 @@ Layout.L.arrangement.div10_2_2_3_3 = function() { return this.columns() };
 // Layout.L.arrangement.div10_2_1_4_3 = Layout.L.arrangement.lastColumnLong;
 // Ten list items. Flatten the top, and multicolumn the largest one
 Layout.L.arrangement.div10_2_2_5_1 = function() { return this.flattenPlusMultiColumn(2) };
+// Another arrangement of that 10 looks better a different way
+Layout.L.arrangement.div10_2_1_5_2 = function() { return this.longRun("onlyMobile") };
 // Ten list items. Balanced lists and a muticolumn
 // TODO: On mobile, flatten all the short columns.
 Layout.L.arrangement.div10_2_2_6_0 = function() { return this.allMultiColumns(2, "onlyMobile", "onlyMobile") };

--- a/js/layout.js
+++ b/js/layout.js
@@ -269,6 +269,9 @@ Layout.L.arrangement.oneMultiColumn = function(columns=0, breaker_mode="both", c
       var mc_count = columns;
       if (mc_count == 0) { mc_count = this.multiColumnCount(list_len) }
       Layout.multiColumn(cur_list, mc_count);
+      if (this.existingColumns() == 1) {
+        cur_list.classList.add("singleton");   // More width for solo columns
+      }
       this.dividerMode = column_mode;   /* Add a divider based on input mode */
       breaking_style = column_mode;     /* Will do an after-column-style break */
     }

--- a/js/show.js
+++ b/js/show.js
@@ -1190,7 +1190,7 @@ Show.displayPandaFamily = function(info) {
     children = Show.displayPandaChildren(info);
   }
   var layout = Layout.init(family, info, parents, litter, siblings, children);
-  family = layout.layoutFamily();
+  family = layout.layout();
   return family;
 }
 


### PR DESCRIPTION
This finally adds the "switchboard" style layout management for the panda family lists I've been envisioning for months!

Based on the arrangement of pandas, I can override the layout with one that is more space-efficient, or more attractive, on a case-by-case basis.

A few of the modes are still TBD and I feel like there's some kind of bug or failure to see permutations in the `longRun()` layout, but it's empirically better than what I have, so updating.