### PR TITLE
Layout 4

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -521,7 +521,7 @@ div.family {
     flex-wrap: wrap;
 }
 
-div.family.vertical {
+div.family.vertical, div.family.vertical.onlyDesktop {
     display: flex;
     flex-direction: column;
 }
@@ -1001,6 +1001,10 @@ div.photoSample h5.caption.familyTitle {
 
     div.family {
         width: 100%;
+        flex-direction: row;
+    }
+
+    div.family.vertical.onlyDesktop {
         flex-direction: row;
     }
 

--- a/css/panda.css
+++ b/css/panda.css
@@ -526,6 +526,10 @@ div.family.vertical, div.family.vertical.onlyDesktop {
     flex-direction: column;
 }
 
+div.family.vertical.onlyDesktop {
+    align-content: start;   /* Makes lists swing left */
+}
+
 div.family.vertical.onlyMobile {
     display: flex;
     flex-direction: row;
@@ -575,12 +579,10 @@ ul.pandaList, ul.linkList {
 
 ul.pandaList.double {
     column-count: 2;
-    column-gap: 10px;   /* Same as left padding */
 }
 
 ul.pandaList.triple {
     column-count: 3;
-    column-gap: 10px;   /* Same as left padding */
 }
 
 ul.pandaList.double.onlyMobile, ul.pandaList.triple.onlyMobile {
@@ -1040,13 +1042,6 @@ div.photoSample h5.caption.familyTitle {
         display: block;
     }
 
-    /* On mobile, parents divs that break after display, must be width 100% and not singletons,
-       as the singletons are 100% on desktop mode too!
-    div.parents.onlyMobileBreakAfter {
-        width: 100%;
-    }
-    */
-
     div.pandaDetails p, div.zooDetails p {
         margin-left: 14px;
     }
@@ -1077,12 +1072,12 @@ div.photoSample h5.caption.familyTitle {
 
     ul.pandaList.double.onlyMobile {
         column-count: 2;
-        column-gap: 10px;
+        column-gap: 20px;
     }
 
     ul.pandaList.triple.onlyMobile {
         column-count: 3;
-        column-gap: 10px;
+        column-gap: 20px;
     }
 
     /* On small screens, not enough room */

--- a/js/layout.js
+++ b/js/layout.js
@@ -596,7 +596,6 @@ Layout.L.arrangement.div3_0_0_3_0 = function() { return this.columns() };
 // Four list items. Two parents and two in a second column
 Layout.L.arrangement.div4_2_2_0_0 = function() { return this.columns() };
 // Four list items. Two in one category and singles
-// TODO: long run, since flatten mode is ambiguous with ordering
 Layout.L.arrangement.div4_2_1_1_0 = function() { return this.longRun("onlyMobile") };
 // Four list items. Three in one category
 Layout.L.arrangement.div4_0_0_3_1 = function() { return this.columns() };
@@ -659,7 +658,8 @@ Layout.L.arrangement.div9_0_0_8_1 = function() { return this.flattenPlusMultiCol
 Layout.L.arrangement.div10_2_0_4_4 = function() { return this.flatten("onlyMobile") };
 // Ten list items. Spread out wide
 Layout.L.arrangement.div10_2_2_3_3 = function() { return this.columns() };
-// TODO: impelment
+// Ten list items. Balance these
+Layout.L.arrangement.div10_2_1_4_3 = function() { return this.longRun("onlyMobile") };
 // Layout.L.arrangement.div10_2_1_4_3 = Layout.L.arrangement.lastColumnLong;
 // Ten list items. Flatten the top, and multicolumn the largest one
 Layout.L.arrangement.div10_2_2_5_1 = function() { return this.flattenPlusMultiColumn(2) };
@@ -679,8 +679,6 @@ Layout.L.arrangement.div10_0_0_5_5 = function() { return this.oneMultiColumn(2, 
 Layout.L.arrangement.div10_0_0_6_4 = function() { return this.oneMultiColumn(2, 'onlyDesktop') };
 // Ten list items. Seven-long columns are too much.
 Layout.L.arrangement.div10_0_0_7_3 = function() { return this.flattenPlusMultiColumn(2, 'onlyMobile') };
-// Ten list items. Two columns of five should both be multiColumn'ed
-// TODO
 // Eleven items: force a two-column flatten, since 9 will default to 3 columns otherwise
 Layout.L.arrangement.div11_2_0_9_0 = function() { return this.flattenPlusMultiColumn(2)};
 // Twelve items: Force multicolumns to be just two wide

--- a/js/layout.js
+++ b/js/layout.js
@@ -756,11 +756,11 @@ function recomputeHeight(e) {
       }
     }
   } else {
-    // We are in mobile mode
     for (family_div of families) {
+      // We are in mobile mode
       if (family_div.classList.contains("onlyDesktop")) {
         // Disable height when in mobile mode for onlyDesktop divs
-        famil_div.style.height = "";
+        family_div.style.height = "";
       } else {
         // Recalculate height after media query change
         family_div.style.height = family_div.dataset.height;

--- a/js/layout.js
+++ b/js/layout.js
@@ -450,7 +450,7 @@ Layout.L.arrangement.threeListOneLong = function(mode="onlyDesktop") {
     this.family.classList.add(mode);
   }
   // Balance columns modeled as single-column-lists
-  var split_point = this.verticalMultiColumnBalance();
+  var split_point = this.verticalMultiColumnBalance(2);
   // Iterate through the list order
   for (let i = 0; i < this.list_order.length ; i++) {
     var list_name = this.list_order[i];
@@ -459,8 +459,10 @@ Layout.L.arrangement.threeListOneLong = function(mode="onlyDesktop") {
     // Set a multicolumn if necessary
     if (list_len == this.longestList()) {
       Layout.multiColumn(cur_list, 2);
+      cur_list.style.order = this.existingColumns();   /* Force to show last */
+    } else {
+      cur_list.style.order = this.boxOrder++;
     }
-    cur_list.style.order = this.boxOrder++;
     this.family.append(this[list_name]);
   }
   // Set height of the container div based on balancing info
@@ -489,11 +491,13 @@ Layout.L.arrangement.default = function() {
     return this.longRun("onlyMobile");
   } else if ((this.longestList() <= 9) && (this.existingColumns() == 4)) {
     return this.longRun("onlyMobile");
+  } else if ((this.longestList() > 5) && (this.existingColumns() == 3) && (this.sum() - this.longestList() <= 4)) {
+    return this.threeListOneLong("onlyDesktop");
   } else if ((this.longestList() > 6) && (this.existingColumns() > 2)) {
     return this.oneMultiColumn();
   // Two parents, and a long multicolumn below
   } else if ((this.longestList() > 5) && (this.existingColumns() == 2) && (this.sum() == this.longestList() + 2)) {
-    return this.flattenPlusMultiColumn();
+    return this.flattenPlusMultiColumn(2);
   } else {
     // Default: just treat everything like a single column
     return this.columns();
@@ -604,14 +608,14 @@ Layout.L.arrangement.verticalBalance = function() {
 }
 
 // Much more hacky calculation for vertical balance of multicolumn vertical flow
-Layout.L.arrangement.verticalMultiColumnBalance = function() {
+Layout.L.arrangement.verticalMultiColumnBalance = function(multi_cols) {
   // How many lines worth of space do we count the gap between lists?
   // Two lines, since it's spacing and a column header
   var between_list_pad = 2;
   // Estimated height of our lines, based on 14pt and padding. Also, necessary
   // values to calculate the final box-height.
   var line_height = "35px";
-  var list_count_height = "25px";
+  var list_count_height = "30px";
   // Do list order based on what things exist or not
   this.list_order = this.list_default.filter(x => this.num[x] != 0);
   // Max items in the multicolumn list is just the list count / 2
@@ -619,8 +623,8 @@ Layout.L.arrangement.verticalMultiColumnBalance = function() {
   var padding = between_list_pad * (parseInt(list_count_height) * squeeze_count);
   var squeeze_num = this.sum() - this.longestList();  // Typically the max number of parents and litter
   var squeeze_height = padding + (squeeze_num * parseInt(line_height));
-  var multi_column_num = Math.ceil(this.longestList() / 2);
-  var multi_column_height = multi_column_num * parseInt(line_height);
+  var multi_column_cnt = Math.ceil(this.longestList() / multi_cols);
+  var multi_column_height = multi_column_cnt * parseInt(line_height);
   if (multi_column_height > squeeze_height) {
     this.height = multi_column_height;
     return 2;   // Split at the third column
@@ -735,9 +739,6 @@ Layout.L.arrangement.div11_2_0_9_0 = function() { return this.flattenPlusMultiCo
 Layout.L.arrangement.div11_2_2_7_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Twelve items: Force multicolumns to be just two wide
 Layout.L.arrangement.div12_2_1_9_0 = function() { return this.threeListOneLong("onlyDesktop") };
-// Thirteen items. Force multicolumns to be just two wide
-Layout.L.arrangement.div13_2_2_9_0 = function() { return this.oneMultiColumn(2, 'onlyMobile')};
-Layout.L.arrangement.div13_2_1_10_0 = function() { return this.oneMultiColumn(2, 'onlyMobile')};
 
 
 /* For vertical flow elements, the height is used to display content properly.

--- a/js/layout.js
+++ b/js/layout.js
@@ -484,8 +484,8 @@ Layout.L.arrangement.threeListOneLong = function(mode="onlyDesktop") {
 // TOWRITE: for now, just default to columns
 Layout.L.arrangement.default = function() {
   // Heuristics based on column sizing
-  // One really long column? Multi-column-split it based on available space
   if ((this.longestList() > 4) && (this.existingColumns() == 1)) {
+    // One really long column? Multi-column-split it based on available space. TEST: Pam
     return this.oneMultiColumn();
   } else if ((this.longestList() <= 6) && (this.existingColumns() == 3)) {
     return this.longRun("onlyMobile");
@@ -493,10 +493,8 @@ Layout.L.arrangement.default = function() {
     return this.longRun("onlyMobile");
   } else if ((this.longestList() > 5) && (this.existingColumns() == 3) && (this.sum() - this.longestList() <= 4)) {
     return this.threeListOneLong("onlyDesktop");
-  } else if ((this.longestList() > 6) && (this.existingColumns() > 2)) {
-    return this.oneMultiColumn();
-  // Two parents, and a long multicolumn below
   } else if ((this.longestList() > 5) && (this.existingColumns() == 2) && (this.sum() == this.longestList() + 2)) {
+    // Two parents, and a long multicolumn below
     return this.flattenPlusMultiColumn(2);
   } else {
     // Default: just treat everything like a single column
@@ -637,26 +635,25 @@ Layout.L.arrangement.verticalMultiColumnBalance = function(multi_cols) {
 /* The arrangement switchboard. Set these arrangement names so they return
    the actual functions that will perform the layout duties. Use "return" syntax
    so that the originating object "this" is preserved. */
-// TODO: remove any switchboard entries that don't need speical behavior!!
-// One list item? Simple column layout is fine.
+// One list item? Simple column layout is fine. TEST: Mai (Buna's Mom)
 Layout.L.arrangement.div1_1_0_0_0 = function() { return this.columns() };
-// Two list items, horizontal display to save space. 
+// Two list items, horizontal display to save space. TEST: Harumaki, You-You (Hirakata)
 Layout.L.arrangement.div2_2_0_0_0 = function() { return this.flatten("both") };
-// Two list items, in their own columns
+// Two list items, in their own columns.
 Layout.L.arrangement.div2_1_1_0_0 = function() { return this.columns() };
-// Three item arrangements all use column mode
+// Three item arrangements all use column mode. TEST: Roshani
 Layout.L.arrangement.div3_2_1_0_0 = function() { return this.columns() };
 Layout.L.arrangement.div3_0_1_1_1 = function() { return this.columns() };
 Layout.L.arrangement.div3_0_0_3_0 = function() { return this.columns() };
-// Four list items. Two parents and two in a second column
+// Four list items. Two parents and two in a second column. TEST: Shizuku
 Layout.L.arrangement.div4_2_2_0_0 = function() { return this.columns() };
-// Four list items. Two in one category and singles
+// Four list items. Two in one category and singles. TEST: Taiyo (Nishiyama)
 Layout.L.arrangement.div4_2_1_1_0 = function() { return this.longRun("onlyMobile") };
 // Four list items. Three in one category
 Layout.L.arrangement.div4_0_0_3_1 = function() { return this.columns() };
-// Four list items. All in one category. Longer lists will get multiColumn'ed
+// Four list items. Longer lists will get multiColumn'ed. Test: You-You (Noichi)
 Layout.L.arrangement.div4_0_0_4_0 = function() { return this.columns() };
-// Five list items. Two parents and three in a second column
+// Five list items. Two parents and three in a second column. TEST: Keti
 Layout.L.arrangement.div5_2_0_3_0 = function() { return this.columns() };
 // Five list items. Two parents and a two/one split.
 // TODO: consider flattenTop for this style of layout
@@ -669,7 +666,7 @@ Layout.L.arrangement.div5_0_0_4_1 = function() { return this.columns() };
 Layout.L.arrangement.div6_2_0_4_0 = function() { return this.columns() };
 // Six list items. Two parents and a short split
 Layout.L.arrangement.div6_2_1_3_0 = function() { return this.longRun("onlyMobile") }; 
-// Six list items. Two parents and even columns
+// Six list items. Two parents and even columns. TEST: Asahi (Kobe), Kiari
 Layout.L.arrangement.div6_2_2_2_0 = function() { return this.flatten("onlyMobile") };
 // Six list items. Two parents and spread
 Layout.L.arrangement.div6_2_2_1_1 = function() { return this.columns() };
@@ -682,8 +679,7 @@ Layout.L.arrangement.div7_2_2_3_0 = function() { return this.longRun("onlyMobile
 // Seven list items. parents, litter, siblings, and children, all straight columns
 Layout.L.arrangement.div7_2_2_2_1 = function() { return this.columns() };
 // Seven list items. A predominant list with parents.
-// The three item list is last, but we can shift it up a little
-// TODO: might try a flat layout on top, and a longRun lower down
+// The three item list is last, but we can shift it up a little. TEST: Gin
 Layout.L.arrangement.div7_2_1_3_1 = function() { return this.longRun("onlyMobile") };
 // Seven list items. a predominant list with no litter. 
 // Place the one below the parents, and the four kicked right.
@@ -695,18 +691,18 @@ Layout.L.arrangement.div8_2_2_3_1 = function() { return this.longRun("onlyMobile
 // Eight list items, a long column and two shorties
 Layout.L.arrangement.div8_2_2_4_0 = function() { return this.longRun("onlyMobile") };
 Layout.L.arrangement.div8_2_1_5_0 = function() { return this.longRun("onlyMobile") };
-// Eight list items. Do the four column below the one, but kick it up
+// Eight list items. Do the four column below the one, but kick it up. TEST: Mitarashi
 Layout.L.arrangement.div8_2_1_4_1 = function() { return this.longRun("onlyMobile") };
-// Nine items. Do a balancing act
+// Nine items. Do a balancing act. TEST: Shiratama
 Layout.L.arrangement.div9_2_1_4_2 = function() { return this.longRun("onlyMobile")};
 // Nine list items. Two single columns sneaking on the left
 Layout.L.arrangement.div9_2_1_5_1 = function() { return this.longRun("onlyMobile") };
 // Nine list items. A long column goes multiColumn. 
 // On mobile the broader multicolumn lists should shrink down to two columns
 Layout.L.arrangement.div9_2_2_5_0 = function() { return this.oneMultiColumn(2, "onlyMobile", "onlyMobile") };
-// Nine list items. Parents and two similar length lists
+// Nine list items. Parents and two similar length lists. TEST: Mugi
 Layout.L.arrangement.div9_2_0_3_4 = function() { return this.flatten("onlyMobile") };
-// TESTING
+// Nine list items. Multi-column, and flow the smaller ones left. TEST: Furin
 Layout.L.arrangement.div9_2_1_6_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Wouldn't normally flatten the one. Might not need this
 Layout.L.arrangement.div9_0_0_8_1 = function() { return this.flattenPlusMultiColumn(3) };
@@ -725,7 +721,7 @@ Layout.L.arrangement.div10_2_1_5_2 = function() { return this.longRun("onlyMobil
 Layout.L.arrangement.div10_2_2_6_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Ten list items. Sneak the singles down the left
 Layout.L.arrangement.div10_2_1_6_1 = function() { return this.longRun("onlyMobile") };
-// Ten list items. Too long to be a long run.
+// Ten list items. Too long to be a long run. TEST: Fuuna
 Layout.L.arrangement.div10_2_0_7_1 = function() { return this.threeListOneLong("onlyDesktop") };
 // Ten list items. No parents layouts, even stevens. Spread out on desktop
 Layout.L.arrangement.div10_0_0_5_5 = function() { return this.oneMultiColumn(2, 'onlyDesktop') };
@@ -737,6 +733,10 @@ Layout.L.arrangement.div10_0_0_7_3 = function() { return this.flattenPlusMultiCo
 // Eleven items: force a two-column flatten, since 9 will default to 3 columns otherwise
 Layout.L.arrangement.div11_2_0_9_0 = function() { return this.flattenPlusMultiColumn(2)};
 Layout.L.arrangement.div11_2_2_7_0 = function() { return this.threeListOneLong("onlyDesktop") };
+// Eleven items: do a vertical flow on desktop and mobile
+// TODO: vertical flow on desktop and mobile. Different heights stored. Adjust other code
+// to use special heights for mobile versus desktop. Yan-Yan Nishiyama
+// Layout.L.arrangement.div11_2_1_3_5 = function { return this.verticalFlow() };
 // Twelve items: Force multicolumns to be just two wide
 Layout.L.arrangement.div12_2_1_9_0 = function() { return this.threeListOneLong("onlyDesktop") };
 

--- a/js/layout.js
+++ b/js/layout.js
@@ -611,13 +611,13 @@ Layout.L.arrangement.verticalMultiColumnBalance = function() {
   // Estimated height of our lines, based on 14pt and padding. Also, necessary
   // values to calculate the final box-height.
   var line_height = "35px";
-  var list_count_height = "20px";
+  var list_count_height = "25px";
   // Do list order based on what things exist or not
   this.list_order = this.list_default.filter(x => this.num[x] != 0);
   // Max items in the multicolumn list is just the list count / 2
   var squeeze_count = (this.existingColumns() > 3) ? 3 : 2;
   var padding = between_list_pad * (parseInt(list_count_height) * squeeze_count);
-  var squeeze_num = 4;  // Typically the max number of parents and litter
+  var squeeze_num = this.sum() - this.longestList();  // Typically the max number of parents and litter
   var squeeze_height = padding + (squeeze_num * parseInt(line_height));
   var multi_column_num = Math.ceil(this.longestList() / 2);
   var multi_column_height = multi_column_num * parseInt(line_height);
@@ -718,11 +718,11 @@ Layout.L.arrangement.div10_2_2_5_1 = function() { return this.flattenPlusMultiCo
 Layout.L.arrangement.div10_2_1_5_2 = function() { return this.longRun("onlyMobile") };
 // Ten list items. Balanced lists and a muticolumn
 // TODO: On mobile, flatten all the short columns.
-Layout.L.arrangement.div10_2_2_6_0 = function() { return this.oneMultiColumn(2, "onlyMobile", "onlyMobile") };
+Layout.L.arrangement.div10_2_2_6_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Ten list items. Sneak the singles down the left
 Layout.L.arrangement.div10_2_1_6_1 = function() { return this.longRun("onlyMobile") };
 // Ten list items. Too long to be a long run.
-Layout.L.arrangement.div10_2_0_7_1 = function() { return this.oneMultiColumn(2, "onlyMobile", "onlyMobile") };
+Layout.L.arrangement.div10_2_0_7_1 = function() { return this.threeListOneLong("onlyDesktop") };
 // Ten list items. No parents layouts, even stevens. Spread out on desktop
 Layout.L.arrangement.div10_0_0_5_5 = function() { return this.oneMultiColumn(2, 'onlyDesktop') };
 // Ten list items. On mobile this looks fine as two columns.
@@ -732,8 +732,9 @@ Layout.L.arrangement.div10_0_0_6_4 = function() { return this.oneMultiColumn(2, 
 Layout.L.arrangement.div10_0_0_7_3 = function() { return this.flattenPlusMultiColumn(2, 'onlyMobile') };
 // Eleven items: force a two-column flatten, since 9 will default to 3 columns otherwise
 Layout.L.arrangement.div11_2_0_9_0 = function() { return this.flattenPlusMultiColumn(2)};
+Layout.L.arrangement.div11_2_2_7_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Twelve items: Force multicolumns to be just two wide
-Layout.L.arrangement.div12_2_1_9_0 = function() { return this.oneMultiColumn(2, 'onlyMobile')};
+Layout.L.arrangement.div12_2_1_9_0 = function() { return this.threeListOneLong("onlyDesktop") };
 // Thirteen items. Force multicolumns to be just two wide
 Layout.L.arrangement.div13_2_2_9_0 = function() { return this.oneMultiColumn(2, 'onlyMobile')};
 Layout.L.arrangement.div13_2_1_10_0 = function() { return this.oneMultiColumn(2, 'onlyMobile')};


### PR DESCRIPTION
Added multi-column layouts that can have short column runs on their left. This is done using vertical-flow layouts for non-mobile. 

I'm pissed that there's no great way to get flex-spreading of contents in column-mode -- maybe min-width, max-width, and basis will be useful, but for now the multicolumn lists feel scrunched. Search "Furin" or "Fuuna" to see.

Slightly adjusted the height/padding rules as well.