### PR TITLE
Method refactors

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,9 @@
 </script>
 <script type="application/javascript" src="./js/relexer.js"></script>
 <script type="application/javascript" src="./js/dagoba.js"></script>
+<script type="application/javascript" src="./js/pandas.js"></script>
 <script type="application/javascript" src="./js/language.js"></script>
 <script type="application/javascript" src="./js/touch.js"></script>
-<script type="application/javascript" src="./js/pandas.js"></script>
 <script type="application/javascript" src="./js/query.js"></script>
 <script type="application/javascript" src="./js/layout.js"></script>
 <script type="application/javascript" src="./js/show.js"></script>

--- a/js/language.js
+++ b/js/language.js
@@ -16,6 +16,178 @@ Language.init = function() {
 }
 
 /*
+   Language elements translatable in the GUI
+*/
+// TODO: do we need localized emojis for various things?
+Language.L.emoji = {
+  "animal": "🐼",
+   "alien": "👽",
+   "arrow": "➡",
+  "author": "✍️",
+"birthday": "🎂",
+    "baby": "👶🏻", 
+    "born": "👼",
+     "boy": "👦🏻",
+  "camera": "📷",
+    "died": "🌈",
+    "edit": "📝",
+  "father": "👨🏻",
+  "female": "♀️",
+    "gift": "🍎",
+    "girl": "👧🏻",
+    "home": "🏡",
+"language": "‍👁️‍🗨️",
+    "link": "🦉",
+    "male": "♂️",
+     "map": "🗺️",
+   "media": "🖼",
+   "money": "💸",
+  "mother": "👩🏻",
+ "no_more": "🚫",
+ "profile": "💟",
+  "random": "🎲",
+  "search": "🔍",
+"star_dad": "👨‍🎤",
+"star_mom": "👩‍🎤",
+   "story": "🎍",
+     "top": "⬆",
+"timeline": "📰",
+  "travel": "✈️",
+ "website": "🌐",
+     "wip": "🚧",
+     "zoo": "🦁"
+}
+
+// TODO: key on other language versions of country names
+Language.L.flags = {
+  "Argentina": "🇦🇷",
+     "Bhutan": "🇧🇹",
+     "Canada": "🇨🇦",
+      "Chile": "🇨🇱",
+      "China": "🇨🇳",
+      "India": "🇮🇳",
+      "Japan": "🇯🇵",
+     "Mexico": "🇲🇽",
+      "Nepal": "🇳🇵",
+"South Korea": "🇰🇷",
+     "Taiwan": "🇹🇼",
+   "Thailand": "🇹🇭",
+        "USA": "🇺🇸"
+}
+
+// TODO: use this.display to auto grab the right emoji for the current language,
+// or allow overriding given an input language provided at the function call
+Language.L.gui = {
+  "about": {
+    "cn": "關於",
+    "en": "About",
+    "jp": "概要"
+  },
+  "credit": {
+    "cn": "TOWRITE",
+    "en": [Language.L.emoji.gift + " ",
+           "<INSERTUSER>",
+           " has contributed ",
+           "<INSERTNUMBER>",
+           " photos."],
+    "jp": [Language.L.emoji.gift + " ",
+           "<INSERTUSER>",
+           "は",
+           "<INSERTNUMBER>",
+           "枚の写真を寄稿しました。"]
+  },
+  "children": {
+    "cn": Pandas.def.relations.children["cn"],
+    "en": "Children",   // Capitalization
+    "jp": Pandas.def.relations.children["jp"]
+  },
+  "flag": {
+    "cn": Language.L.flags["China"],
+    "en": Language.L.flags["USA"],
+    "jp": Language.L.flags["Japan"]
+  },
+  "footer": {
+    "cn": "TOWRITE",
+    "en": ["All information courtesy of the ",
+           "<INSERTLINK>",
+           " and red panda fans worldwide. ",
+          "Any media linked from this dataset remains property of its creator. ",
+          "Layout and design © 2018 Justin Fairchild."],
+    "jp": ["<INSERTLINK>", 
+           "、世界中のレッサーパンダファンのすべての情報提供。",
+           "このデータセットからリンクされたメディアはすべて、作成者の所有物です。",
+           "設計©2018 Justin Fairchild"]
+  },
+  "footerLink": {
+    "cn": "TOWRITE",
+    "en": "Red Panda Lineage",
+    "jp": "Red Panda Lineage"
+  },
+  "home": {
+    "cn": "TOWRITE",
+    "en": "Home",
+    "jp": "ホメパゲ"
+  },
+  "language": {
+    "cn": "漢語",
+    "en": "English",
+    "jp": "日本語"
+  },
+  "loading": {
+    "cn": "Loading...",
+    "en": "Loading...",
+    "jp": "ローディング"
+  },
+  "litter": {
+    "cn": Pandas.def.relations.litter["cn"],
+    "en": "Litter",   // Capitalization
+    "jp": Pandas.def.relations.litter["jp"]
+  },
+  "links": {
+    "cn": "鏈接",
+    "en": "Links",
+    "jp": "リンク"
+  },
+  "parents": {
+    "cn": Pandas.def.relations.parents["cn"],
+    "en": "Parents",   // Capitalization
+    "jp": Pandas.def.relations.parents["jp"]
+  },
+  "random": {
+    "cn": "隨機",
+    "en": "Random",
+    "jp": "適当"
+  },
+  "search": {
+    "cn": "Search...",
+    "en": "Search...",
+    "jp": "サーチ..."
+  },
+  "siblings": {
+    "cn": Pandas.def.relations.siblings["cn"],
+    "en": "Siblings",   // Capitalization
+    "jp": Pandas.def.relations.siblings["jp"]
+  },
+  "title": {
+    "cn": "TOWRITE",
+    "en": "Red Panda Finder",
+    "jp": "レッサーパンダのファインダー"
+  },
+  "top": {
+    "cn": "TOWRITE",
+    "en": "Top",
+    "jp": "上"
+  }
+}
+
+// TODO: fold into Language.L.gui
+Language.L.no_result = {
+  "cn": "沒有發現熊貓",
+  "en": "No Pandas Found",
+  "jp": "パンダが見つかりません"
+}
+
+/*
    Language selection functions
 */
 // Map a browser specified language to one of our supported options.
