### PR TITLE
Spacing fixes

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -628,6 +628,16 @@ ul.pandaList li a.passedAway {
     color: gray;
 }
 
+span.condensed {
+    letter-spacing: -1px;
+    font-size: 13pt;
+}
+
+span.ultraCondensed {
+    letter-spacing: -4px;
+    font-size: 12pt;
+}
+
 h4.parentsHeading, h4.litterHeading, h4.siblingsHeading, h4.childrenHeading {
     padding-bottom: 0.25ex;
 }
@@ -1105,14 +1115,6 @@ div.photoSample h5.caption.familyTitle {
         flex-grow: 1;   /* Force list items to expand to fill space */
         width: 6.4em;
     }
-
-    span.condensed {
-        letter-spacing: -1px;
-    }
-    
-    span.ultraCondensed {
-        letter-spacing: -4px;
-    }    
 
     div.profileSummary {
         margin-top: 0px;   /* Vertical rhythm things unnecessary on mobile */

--- a/js/layout.js
+++ b/js/layout.js
@@ -136,14 +136,12 @@ Layout.recomputeHeight = function(e) {
 // Look for span elements that are children of links, in the family bars.
 // Any of these that are displayed in the page larger than 100px, need to get shrunk.
 Layout.shrinkNames = function() {
-  if (window.matchMedia("(max-width: 670px)").matches == false) {
-    return;
-  }
   var link_nodes = document.getElementsByClassName("geneaologyListName");
   for (let link of link_nodes) {
     var span = link.childNodes[1];
     if (span.offsetWidth > 95) {
       span.classList.add("ultraCondensed");
+      span.classList.remove("condensed");
     } else if (span.offsetWidth > 75) {
       span.classList.add("condensed");
     }

--- a/js/show.js
+++ b/js/show.js
@@ -780,7 +780,7 @@ Show.animalLink = function(animal, link_text, language, options) {
     if (options.indexOf("dad_icon") != -1) {
       alien = Show.emoji.star_dad;
     }
-    return Show.emptyLink(alien + "\u2009" + link_text);
+    return Show.emptyLink(alien + "\xa0" + link_text);
   }
 
   // Set up values for other functions working properly
@@ -797,14 +797,14 @@ Show.animalLink = function(animal, link_text, language, options) {
   var trailing_text = "";
   // Option to display gender face
   if (options.indexOf("child_icon") != -1) {
-    gender_text = Show.displayChildIcon(gender) + "\u2009";
+    gender_text = Show.displayChildIcon(gender) + "\xa0";
   }
   // Moms and dads have older faces
   if (options.indexOf("mom_icon") != -1) {
-    gender_text = Show.emoji.mother + "\u2009";
+    gender_text = Show.emoji.mother + "\xa0";
   }
   if (options.indexOf("dad_icon") != -1) {
-    gender_text = Show.emoji.father + "\u2009";
+    gender_text = Show.emoji.father + "\xa0";
   }
   // Half siblings indicator
   if (options.indexOf("half_icon") != -1) {


### PR DESCRIPTION
When moving to the new layouts, especially the vertical flex layouts that can't swing their width because flex is up-down, I noticed that long names were causing container overflows. This breaks the usability of photo swipe gestures on mobile.

This is the first measures to improve this. I replaced full width spaces with shorter ones (special Unicode characters), made animal link text appear in its own `<span>`, and added squeeze classes to impact the letter spacing and font sizing of text in these classes when the `offsetWidth` gets too long.