@@ -127,25 +299,25 @@ Language.L.fallbackInfo = function(info, original) {
 Language.L.update = function() {
   var languageButton = document.getElementById('languageButton');
   [ langIcon, langText ] = languageButton.childNodes[0].childNodes;
-  langIcon.innerText = Show.gui.flag[this.display];
-  langText.innerText = Show.gui.language[this.display];
+  langIcon.innerText = this.gui.flag[this.display];
+  langText.innerText = this.gui.language[this.display];
   var aboutButton = document.getElementById('aboutButton');
   [ langIcon, langText ] = aboutButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.about[this.display];
+  langText.innerText = this.gui.about[this.display];
   var randomButton = document.getElementById('randomButton');
   [ langIcon, langText ] = randomButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.random[this.display];
+  langText.innerText = this.gui.random[this.display];
   var linksButton = document.getElementById('linksButton');
   [ langIcon, langText ] = linksButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.links[this.display];
+  langText.innerText = this.gui.links[this.display];
   // Update the placeholder text for a search bar
   if (P.db == undefined) {
-    document.forms['searchForm']['searchInput'].placeholder = Show.gui.loading[this.display];
+    document.forms['searchForm']['searchInput'].placeholder = this.gui.loading[this.display];
   } else {
-    document.forms['searchForm']['searchInput'].placeholder = "➤ " + Show.gui.search[this.display];
+    document.forms['searchForm']['searchInput'].placeholder = "➤ " + this.gui.search[this.display];
   }
   // Change the page title
-  document.title = Show.gui.title[this.display];
+  document.title = this.gui.title[this.display];
   // Write localStorage for your chosen language. This is better than a cookie
   // since the server never has to see what language you're using in each request.
   this.storage.setItem('language', this.display);
@@ -242,5 +414,5 @@ Language.saveInfoKeys = function(info, order) {
     obj[key] = info[key];
     return obj;
   }, {});
-  return filtered;     
+  return filtered;
 }

--- a/js/language.js
+++ b/js/language.js
@@ -15,66 +15,65 @@ Language.init = function() {
   return language;
 }
 
-// For fallback functions, don't replace these fields
-Language.fallback_blacklist = ["othernames", "nicknames"];
-
 /*
    Language selection functions
 */
 // Map a browser specified language to one of our supported options.
-Language.default = function(lang_object) {
+Language.L.default = function() {
   // Read language settings from browser's Accept-Language header
   Object.keys(Pandas.def.languages).forEach(function(option) {
     if ((navigator.languages.indexOf(option) != -1) &&
-        (lang_object.display == undefined)) {
-      lang_object.display = Pandas.def.languages[option];
+        (this.display == undefined)) {
+      this.display = Pandas.def.languages[option];
     }
   });
   // Read language cookie if it's there
-  var test = lang_object.storage.getItem("language");
+  var test = this.storage.getItem("language");
   if (test != null) {
     if (Object.values(Pandas.def.languages).indexOf(test) != -1) {
-      lang_object.display = test;
+      this.display = test;
     }
   }  
   // Fallback to English
-  if (lang_object.display == undefined) {
-    lang_object.display = "en";
+  if (this.display == undefined) {
+    this.display = "en";
   }
 }
 
 // Update all GUI elements based on the currently chosen language
-// For now, just do the language button itself
-Language.update = function(lang_object) {
+Language.L.update = function() {
   var languageButton = document.getElementById('languageButton');
   [ langIcon, langText ] = languageButton.childNodes[0].childNodes;
-  langIcon.innerText = Show.gui.flag[lang_object.display];
-  langText.innerText = Show.gui.language[lang_object.display];
+  langIcon.innerText = Show.gui.flag[this.display];
+  langText.innerText = Show.gui.language[this.display];
   var aboutButton = document.getElementById('aboutButton');
   [ langIcon, langText ] = aboutButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.about[lang_object.display];
+  langText.innerText = Show.gui.about[this.display];
   var randomButton = document.getElementById('randomButton');
   [ langIcon, langText ] = randomButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.random[lang_object.display];
+  langText.innerText = Show.gui.random[this.display];
   var linksButton = document.getElementById('linksButton');
   [ langIcon, langText ] = linksButton.childNodes[0].childNodes;
-  langText.innerText = Show.gui.links[lang_object.display];
+  langText.innerText = Show.gui.links[this.display];
   // Update the placeholder text for a search bar
   if (P.db == undefined) {
-    document.forms['searchForm']['searchInput'].placeholder = Show.gui.loading[lang_object.display];
+    document.forms['searchForm']['searchInput'].placeholder = Show.gui.loading[this.display];
   } else {
-    document.forms['searchForm']['searchInput'].placeholder = "➤ " + Show.gui.search[lang_object.display];
+    document.forms['searchForm']['searchInput'].placeholder = "➤ " + Show.gui.search[this.display];
   }
   // Change the page title
-  document.title = Show.gui.title[lang_object.display];
+  document.title = Show.gui.title[this.display];
   // Write localStorage for your chosen language. This is better than a cookie
   // since the server never has to see what language you're using in each request.
-  lang_object.storage.setItem('language', lang_object.display);
+  this.storage.setItem('language', this.display);
 }
 
 /*
     Language helper and utility functions
 */
+// For fallback functions, don't replace these fields
+Language.fallback_blacklist = ["othernames", "nicknames"];
+
 // Determine if altname is not worth displaying for furigana by calculating
 // its Levenshtein distance. Courtesy of https://gist.github.com/rd4k1
 Language.editDistance = function(a, b){

--- a/js/show.js
+++ b/js/show.js
@@ -729,7 +729,7 @@ Show.acquirePandaInfo = function(animal, language) {
        "siblings": Pandas.searchNonLitterSiblings(animal["_id"]),
             "zoo": Pandas.myZoo(animal, "zoo")
   }
-  bundle = Language.fallbackInfo(bundle, animal);  // Any defaults here?
+  bundle = L.fallbackInfo(bundle, animal);  // Any defaults here?
   return bundle;
 }
 
@@ -755,7 +755,7 @@ Show.acquireZooInfo = function(zoo, language) {
 "recorded_count": recorded.length,
        "website": Pandas.zooField(zoo, "website")
   }
-  bundle = Language.fallbackInfo(bundle, zoo);  // Any defaults here?
+  bundle = L.fallbackInfo(bundle, zoo);  // Any defaults here?
   return bundle;
 }
 

--- a/js/show.js
+++ b/js/show.js
@@ -24,7 +24,6 @@ var Q;   // Query stack
 var L;   // Language methods and current language
 var T;   // Touch object
 var G;   // Lineage graph
-var F;   // Layout tools for list visual optimization
 
 /*
     Once page has loaded, add new event listeners for search processing
@@ -1404,16 +1403,16 @@ Show.displayPhotoPreload = function(entity_id, photo_id) {
 // Touchable carousels for every loaded photo.
 Show.displayPhotoTouch = function(photo) {
   photo.addEventListener('touchstart', function(event) {
-    Touch.start(event, T, photo.id);
+    T.start(event, photo.id);
   }, true);
   photo.addEventListener('touchend', function(event) {
-    Touch.end(event, T);
+    T.end(event);
   }, true);
   photo.addEventListener('touchmove', function(event) {
-    Touch.move(event, T);
+    T.move(event);
   }, true);
   photo.addEventListener('touchcancel', function(event) {
-    Touch.cancel(T);
+    T.cancel();
   }, true);
 }
 

--- a/js/show.js
+++ b/js/show.js
@@ -35,9 +35,9 @@ document.addEventListener("DOMContentLoaded", function() {
   T = Touch.init();
   G = Dagoba.graph();
 
-  Language.default(L);     // Set default language
+  L.default();     // Set default language
   checkHashes();           // See if we started on the links or about pages
-  Language.update(L);      // Update buttons, displayed results, and cookie state
+  L.update();      // Update buttons, displayed results, and cookie state
   redrawPage(Show.page);   // Ready to redraw? Let's go.
 
   // Once the panda data is loaded, create the graph
@@ -77,7 +77,7 @@ document.addEventListener("DOMContentLoaded", function() {
     choice = (choice + 1) % options.length;
     var new_language = options[choice];
     L.display = new_language;
-    Language.update(L, Show.page);
+    L.update();
     redrawPage(Show.page);
   });  
 

--- a/js/show.js
+++ b/js/show.js
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", function() {
     P.db.vertices.forEach(G.addVertex.bind(G));
     P.db.edges   .forEach(G.addEdge  .bind(G));
     // Enable search bar once the page has loaded
-    var placeholder = "➤ " + Show.gui.search[L.display];
+    var placeholder = "➤ " + L.gui.search[L.display];
     document.forms['searchForm']['searchInput'].disabled = false;
     document.forms['searchForm']['searchInput'].placeholder = placeholder;
     document.getElementById('searchInput').focus();  // Set text cursor
@@ -504,175 +504,10 @@ Show.about.content = undefined;    // About page content
 Show.about.language = undefined;   // Language the content was loaded in
 Show.about.loaded = new Event('about_loaded');
 
-Show.emoji = {
-  "animal": "🐼",
-   "alien": "👽",
-   "arrow": "➡",
-  "author": "✍️",
-"birthday": "🎂",
-    "baby": "👶🏻", 
-    "born": "👼",
-     "boy": "👦🏻",
-  "camera": "📷",
-    "died": "🌈",
-    "edit": "📝",
-  "father": "👨🏻",
-  "female": "♀️",
-    "gift": "🍎",
-    "girl": "👧🏻",
-    "home": "🏡",
-"language": "‍👁️‍🗨️",
-    "link": "🦉",
-    "male": "♂️",
-     "map": "🗺️",
-   "media": "🖼",
-   "money": "💸",
-  "mother": "👩🏻",
- "no_more": "🚫",
- "profile": "💟",
-  "random": "🎲",
-  "search": "🔍",
-"star_dad": "👨‍🎤",
-"star_mom": "👩‍🎤",
-   "story": "🎍",
-     "top": "⬆",
-"timeline": "📰",
-  "travel": "✈️",
- "website": "🌐",
-     "wip": "🚧",
-     "zoo": "🦁"
-}
-
-// TODO: key on other language versions of country names
-Show.flags = {
-  "Argentina": "🇦🇷",
-     "Bhutan": "🇧🇹",
-     "Canada": "🇨🇦",
-      "Chile": "🇨🇱",
-      "China": "🇨🇳",
-      "India": "🇮🇳",
-      "Japan": "🇯🇵",
-     "Mexico": "🇲🇽",
-      "Nepal": "🇳🇵",
-"South Korea": "🇰🇷",
-     "Taiwan": "🇹🇼",
-   "Thailand": "🇹🇭",
-        "USA": "🇺🇸"
-}
-
-Show.gui = {
-  "about": {
-    "cn": "關於",
-    "en": "About",
-    "jp": "概要"
-  },
-  "credit": {
-    "cn": "TOWRITE",
-    "en": [Show.emoji.gift + " ",
-           "<INSERTUSER>",
-           " has contributed ",
-           "<INSERTNUMBER>",
-           " photos."],
-    "jp": [Show.emoji.gift + " ",
-           "<INSERTUSER>",
-           "は",
-           "<INSERTNUMBER>",
-           "枚の写真を寄稿しました。"]
-  },
-  "children": {
-    "cn": Pandas.def.relations.children["cn"],
-    "en": "Children",   // Capitalization
-    "jp": Pandas.def.relations.children["jp"]
-  },
-  "flag": {
-    "cn": Show.flags["China"],
-    "en": Show.flags["USA"],
-    "jp": Show.flags["Japan"]
-  },
-  "footer": {
-    "cn": "TOWRITE",
-    "en": ["All information courtesy of the ",
-           "<INSERTLINK>",
-           " and red panda fans worldwide. ",
-          "Any media linked from this dataset remains property of its creator. ",
-          "Layout and design © 2018 Justin Fairchild."],
-    "jp": ["<INSERTLINK>", 
-           "、世界中のレッサーパンダファンのすべての情報提供。",
-           "このデータセットからリンクされたメディアはすべて、作成者の所有物です。",
-           "設計©2018 Justin Fairchild"]
-  },
-  "footerLink": {
-    "cn": "TOWRITE",
-    "en": "Red Panda Lineage",
-    "jp": "Red Panda Lineage"
-  },
-  "home": {
-    "cn": "TOWRITE",
-    "en": "Home",
-    "jp": "ホメパゲ"
-  },
-  "language": {
-    "cn": "漢語",
-    "en": "English",
-    "jp": "日本語"
-  },
-  "loading": {
-    "cn": "Loading...",
-    "en": "Loading...",
-    "jp": "ローディング"
-  },
-  "litter": {
-    "cn": Pandas.def.relations.litter["cn"],
-    "en": "Litter",   // Capitalization
-    "jp": Pandas.def.relations.litter["jp"]
-  },
-  "links": {
-    "cn": "鏈接",
-    "en": "Links",
-    "jp": "リンク"
-  },
-  "parents": {
-    "cn": Pandas.def.relations.parents["cn"],
-    "en": "Parents",   // Capitalization
-    "jp": Pandas.def.relations.parents["jp"]
-  },
-  "random": {
-    "cn": "隨機",
-    "en": "Random",
-    "jp": "適当"
-  },
-  "search": {
-    "cn": "Search...",
-    "en": "Search...",
-    "jp": "サーチ..."
-  },
-  "siblings": {
-    "cn": Pandas.def.relations.siblings["cn"],
-    "en": "Siblings",   // Capitalization
-    "jp": Pandas.def.relations.siblings["jp"]
-  },
-  "title": {
-    "cn": "TOWRITE",
-    "en": "Red Panda Finder",
-    "jp": "レッサーパンダのファインダー"
-  },
-  "top": {
-    "cn": "TOWRITE",
-    "en": "Top",
-    "jp": "上"
-  }
-}
-
 Show.links = {};
 Show.links.content = undefined;    // Links page content
 Show.links.language = undefined;   // Language the content was loaded in
 Show.links.loaded = new Event('links_loaded');
-
-Show.no_result = {
-  "cn": "沒有發現熊貓",
-  "en": "No Pandas Found",
-  "jp": "パンダが見つかりません"
-}
 
 // Hashlink routes that map to non-search-results content
 Show.routes = {
@@ -772,12 +607,12 @@ Show.animalLink = function(animal, link_text, language, options) {
   // Don't print content if the input id is zero. If these are
   // fill-in links for moms or dads, use the Aladdin Sane icons :)
   if (animal['_id'] == Pandas.def.animal['_id']) {
-    var alien = Show.emoji.alien;
+    var alien = L.emoji.alien;
     if (options.indexOf("mom_icon") != -1) {
-      alien = Show.emoji.star_mom;
+      alien = L.emoji.star_mom;
     }
     if (options.indexOf("dad_icon") != -1) {
-      alien = Show.emoji.star_dad;
+      alien = L.emoji.star_dad;
     }
     return Show.emptyLink(alien + "\xa0" + link_text);
   }
@@ -800,10 +635,10 @@ Show.animalLink = function(animal, link_text, language, options) {
   }
   // Moms and dads have older faces
   if (options.indexOf("mom_icon") != -1) {
-    gender_text = Show.emoji.mother + "\xa0";
+    gender_text = L.emoji.mother + "\xa0";
   }
   if (options.indexOf("dad_icon") != -1) {
-    gender_text = Show.emoji.father + "\xa0";
+    gender_text = L.emoji.father + "\xa0";
   }
   // Half siblings indicator
   if (options.indexOf("half_icon") != -1) {
@@ -811,7 +646,7 @@ Show.animalLink = function(animal, link_text, language, options) {
   }
   if ((options.indexOf("live_icon") != -1) && ("death" in animal)) {
     a.classList.add("passedAway");
-    trailing_text = trailing_text + "\u200A" + Show.emoji.died;
+    trailing_text = trailing_text + "\u200A" + L.emoji.died;
   }
   name_span.innerText = inner_text;
   a.append(gender_text);
@@ -891,17 +726,17 @@ Show.homeLocation = function(zoo, desired_text, language, options) {
   }
   var output_text = desired_text;
   if (options.indexOf("map_icon") != -1) {
-    output_text = Show.emoji.map + " " + output_text;
+    output_text = L.emoji.map + " " + output_text;
   }
   if ("country_flag" in options) {
     // Replace any country names in location details with a flag
-    var countries = Object.keys(Show.flags).filter(function(key) {
+    var countries = Object.keys(L.flags).filter(function(key) {
       if (output_text.indexOf(key) != -1) {
         return key;
       }
     });
     countries.forEach(function(place) {
-      output_text.replace(place, Show.flags[place]);
+      output_text.replace(place, L.flags[place]);
     });
   }
   return output_text;
@@ -915,7 +750,7 @@ Show.locationLink = function(zoo, language) {
   if (zoo['_id'] == Pandas.def.zoo['_id']) {
     return Pandas.def.zoo[language + ".location"];
   }
-  var link_text = Show.emoji.map + " " + Show.flags[zoo.flag];
+  var link_text = L.emoji.map + " " + L.flags[zoo.flag];
   var google_search = zoo['map'];
   var a = document.createElement('a');
   a.href = google_search;
@@ -946,10 +781,10 @@ Show.zooLink = function(zoo, link_text, language, options) {
   var inner_text = link_text;
   // Options processing
   if (options.indexOf("home_icon") != -1) {
-    inner_text = Show.emoji.home + " " + inner_text;
+    inner_text = L.emoji.home + " " + inner_text;
   }
   if (options.indexOf("map_icon") != -1) {
-    inner_text = Show.emoji.map + " " + inner_text;
+    inner_text = L.emoji.map + " " + inner_text;
   }
   a.innerText = inner_text;
   if (options.indexOf("in_link") != -1) {
@@ -993,8 +828,8 @@ Show.bottomMenu = function(language) {
   shrinker.className = "shrinker";
   // Currently there are top and home buttons
   // Top button
-  var top_icon = Show.emoji.top;
-  var top_text = Show.gui.top[language];
+  var top_icon = L.emoji.top;
+  var top_text = L.gui.top[language];
   var top_button = Show.button("topButton", top_icon, top_text);
   top_button.addEventListener("click", function() {
     // anchor tags get used for JS redraws, so don't use an anchor tag for
@@ -1002,8 +837,8 @@ Show.bottomMenu = function(language) {
     window.scrollTo(0, 0);
   });
   // Home button
-  var home_icon = Show.emoji.home;
-  var home_text = Show.gui.home[language];
+  var home_icon = L.emoji.home;
+  var home_text = L.gui.home[language];
   var home_button = Show.button("homeButton", home_icon, home_text);
   // In mobile mode, logo button at the top doesn't exist so add a home button
   // to the footer bar menu.
@@ -1024,8 +859,8 @@ Show.bottomMenu = function(language) {
 // with the correct language
 Show.credit = function(credit, count, language) {
   var p = document.createElement('p');
-  for (var i in Show.gui.credit[language]) {
-    var field = Show.gui.credit[language][i];
+  for (var i in L.gui.credit[language]) {
+    var field = L.gui.credit[language][i];
     if (field == "<INSERTUSER>") {
       field = credit;
       var msg = document.createElement('i');
@@ -1055,7 +890,7 @@ Show.credit = function(credit, count, language) {
 Show.displayEmptyResult = function(language) {
   var message = document.createElement('div');
   message.className = 'overlay';
-  message.innerText = Show.no_result[language];
+  message.innerText = L.no_result[language];
   var image = document.createElement('img');
   image.src = "images/no-panda.jpg";
   var result = document.createElement('div');
@@ -1069,11 +904,11 @@ Show.displayEmptyResult = function(language) {
 // This uses unlocalized m/f/unknown gender values
 Show.displayChildIcon = function(gender) {
   if (Object.values(Pandas.def.gender.Male).indexOf(gender) != -1) {
-    return Show.emoji.boy;
+    return L.emoji.boy;
   } else if (Object.values(Pandas.def.gender.Female).indexOf(gender) != -1) {
-    return Show.emoji.girl;
+    return L.emoji.girl;
   } else {
-    return Show.emoji.baby;
+    return L.emoji.baby;
   }
 }
 
@@ -1100,7 +935,7 @@ Show.displayGender = function(info) {
 Show.displayPandaChildren = function(info) {
   var heading = document.createElement('h4');
   heading.className = "childrenHeading" + " " + info.language;
-  heading.innerText = Show.gui.children[info.language];
+  heading.innerText = L.gui.children[info.language];
   var ul = document.createElement('ul');
   ul.className = "pandaList" + " " + info.language;
   for (index in Pandas.sortOldestToYoungest(info.children)) {
@@ -1123,13 +958,13 @@ Show.displayPandaChildren = function(info) {
 Show.displayPandaDetails = function(info) {
   var language = info.language;
   var born = document.createElement('p');
-  born.innerText = Show.emoji.born + " " + info.birthday;
+  born.innerText = L.emoji.born + " " + info.birthday;
   // If still alive, print their current age
   var second = document.createElement ('p');
   if (info.death == Pandas.def.unknown[language]) {
     second.innerText = "(" + info.age + ")";
   } else {
-    second.innerText = Show.emoji.died + " " + info.death;
+    second.innerText = L.emoji.died + " " + info.death;
   }
   // Zoo link is the animal's home zoo, linking to a search 
   // for all living pandas at the given zoo.
@@ -1146,7 +981,7 @@ Show.displayPandaDetails = function(info) {
   credit_link.id = info.id + "/author/" + info.photo_index;   // Carousel
   credit_link.href = info.photo_link;
   credit_link.target = "_blank";   // Open in new tab
-  credit_link.innerText = Show.emoji.camera + " " + info.photo_credit;
+  credit_link.innerText = L.emoji.camera + " " + info.photo_credit;
   var credit = document.createElement('p');
   credit.appendChild(credit_link);
   var details = document.createElement('div');
@@ -1164,7 +999,7 @@ Show.displayPandaDetails = function(info) {
     var credit_count_link = document.createElement('a');
     credit_count_link.id = info.id + "/counts/" + info.photo_index;   // Carousel
     credit_count_link.href = "#credit/" + info.photo_credit;
-    credit_count_link.innerText = Show.emoji.gift + " " + P.db._photo.credit[info.photo_credit];
+    credit_count_link.innerText = L.emoji.gift + " " + P.db._photo.credit[info.photo_credit];
     other_photos.appendChild(credit_count_link);
     details.appendChild(other_photos);
   }
@@ -1211,7 +1046,7 @@ Show.displayPandaLitter = function(info) {
   var heading = document.createElement('h4');
   heading.className = "litterHeading" + " " + info.language;
   heading.classList.add(language);
-  heading.innerText = Show.gui.litter[info.language];
+  heading.innerText = L.gui.litter[info.language];
   var ul = document.createElement('ul');
   ul.className = "pandaList" + " " + info.language;
   for (index in Pandas.sortOldestToYoungest(info.litter)) {
@@ -1233,7 +1068,7 @@ Show.displayPandaLitter = function(info) {
 Show.displayPandaParents = function(info) {
   var heading = document.createElement('h4');
   heading.className = "parentsHeading" + " " + info.language;
-  heading.innerText = Show.gui.parents[info.language];
+  heading.innerText = L.gui.parents[info.language];
   var ul = document.createElement('ul');
   ul.className = "pandaList" + " " + info.language;
   var mom_li = document.createElement('li');
@@ -1269,7 +1104,7 @@ Show.displayPandaParents = function(info) {
 Show.displayPandaSiblings = function(info) {
   var heading = document.createElement('h4');
   heading.className = "siblingsHeading" + " " + info.language;
-  heading.innerText = Show.gui.siblings[info.language];
+  heading.innerText = L.gui.siblings[info.language];
   var ul = document.createElement('ul');
   ul.className = "pandaList" + " " + info.language;
   for (index in Pandas.sortOldestToYoungest(info.siblings)) {
@@ -1359,7 +1194,7 @@ Show.displayPhotoNavigation = function(animal_id, photo_id) {
   span.className = "navigator";
   // Clickable dogears when you have a carousel of more than one photo
   if (Show.photoCount(animal_id) < 2) {
-    span.innerText = Show.emoji.no_more;
+    span.innerText = L.emoji.no_more;
   } else {
     span.innerText = photo_id;
     span_link.addEventListener('click', function() {  // Left click event
@@ -1436,10 +1271,10 @@ Show.displayZooDetails = function(info) {
       "頭の記録があります)"
     ].join('')
   }
-  counts.innerText = Show.emoji.animal + " " + count_text[language];
+  counts.innerText = L.emoji.animal + " " + count_text[language];
   var address = document.createElement('p');
   var address_link = document.createElement('a');
-  address_link.innerText = Show.emoji.travel + " " + info.address;
+  address_link.innerText = L.emoji.travel + " " + info.address;
   address_link.href = info.map;
   address_link.target = "_blank";   // Open in new tab
   address.appendChild(address_link);
@@ -1447,7 +1282,7 @@ Show.displayZooDetails = function(info) {
   var zoo_link = document.createElement('a');
   zoo_link.href = info.website;
   zoo_link.target = "_blank";   // Open in new tab
-  zoo_link.innerText = Show.emoji.website + " " + info.name;
+  zoo_link.innerText = L.emoji.website + " " + info.name;
   zoo_page.appendChild(zoo_link);
   var details = document.createElement('div');
   details.className = "zooDetails";
@@ -1460,14 +1295,14 @@ Show.displayZooDetails = function(info) {
     var photo_page = document.createElement('p');
     var photo_link = document.createElement('a');
     photo_link.href = info.photo_link;
-    photo_link.innerText = Show.emoji.camera + " " + info.photo_credit;
+    photo_link.innerText = L.emoji.camera + " " + info.photo_credit;
     photo_page.appendChild(photo_link);
     details.appendChild(photo_page);
     // See how many other panda photos this user has posted
     var other_photos = document.createElement('p');
     var credit_count_link = document.createElement('a');
     credit_count_link.href = "#credit/" + info.photo_credit;
-    credit_count_link.innerText = Show.emoji.gift + " " + P.db._photo.credit[info.photo_credit];
+    credit_count_link.innerText = L.emoji.gift + " " + P.db._photo.credit[info.photo_credit];
     other_photos.appendChild(credit_count_link);
     details.appendChild(other_photos);
   }
@@ -1489,12 +1324,12 @@ Show.displayZooTitle = function(info) {
 // Draw a footer with the correct language
 Show.footer = function(language) {
   var p = document.createElement('p');
-  for (var i in Show.gui.footer[language]) {
-    var field = Show.gui.footer[language][i];
+  for (var i in L.gui.footer[language]) {
+    var field = L.gui.footer[language][i];
     if (field == "<INSERTLINK>") {
       var rpl = document.createElement('a');
       rpl.href = "https://github.com/wwoast/redpanda-lineage";
-      rpl.innerText = Show.gui.footerLink[language];
+      rpl.innerText = L.gui.footerLink[language];
       p.appendChild(rpl);
     } else {
       var msg = document.createTextNode(field);
@@ -1638,12 +1473,12 @@ Show.photoSwap = function(photo, desired_index) {
   credit_link.id = animal_id + "/author/" + new_index;
   credit_link.href = photo_info["link"];
   credit_link.target = "_blank";   // Open in new tab
-  credit_link.innerText = Show.emoji.camera + " " + photo_info["credit"];
+  credit_link.innerText = L.emoji.camera + " " + photo_info["credit"];
   // And the photographer credit's apple points
   var apple_link = document.getElementById(animal_id + "/counts/" + photo_id);
   apple_link.id = animal_id + "/counts/" + new_index;
   apple_link.href = "#credit/" + photo_info["credit"];
-  apple_link.innerText = Show.emoji.gift + " " + P.db._photo.credit[photo_info["credit"]];
+  apple_link.innerText = L.emoji.gift + " " + P.db._photo.credit[photo_info["credit"]];
 }
 
 // Display information for a zoo relevant to the red pandas

--- a/js/show.js
+++ b/js/show.js
@@ -36,7 +36,7 @@ document.addEventListener("DOMContentLoaded", function() {
   G = Dagoba.graph();
 
   L.default();     // Set default language
-  checkHashes();           // See if we started on the links or about pages
+  checkHashes();   // See if we started on the links or about pages
   L.update();      // Update buttons, displayed results, and cookie state
   redrawPage(Show.page);   // Ready to redraw? Let's go.
 

--- a/js/touch.js
+++ b/js/touch.js
@@ -24,107 +24,105 @@ Touch.init = function() {
 }
 
 // The 4 Touch Event Handlers
-Touch.start = function(event, T, passedName) {
-  // disable the standard ability to select the touched object
-  // event.preventDefault();
+Touch.T.start = function(event, passedName) {
   // get the total number of fingers touching the screen
-  T.fingerCount = event.touches.length;
+  this.fingerCount = event.touches.length;
   // since we're looking for a swipe (single finger) and not a gesture (multiple fingers),
   // check that only one finger was used
-  if (T.fingerCount == 1) {
+  if (this.fingerCount == 1) {
     // get the coordinates of the touch
-    T.startX = event.touches[0].pageX;
-    T.startY = event.touches[0].pageY;
+    this.startX = event.touches[0].pageX;
+    this.startY = event.touches[0].pageY;
     // store the triggering element ID
-    T.triggerElementID = passedName;
+    this.triggerElementID = passedName;
   } else {
     // more than one finger touched so cancel
-    Touch.cancel(T);
+    this.cancel();
   }
 }
 
-Touch.move = function(event, T) {
+Touch.T.move = function(event) {
   // event.preventDefault();
   if (event.touches.length == 1) {
-    T.curX = event.touches[0].pageX;
-    T.curY = event.touches[0].pageY;
+    this.curX = event.touches[0].pageX;
+    this.curY = event.touches[0].pageY;
   } else {
-    Touch.cancel(T);
+    this.cancel();
   }
 }
 
-Touch.end = function(event, T) {
+Touch.T.end = function(event) {
   event.preventDefault();
-  if (T.fingerCount == 1 && T.curX != 0) {
+  if (this.fingerCount == 1 && this.curX != 0) {
     // A swipe just happened. Use the distance formula
     // to determine the length of the swipe
-    T.swipeLength = Math.round(Math.sqrt(Math.pow(T.curX - T.startX,2) + 
-                                         Math.pow(T.curY - T.startY,2)));
+    this.swipeLength = Math.round(Math.sqrt(Math.pow(this.curX - this.startX,2) + 
+                                            Math.pow(this.curY - this.startY,2)));
     // If the swipe is longer than the minimum length, do an interface task
-    if (T.swipeLength >= T.minLength) {
-      Touch.angle(T);
-      Touch.swipeDirection(T);
-      Touch.process(T);   // Interface task
-      Touch.cancel(T); // Reset the variables
+    if (this.swipeLength >= this.minLength) {
+      this.angle();
+      this.determine();   // What the swipe direction and angle are
+      this.process();     // Do something in the RPF interface
+      this.cancel();      // Reset the variables
     } else {
-      Touch.cancel(T);
+      this.cancel();
     }
   } else {
-    Touch.cancel(T);
+    this.cancel();
   }
 }
 
-Touch.cancel = function(T) {
+Touch.T.cancel = function() {
   // reset the variables back to default values
-  T.fingerCount = 0;
-  T.startX = 0;
-  T.startY = 0;
-  T.curX = 0;
-  T.curY = 0;
-  T.deltaX = 0;
-  T.deltaY = 0;
-  T.horzDiff = 0;
-  T.vertDiff = 0;
-  T.swipeLength = 0;
-  T.swipeAngle = null;
-  T.swipeDirection = null;
-  T.triggerElementID = null;
+  this.fingerCount = 0;
+  this.startX = 0;
+  this.startY = 0;
+  this.curX = 0;
+  this.curY = 0;
+  this.deltaX = 0;
+  this.deltaY = 0;
+  this.horzDiff = 0;
+  this.vertDiff = 0;
+  this.swipeLength = 0;
+  this.swipeAngle = null;
+  this.swipeDirection = null;
+  this.triggerElementID = null;
 }
 
-Touch.angle = function(T) {
-  var X = T.startX - T.curX;
-  var Y = T.curY - T.startY;
+Touch.T.angle = function() {
+  var X = this.startX - this.curX;
+  var Y = this.curY - this.startY;
   // var Z = Math.round(Math.sqrt(Math.pow(X,2) + Math.pow(Y,2))); // the distance - rounded - in pixels
   var r = Math.atan2(Y,X); // angle in radians (Cartesian system)
-  T.swipeAngle = Math.round(r*180/Math.PI); // angle in degrees
-  if (T.swipeAngle < 0) { 
-    T.swipeAngle = 360 - Math.abs(T.swipeAngle);
+  this.swipeAngle = Math.round(r*180/Math.PI); // angle in degrees
+  if (this.swipeAngle < 0) { 
+    this.swipeAngle = 360 - Math.abs(this.swipeAngle);
   }
 }
 
-Touch.swipeDirection = function(T) {
-  if ((T.swipeAngle <= 45) && (T.swipeAngle >= 0)) {
-    T.swipeDirection = 'left';
-  } else if ((T.swipeAngle <= 360) && (T.swipeAngle >= 315)) {
-    T.swipeDirection = 'left';
-  } else if ((T.swipeAngle >= 135) && (T.swipeAngle <= 225)) {
-    T.swipeDirection = 'right';
-  } else if ((T.swipeAngle > 45) && (T.swipeAngle < 135)) {
-    T.swipeDirection = 'down';
+Touch.T.determine = function() {
+  if ((this.swipeAngle <= 45) && (this.swipeAngle >= 0)) {
+    this.swipeDirection = 'left';
+  } else if ((T.swipeAngle <= 360) && (this.swipeAngle >= 315)) {
+    this.swipeDirection = 'left';
+  } else if ((T.swipeAngle >= 135) && (this.swipeAngle <= 225)) {
+    this.swipeDirection = 'right';
+  } else if ((T.swipeAngle > 45) && (this.swipeAngle < 135)) {
+    this.swipeDirection = 'down';
   } else {
-    T.swipeDirection = 'up';
+    this.swipeDirection = 'up';
   }
 }
 
 // Callback to change the photo based on where the touch event happened
-Touch.process = function(T) {
-  var animal_id = T.triggerElementID.split('/')[0];
+Touch.T.process = function() {
+  var animal_id = this.triggerElementID.split('/')[0];
   var navigator_id = animal_id + "/navigator";
   var navigator = document.getElementById(navigator_id);
-  if (T.swipeDirection == 'right') {
+  if (this.swipeDirection == 'right') {
     Show.photoPrevious(animal_id);
     Show.fade(navigator);
-  } else if (T.swipeDirection == 'left') {
+  } else if (this.swipeDirection == 'left') {
     Show.photoNext(animal_id);
     Show.fade(navigator);
   }

--- a/tests/detail.html
+++ b/tests/detail.html
@@ -7,9 +7,9 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <script type="application/javascript" src="../js/relexer.js"></script>
 <script type="application/javascript" src="../js/dagoba.js"></script>
+<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="./js/language.js"></script>
 <script type="application/javascript" src="../js/touch.js"></script>
-<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="../js/query.js"></script>
 <script type="application/javascript" src="../js/layout.js"></script>
 <script type="application/javascript" src="../js/show.js"></script>

--- a/tests/mockup.html
+++ b/tests/mockup.html
@@ -7,9 +7,9 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <script type="application/javascript" src="../js/relexer.js"></script>
 <script type="application/javascript" src="../js/dagoba.js"></script>
+<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="../js/language.js"></script>
 <script type="application/javascript" src="../js/touch.js"></script>
-<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="../js/query.js"></script>
 <script type="application/javascript" src="../js/layout.js"></script>
 <script type="application/javascript" src="../js/show.js"></script>

--- a/tests/photo.html
+++ b/tests/photo.html
@@ -8,9 +8,9 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <script type="application/javascript" src="../js/relexer.js"></script>
 <script type="application/javascript" src="../js/dagoba.js"></script>
+<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="../js/language.js"></script>
 <script type="application/javascript" src="../js/touch.js"></script>
-<script type="application/javascript" src="../js/pandas.js"></script>
 <script type="application/javascript" src="../js/query.js"></script>
 <script type="application/javascript" src="../js/layout.js"></script>
 <script type="application/javascript" src="../js/show.js"></script>


### PR DESCRIPTION
`show.js` is full of junk, and it would be a poor place to put code related to the detailed panda pages I'm working on. I'm trying to yank as much logic out of `show.js` as possible, and put them in their own modules. Eventually `show.js` will just be code that makes the `pandas.js` output consumable by other things.

`show.js` will remain the home for the `Show` object, which renders text and links and other things in the proper language. Most of the event listeners and button code will eventually live in `page.js`, which will be a multi-level object similar to the `Layout.L` and `Layout.L.arrangements` code in `layout.js` -- each child object of `Page.P` will represent a different modality I want to add to RPF.

Step one of this refactor is yanking all the emojis and language lookup tables, and putting them in `language.js`. Ideally I'd have functions that make the syntax of getting the text you want much simpler, without specifying the `L.display` language to get the right language. But I'm not clever enough to know how to implement this idea yet.

I also refactored both the Language and Touch objects so that they have instance methods, rather than passing the object as a variable to class methods.