### PR TITLE
Multi zoo photos

### DIFF
--- a/build.py
+++ b/build.py
@@ -385,7 +385,8 @@ class RedPandaGraph:
         for field in infile.items("wild"):
             # Use negative numbers for zoo IDs, to distinguish from pandas
             [ key, value ] = [field[0], field[1]]
-            if key == 'photo':
+            if (key.find("photo") != -1 and
+                len(key.split(".")) == 2):
                 author = infile.get("wild", key + ".author")
                 if author in self.photo["credit"].keys():
                     self.photo["credit"][author] = self.photo["credit"][author] + 1
@@ -411,7 +412,8 @@ class RedPandaGraph:
             [ key, value ] = [field[0], field[1]]
             if key == '_id':
                 value = str(int(field[1]) * -1)
-            elif key == 'photo':
+            elif (key.find("photo") != -1 and
+                  len(key.split(".")) == 2):
                 author = infile.get("zoo", key + ".author")
                 if author in self.photo["credit"].keys():
                     self.photo["credit"][author] = self.photo["credit"][author] + 1

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -309,24 +309,37 @@ Gallery.pandaPhotoCredits = function(animal, credit, language) {
 // Take a zoo, and return the photo. Assumes that you have a match
 // that match the username that was searched. Used for making reports of all
 // the photos in the website contributed by a single author.
-Gallery.zooPhotoCredits = function(zoo, language) {
+Gallery.zooPhotoCredits = function(zoo, credit, language) {
+  var content_divs = [];
+  var photos = [];
   var info = Show.acquireZooInfo(zoo, language);
-  var img_link = document.createElement('a');
-  // Link to the original instagram media
-  img_link.href = zoo.photo.replace("/media/?size=m", "");
-  img_link.target = "_blank";   // Open in new tab
-  var img = document.createElement('img');
-  img.src = zoo.photo;
-  img_link.appendChild(img);
-  var caption_link = document.createElement('a');
-  caption_link.href = "#zoo/" + zoo._id;
-  var caption = document.createElement('h5');
-  caption.className = "caption";
-  caption.innerText = info.name;
-  caption_link.appendChild(caption);
-  var container = document.createElement('div');
-  container.className = "photoSample";
-  container.appendChild(img_link);
-  container.appendChild(caption_link);
-  return container;
+  var photo_indexes = Pandas.photoGeneratorEntity;
+  for (let field_name of photo_indexes(zoo, 0)) {
+    if (zoo[field_name + ".author"] == credit) {
+      photos.push({"image": zoo[field_name], "index": field_name});
+    }
+  }
+  for (let item of photos) {
+    var photo = item.image;
+    var index = item.index.split(".")[1];
+    var img_link = document.createElement('a');
+    // Link to the original instagram media
+    img_link.href = photo.replace("/media/?size=m", "");
+    img_link.target = "_blank";   // Open in new tab
+    var img = document.createElement('img');
+    img.src = photo.replace('/?size=m', '/?size=t');
+    img_link.appendChild(img);
+    var caption_link = document.createElement('a');
+    caption_link.href = "#zoo/" + zoo._id + "/photo/" + index;
+    var caption = document.createElement('h5');
+    caption.className = "caption";
+    caption.innerText = info.name;
+    caption_link.appendChild(caption);
+    var container = document.createElement('div');
+    container.className = "photoSample";
+    container.appendChild(img_link);
+    container.appendChild(caption_link);
+    content_divs.push(container);
+  }
+  return content_divs;
 }

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -10,9 +10,19 @@ Gallery = {};     /* Namespace */
 
 Gallery.G = {};   /* Prototype */
 
-Gallery.init = function(info, element_class, fallback_url='images/no-panda-portrait.jpg') {
+Gallery.init = function(info, carousel_type, fallback_url='images/no-panda-portrait.jpg') {
   var gallery = Object.create(Gallery.G);
   gallery.info = info;   // Old photo value == info.photo
+  // Hacky way to determine the proper element class from whether this
+  // is an animal photo carousel or a zoo photo carousel
+  gallery.carousel_type = carousel_type;
+  if (carousel_type == "animal") {
+    gallery.element_class = "pandaPhoto";
+  } else if (carousel_type == "zoo") {
+    gallery.element_class = "zooPhoto";
+  } else {
+    gallery.element_class = "pandaPhoto";
+  }
   // Define index value for which of an animal's photos we'll display by default.
   // Doesn't apply to zoo info objects, so we have a default standby value
   if ("photo_index" in gallery.info) {
@@ -20,7 +30,6 @@ Gallery.init = function(info, element_class, fallback_url='images/no-panda-portr
   } else {
     gallery.index = "1";
   }
-  gallery.element_class = element_class;
   gallery.fallback_url = fallback_url;
   return gallery;
 }
@@ -96,16 +105,16 @@ Gallery.G.displayPhotoPreload = function() {
   var next_photo = "photo." + (parseInt(this.index) + 1).toString();
   var count = this.photoCount(this.info.id);
   var last_photo = "photo." + count.toString();
-  var animal = Pandas.searchPandaId(this.info.id)[0];
-  if (Pandas.field(animal, prev_photo) != default_photo) {
-    imgs.push(animal[prev_photo]);
+  var entity = this.photoEntity();
+  if (Pandas.field(entity, prev_photo, this.carousel_type) != default_photo) {
+    imgs.push(entity[prev_photo]);
   } else {
-    imgs.push(animal[last_photo]);  // Before first item is the last photo in the list
+    imgs.push(entity[last_photo]);  // Before first item is the last photo in the list
   }
-  if (Pandas.field(animal, next_photo) != default_photo) {
-    imgs.push(animal[next_photo]);
+  if (Pandas.field(entity, next_photo, this.carousel_type) != default_photo) {
+    imgs.push(entity[next_photo]);
   } else {
-    imgs.push(animal["photo.1"]);  // After last item is back to the first
+    imgs.push(entity["photo.1"]);  // After last item is back to the first
   }
   // If any of the photos we tried to preload are undefined, remove them from the preload list
   return imgs.filter(function(element) {
@@ -115,22 +124,33 @@ Gallery.G.displayPhotoPreload = function() {
 
 // Utility function to get the current number of photos.
 Gallery.G.photoCount = function() {
-  var animal = Pandas.searchPandaId(this.info.id)[0];
-  var photo_manifest = Pandas.photoManifest(animal);
+  var entity = this.photoEntity();
+  var photo_manifest = Pandas.photoManifest(entity, this.carousel_type);
   var max_index = Object.values(photo_manifest).length;
   return max_index;
 }
 
+// Utility function to get the proper entity for photo counts
+Gallery.G.photoEntity = function() {
+  var entity = undefined;
+  if (this.carousel_type == "zoo") {
+    entity = Pandas.searchZooId(this.info.id)[0];
+  } else {
+    entity = Pandas.searchPandaId(this.info.id)[0];
+  }
+  return entity;
+}
+
 // Navigation input event -- load the next photo in the carousel
-Gallery.G.photoNext = function(animal_id=this.info.id) {
-  var current_photo_element = document.getElementsByClassName(animal_id + "/photo")[0];
+Gallery.G.photoNext = function(entity_id=this.info.id) {
+  var current_photo_element = document.getElementsByClassName(entity_id + "/photo")[0];
   var current_photo_id = current_photo_element.id.split("/")[2];
   this.photoSwap(current_photo_element, parseInt(current_photo_id) + 1);
 }
 
 // Navigation input event -- load the previous photo in the carousel
-Gallery.G.photoPrevious = function(animal_id=this.info.id) {
-  var current_photo_element = document.getElementsByClassName(animal_id + "/photo")[0];
+Gallery.G.photoPrevious = function(entity_id=this.info.id) {
+  var current_photo_element = document.getElementsByClassName(entity_id + "/photo")[0];
   var current_photo_id = current_photo_element.id.split("/")[2];
   this.photoSwap(current_photo_element, parseInt(current_photo_id) - 1);
 }
@@ -138,9 +158,9 @@ Gallery.G.photoPrevious = function(animal_id=this.info.id) {
 // Switch the currently displayed photo to the next one in the list
 Gallery.G.photoSwap = function(photo, desired_index) {
   var span_link = photo.parentNode.childNodes[photo.parentNode.childNodes.length - 1];
-  var [animal_id, _, photo_id] = photo.id.split("/");
-  var animal = Pandas.searchPandaId(animal_id)[0];
-  var photo_manifest = Pandas.photoManifest(animal);
+  var [entity_id, _, photo_id] = photo.id.split("/");
+  var entity = this.photoEntity();
+  var photo_manifest = Pandas.photoManifest(entity, this.carousel_type);
   var max_index = Object.values(photo_manifest).length;
   var new_index = 1;   // Fallback value
   if (desired_index < 1) {
@@ -158,14 +178,14 @@ Gallery.G.photoSwap = function(photo, desired_index) {
   }
   var chosen = "photo." + new_index.toString();
   var new_choice = photo_manifest[chosen];
-  var new_container = this.displayPhoto(new_choice, animal_id, new_index.toString());
+  var new_container = this.displayPhoto(new_choice, entity_id, new_index.toString());
   var new_photo = new_container.childNodes[0];
   // Update existing photo element with info from the frame we switched to
   photo.src = new_photo.src;
   photo.id = new_photo.id;
   photo.className = new_photo.className;
   Touch.addHandler(new_photo);
-  var photo_info = Pandas.profilePhoto(animal, new_index);
+  var photo_info = Pandas.profilePhoto(entity, new_index, this.carousel_type);
   // Replace the animal credit info
   this.singlePhotoCredit(photo_info, photo_id, new_index);
   // And the photographer credit's apple points

--- a/js/page.js
+++ b/js/page.js
@@ -354,12 +354,12 @@ Page.results.entities = function(results) {
 }
 Page.results.photos = function(results) {
   var content_divs = [];
+  // Pandas and zoos have multiple photos, and 
+  // you'll need to filter on the credited photo
   results.forEach(function(entity) {
     if (entity["_id"] < 0) {
-      // Zoos have a single photo to get
-      content_divs.push(Gallery.zooPhotoCredits(entity, L.display));
+      content_divs = content_divs.concat(Gallery.zooPhotoCredits(entity, Query.env.credit, L.display));
     } else {
-      // Pandas have multiple photos, and you'll need to filter on the credited photo
       content_divs = content_divs.concat(Gallery.pandaPhotoCredits(entity, Query.env.credit, L.display));
     }
   });

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -1006,13 +1006,13 @@ Pandas.othernames = function(animal, language) {
 }
 
 // Find all available photos for a specific animal
-Pandas.photoManifest = function(animal, mode="animal") {
+Pandas.photoManifest = function(entity, mode="animal") {
   // Find the available photo indexes between one and ten
   var photos = {};
   var photo_fields = Pandas.photoGeneratorEntity;
   // Gets panda or zoo photos
-  for (let field_name of photo_fields(animal)) {
-    photos[field_name] = Pandas.field(animal, field_name, mode);
+  for (let field_name of photo_fields(entity)) {
+    photos[field_name] = Pandas.field(entity, field_name, mode);
   }
   // Filter out any keys that have the default value for either
   // an animal or a zoo

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -256,8 +256,8 @@ Pandas.def.wild = {
   "jp.address": "TOWRITE",
   "jp.location": "市区町村の情報が表示されていない",
   "jp.name": "動物園が見つかりません",
-  "photo": "images/no-zoo.jpg",
-  "video": "images/no-zoo.jpg",
+  "photo.1": "images/no-zoo.jpg",
+  "video.1": "images/no-zoo.jpg",
   "website": "https://www.worldwildlife.org/"
 }
 
@@ -269,8 +269,8 @@ Pandas.def.zoo = {
   "jp.address": "Googleマップのアドレスが記録されていません",
   "jp.location": "市区町村の情報が表示されていない",
   "jp.name": "動物園が見つかりません",
-  "photo": "images/no-zoo.jpg",
-  "video": "images/no-zoo.jpg",
+  "photo.1": "images/no-zoo.jpg",
+  "video.1": "images/no-zoo.jpg",
   "website": "https://www.worldwildlife.org/"
 }
 
@@ -780,15 +780,15 @@ Pandas.date = function(animal, field, language) {
 
 // Given a field that doesn't have language information associated with it,
 // return either the field if it exists, or some reasonable default.
-Pandas.field = function(animal, field) {
+Pandas.field = function(animal, field, mode="animal") {
   if (animal[field] != undefined) {
     return animal[field];
-  } else if (Pandas.def.animal[field] != undefined ) {
-    return Pandas.def.animal[field];
+  } else if (Pandas.def[mode][field] != undefined ) {
+    return Pandas.def[mode][field];
   } else if (field.indexOf("photo.") == 0) {
-    return Pandas.def.animal["photo.1"];
+    return Pandas.def[mode]["photo.1"];
   } else if (field.indexOf("video.") == 0) {
-    return Pandas.def.animal["video.1"];
+    return Pandas.def[mode]["video.1"];
   } else {
     return undefined;
   }
@@ -1006,17 +1006,19 @@ Pandas.othernames = function(animal, language) {
 }
 
 // Find all available photos for a specific animal
-Pandas.photoManifest = function(animal) {
+Pandas.photoManifest = function(animal, mode="animal") {
   // Find the available photo indexes between one and ten
   var photos = {};
   var photo_fields = Pandas.photoGeneratorEntity;
-  // Gets panda photos
+  // Gets panda or zoo photos
   for (let field_name of photo_fields(animal)) {
-    photos[field_name] = Pandas.field(animal, field_name);
+    photos[field_name] = Pandas.field(animal, field_name, mode);
   }
-  // Filter out any keys that have the default value
+  // Filter out any keys that have the default value for either
+  // an animal or a zoo
   photos = Object.keys(photos).reduce(function(filtered, key) {
-    if (photos[key] != Pandas.def.animal[key]) {
+    if ((photos[key] != Pandas.def.animal[key]) && 
+        (photos[key] != Pandas.def.zoo[key])) {
       filtered[key] = photos[key];
     }
     return filtered;
@@ -1025,9 +1027,9 @@ Pandas.photoManifest = function(animal) {
 }
 
 // Given an animal, choose a single photo to display as its profile photo.
-Pandas.profilePhoto = function(animal, index) {
+Pandas.profilePhoto = function(animal, index, mode="animal") {
   // Find the available photo indexes
-  var photos = Pandas.photoManifest(animal);
+  var photos = Pandas.photoManifest(animal, mode);
   // If photo.(index) not in the photos dict, choose one of the available keys
   // at random from the set of remaining valid images.
   var choice = "photo." + index.toString(); 
@@ -1041,7 +1043,7 @@ Pandas.profilePhoto = function(animal, index) {
   // Javascript is ridiculous
   if (Object.keys(photos).length === 0) {
     choice = "photo.1";
-    photos[choice] = Pandas.field(animal, choice);
+    photos[choice] = Pandas.field(animal, choice, mode);
   }
   // Return not just the chosen photo but the author and link as well
   var desired = {

--- a/js/show.js
+++ b/js/show.js
@@ -63,6 +63,7 @@ Show.acquireLocationList = function(animal, language) {
 // about the number of pandas (living) that are at the zoo
 Show.acquireZooInfo = function(zoo, language) {
   var animals = Pandas.searchPandaZooCurrent(zoo["_id"]);
+  var chosen_index = Query.env.specific == undefined ? "random" : Query.env.specific;
   var picture = Pandas.profilePhoto(zoo, chosen_index);   // TODO: all photos for carousel
   var recorded = Pandas.searchPandaZooBornLived(zoo["_id"]);
   var bundle = {

--- a/js/show.js
+++ b/js/show.js
@@ -71,6 +71,7 @@ Show.acquireZooInfo = function(zoo, language) {
        "address": Pandas.zooField(zoo, language + ".address"),
   "animal_count": animals.length,
       "get_name": language + ".name",
+            "id": zoo["_id"],
       "language": language,
 "language_order": Pandas.language_order(zoo),
       "location": Pandas.zooField(zoo, language + ".location"),
@@ -1061,7 +1062,7 @@ Show.profile.family = function(animal, language) {
 Show.profile.gallery = function(info) {
   // Show a carousel of photos for this animal
   // TODO: start at the profile photo always
-  var gallery = Gallery.init(info, 'pandaPhoto');
+  var gallery = Gallery.init(info, 'animal');
   var photo = gallery.displayPhoto();
   var span = gallery.displayPhotoNavigation();
   photo.appendChild(span);
@@ -1378,7 +1379,7 @@ Show.results.panda = function(animal, language) {
   // Most missing elements should not be displayed, but 
   // a few should be printed regardless (birthday / death)
   var info = Show.acquirePandaInfo(animal, language);
-  var gallery = Gallery.init(info, 'pandaPhoto');
+  var gallery = Gallery.init(info, 'animal');
   var photo = gallery.displayPhoto();
   var span = gallery.displayPhotoNavigation();
   photo.appendChild(span);
@@ -1550,9 +1551,17 @@ Show.results.siblings = function(info) {
 Show.results.zoo = function(zoo, language) {
   // Display information for a zoo relevant to the red pandas
   var info = Show.acquireZooInfo(zoo, language);
-  var gallery = Gallery.init(info, 'zooPhoto', 'images/no-zoo.jpg');
+  var gallery = Gallery.init(info, 'zoo', 'images/no-zoo.jpg');
   var photo = gallery.displayPhoto();
-  var title = Show.zooTitle(info);
+  var span = gallery.displayPhotoNavigation();
+  photo.appendChild(span);
+  photo.addEventListener('mouseover', function() {
+    span.style.display = "block";
+  });
+  photo.addEventListener('mouseout', function() {
+    span.style.display = "none";
+  });
+  title = Show.zooTitle(info);
   var details = Show.results.zooDetails(info);
   var dossier = document.createElement('div');
   dossier.className = "zooDossier";

--- a/js/show.js
+++ b/js/show.js
@@ -1605,7 +1605,7 @@ Show.results.zooDetails = function(info) {
   details.appendChild(zoo_page);
   // Photo details are optional for zoos, so don't show the
   // photo link if there's no photo included in the dataset
-  if (info.photo != Pandas.def.zoo["photo"]) {
+  if (info.photo != Pandas.def.zoo["photo.1"]) {
     var photo_page = document.createElement('p');
     var photo_link = document.createElement('a');
     photo_link.href = info.photo_link;

--- a/js/show.js
+++ b/js/show.js
@@ -63,6 +63,7 @@ Show.acquireLocationList = function(animal, language) {
 // about the number of pandas (living) that are at the zoo
 Show.acquireZooInfo = function(zoo, language) {
   var animals = Pandas.searchPandaZooCurrent(zoo["_id"]);
+  var picture = Pandas.profilePhoto(zoo, chosen_index);   // TODO: all photos for carousel
   var recorded = Pandas.searchPandaZooBornLived(zoo["_id"]);
   var bundle = {
        "animals": animals,
@@ -74,9 +75,10 @@ Show.acquireZooInfo = function(zoo, language) {
       "location": Pandas.zooField(zoo, language + ".location"),
            "map": Pandas.zooField(zoo, "map"),
           "name": Pandas.zooField(zoo, language + ".name"),
-         "photo": Pandas.zooField(zoo, "photo"),
-  "photo_credit": Pandas.zooField(zoo, "photo.author"),
-    "photo_link": Pandas.zooField(zoo, "photo.link"),
+         "photo": picture['photo'],
+  "photo_credit": picture['credit'],
+   "photo_index": picture['index'],
+    "photo_link": picture['link'],
       "recorded": recorded,
 "recorded_count": recorded.length,
        "website": Pandas.zooField(zoo, "website")

--- a/js/show.js
+++ b/js/show.js
@@ -8,7 +8,7 @@ var Show = {};   /* Namespace */
 // its relatives.
 Show.acquirePandaInfo = function(animal, language) {
   var chosen_index = Query.env.specific == undefined ? "random" : Query.env.specific;
-  var picture = Pandas.profilePhoto(animal, chosen_index);   // TODO: all photos for carousel
+  var picture = Pandas.profilePhoto(animal, chosen_index, "animal");   // TODO: all photos for carousel
   var bundle = {
             "age": Pandas.age(animal, language),
        "birthday": Pandas.birthday(animal, language),
@@ -64,7 +64,7 @@ Show.acquireLocationList = function(animal, language) {
 Show.acquireZooInfo = function(zoo, language) {
   var animals = Pandas.searchPandaZooCurrent(zoo["_id"]);
   var chosen_index = Query.env.specific == undefined ? "random" : Query.env.specific;
-  var picture = Pandas.profilePhoto(zoo, chosen_index);   // TODO: all photos for carousel
+  var picture = Pandas.profilePhoto(zoo, chosen_index, "zoo");   // TODO: all photos for carousel
   var recorded = Pandas.searchPandaZooBornLived(zoo["_id"]);
   var bundle = {
        "animals": animals,

--- a/manage.py
+++ b/manage.py
@@ -12,7 +12,6 @@ import sys
 from collections import OrderedDict
 from shared import PANDA_PATH, ZOO_PATH
 
-
 class ProperlyDelimitedConfigParser(configparser.ConfigParser):
     def write(self, fp, space_around_delimiters=True):
         """
@@ -41,33 +40,33 @@ class ProperlyDelimitedConfigParser(configparser.ConfigParser):
                 value = ""
             fp.write("{}{}\n".format(key, value))
 
-def fetch_next_photo_index(config, start_point, stop_point):
+def fetch_next_photo_index(config, section, start_point, stop_point):
     """
     Given we deleted pandas from a dataset entry, find the first available hole in
     the list of photos, and the next available photo to move into that hole.
     """
     photo_index = start_point
     photo_option = "photo." + str(photo_index)
-    is_photo = config.has_option("panda", photo_option)
+    is_photo = config.has_option(section, photo_option)
     if is_photo == True:
         # Find the first hole (slot without a photo)
         while is_photo == True:
             photo_index = photo_index + 1
             photo_option = "photo." + str(photo_index)
-            is_photo = config.has_option("panda", photo_option)
+            is_photo = config.has_option(section, photo_option)
             if photo_index > stop_point:
                 return 0
     # Now that we're in holes, find the next valid photo
     while is_photo == False:
         photo_index = photo_index + 1
         photo_option = "photo." + str(photo_index)
-        is_photo = config.has_option("panda", photo_option)
+        is_photo = config.has_option(section, photo_option)
         # If start point went beyond the last photo, return zero
         if photo_index > stop_point:
             return 0
     return photo_index
 
-def renumber_panda_photos(config, stop_point):
+def renumber_photos(config, section, stop_point):
     """
     Given a file that's just had photos removed from it, renumber all the
     remaining photos so that there are no gaps.
@@ -80,27 +79,27 @@ def renumber_panda_photos(config, stop_point):
         photo_author = photo_option + ".author"
         photo_link = photo_option + ".link"
         photo_tags = photo_option + ".tags"
-        if config.has_option("panda", photo_option) == False:
-            next_index = fetch_next_photo_index(config, photo_index, stop_point)
+        if config.has_option(section, photo_option) == False:
+            next_index = fetch_next_photo_index(config, section, photo_index, stop_point)
             next_option = "photo." + str(next_index)
             next_author = next_option + ".author"
             next_link = next_option + ".link"
             next_tags = next_option + ".tags"
-            if config.has_option("panda", next_option) == True:
-                config.set("panda", photo_option, config.get("panda", next_option))
-                config.set("panda", photo_author, config.get("panda", next_author))
-                config.set("panda", photo_link, config.get("panda", next_link))
-                if config.has_option("panda", next_tags):
-                    config.set("panda", photo_tags, config.get("panda", next_tags))
+            if config.has_option(section, next_option) == True:
+                config.set(section, photo_option, config.get(section, next_option))
+                config.set(section, photo_author, config.get(section, next_author))
+                config.set(section, photo_link, config.get(section, next_link))
+                if config.has_option(section, next_tags):
+                    config.set(section, photo_tags, config.get(section, next_tags))
                 else:
-                    config.remove_option("panda", photo_tags)
-                config.remove_option("panda", next_option)
-                config.remove_option("panda", next_author)
-                config.remove_option("panda", next_link)
-                config.remove_option("panda", next_tags)
+                    config.remove_option(section, photo_tags)
+                config.remove_option(section, next_option)
+                config.remove_option(section, next_author)
+                config.remove_option(section, next_link)
+                config.remove_option(section, next_tags)
         photo_index = photo_index + 1
 
-def remove_panda_photos(author):
+def remove_photos(section, author, file_path):
     """
     Occasionally users will remove or rename their photo files online.
     For cases where the original files cannot be recovered, it may be
@@ -109,14 +108,15 @@ def remove_panda_photos(author):
     Given a author (typically an Instagram username), remove their photos
     from every panda or zoo data entry.
     """
+    file_path = ""
     start_index = 1
     removals = 0
     # Enter the pandas subdirectories
-    for root, dirs, files in os.walk(PANDA_PATH):
+    for root, dirs, files in os.walk(file_path):
         for filename in files:
             photo_index = start_index
             path = root + os.sep + filename
-            config = ProperlyDelimitedConfigParser(default_section="panda", delimiters=(':'))
+            config = ProperlyDelimitedConfigParser(default_section=section, delimiters=(':'))
             config.read(path, encoding="utf-8")
             photo_option = "photo." + str(photo_index)
             author_option = photo_option + ".author"
@@ -124,15 +124,15 @@ def remove_panda_photos(author):
             author_tags = photo_option + ".tags"
             # Look at all available photo fields for a panda, until we get to
             # the Nth photo that doesn't exist 
-            while config.has_option("panda", author_option) == True:
-                panda_author = config.get("panda", "photo." + str(photo_index) + ".author")
-                if author == panda_author:
-                    # print("DEBUG REMOVE: " + path + " -- " + panda_author + " -- " + photo_option)
-                    config.remove_option("panda", photo_option)
-                    config.remove_option("panda", author_option)
-                    config.remove_option("panda", author_link)
-                    if config.has_option("panda", author_tags):
-                        config.remove_option("panda", author_tags)
+            while config.has_option(section, author_option) == True:
+                photo_author = config.get(section, "photo." + str(photo_index) + ".author")
+                if author == photo_author:
+                    # print("DEBUG REMOVE: " + path + " -- " + photo_author + " -- " + photo_option)
+                    config.remove_option(section, photo_option)
+                    config.remove_option(section, author_option)
+                    config.remove_option(section, author_link)
+                    if config.has_option(section, author_tags):
+                        config.remove_option(section, author_tags)
                     removals = removals + 1
                 photo_index = photo_index + 1
                 photo_option = "photo." + str(photo_index)
@@ -141,28 +141,15 @@ def remove_panda_photos(author):
                 author_tags = photo_option + ".tags"
             # Next, renumber the ones that are still there
             if removals > 0:
-                renumber_panda_photos(config, photo_index)
+                renumber_photos(config, section, photo_index)
             # Done? Let's write config
-            write_config(config, "panda", path)
+            write_config(config, section, path)
+
+def remove_panda_photos(author):
+    remove_photos("panda", author, PANDA_PATH)
 
 def remove_zoo_photos(author):
-    """
-    Zoos only have a single photo recorded for each one, and no tags
-    """
-    # Enter the zoo subdirectories
-    for root, dirs, files in os.walk(ZOO_PATH):
-        for filename in files:
-            path = root + os.sep + filename
-            config = ProperlyDelimitedConfigParser(default_section="zoo", delimiters=(':'))
-            config.read(path, encoding="utf-8")
-            if config.has_option("zoo", "photo.author") == True:
-                zoo_author = config.get("zoo", "photo.author")
-                if zoo_author == author:
-                    config.remove_option("zoo", "photo") 
-                    config.remove_option("zoo", "photo.author") 
-                    config.remove_option("zoo", "photo.link")
-            # Done with removals?
-            write_config(config, "zoo", path)
+    remove_photos("zoo", author, ZOO_PATH)
 
 def strings_number_sensitive(input):
     """

--- a/manage.py
+++ b/manage.py
@@ -108,7 +108,6 @@ def remove_photos(section, author, file_path):
     Given a author (typically an Instagram username), remove their photos
     from every panda or zoo data entry.
     """
-    file_path = ""
     start_index = 1
     removals = 0
     # Enter the pandas subdirectories

--- a/zoos/canada/0051_calgary-zoo.txt
+++ b/zoos/canada/0051_calgary-zoo.txt
@@ -6,7 +6,7 @@ en.name: Calgary Zoo
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/gXaumYRHucJ2
-photo: https://www.instagram.com/p/7q3sBBGtnG/media/?size=m
-photo.author: thecalgaryzoo
-photo.link: https://www.instagram.com/thecalgaryzoo/
+photo.1: https://www.instagram.com/p/7q3sBBGtnG/media/?size=m
+photo.1.author: thecalgaryzoo
+photo.1.link: https://www.instagram.com/thecalgaryzoo/
 website: https://www.calgaryzoo.com/

--- a/zoos/canada/0068_safari-niagra.txt
+++ b/zoos/canada/0068_safari-niagra.txt
@@ -6,7 +6,7 @@ en.name: Safari Niagra
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/PkYjqGk5rX22
-photo: https://www.instagram.com/p/oHvh9bxWxl/media/?size=m
-photo.author: a.stevens_xo
-photo.link: https://www.instagram.com/a.stevens_xo/
+photo.1: https://www.instagram.com/p/oHvh9bxWxl/media/?size=m
+photo.1.author: a.stevens_xo
+photo.1.link: https://www.instagram.com/a.stevens_xo/
 website: https://safariniagara.com/

--- a/zoos/canada/0076_assiniboine-park-zoo.txt
+++ b/zoos/canada/0076_assiniboine-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Assiniboine Park Zoo
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/yA6s5Fk3SZx
-photo: https://www.instagram.com/p/BoIJswQg-e6/media/?size=m
-photo.author: steffshieldswriter
-photo.link: https://www.instagram.com/steffshieldswriter/
+photo.1: https://www.instagram.com/p/BoIJswQg-e6/media/?size=m
+photo.1.author: steffshieldswriter
+photo.1.link: https://www.instagram.com/steffshieldswriter/
 website: http://www.assiniboineparkzoo.ca/

--- a/zoos/canada/0082_valley-zoo.txt
+++ b/zoos/canada/0082_valley-zoo.txt
@@ -7,7 +7,7 @@ en.othernames: Valley Zoo & John Janzen Nature Center
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/34HUM7tYy542
-photo: https://www.instagram.com/p/Biuh1AFBxMY/media/?size=m
-photo.author: russell_depeel
-photo.link: https://www.instagram.com/russell_depeel/
+photo.1: https://www.instagram.com/p/Biuh1AFBxMY/media/?size=m
+photo.1.author: russell_depeel
+photo.1.link: https://www.instagram.com/russell_depeel/
 website: https://www.edmonton.ca/attractions_events/edmonton-valley-zoo.aspx

--- a/zoos/canada/0086_vancouver-zoo.txt
+++ b/zoos/canada/0086_vancouver-zoo.txt
@@ -7,7 +7,7 @@ en.othernames:
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/TxXkYjME52C2
-photo: https://www.instagram.com/p/Bki9rSMHJ0X/media/?size=m
-photo.author: gypsy_dreamz
-photo.link: https://www.instagram.com/gypsy_dreamz/
+photo.1: https://www.instagram.com/p/Bki9rSMHJ0X/media/?size=m
+photo.1.author: gypsy_dreamz
+photo.1.link: https://www.instagram.com/gypsy_dreamz/
 website: https://gvzoo.com/

--- a/zoos/canada/0094_zoo-de-granby.txt
+++ b/zoos/canada/0094_zoo-de-granby.txt
@@ -9,7 +9,7 @@ fr.location: Granby, Quebec, Canada
 fr.name: Zoo de Granby
 language.order: fr, en
 map: https://goo.gl/maps/E9eNEDvNPj72
-photo: https://www.instagram.com/p/BQQXyhuDWV6/media/?size=m
-photo.author: zoodegranbyofficiel
-photo.link: https://www.instagram.com/zoodegranbyofficiel/
+photo.1: https://www.instagram.com/p/BQQXyhuDWV6/media/?size=m
+photo.1.author: zoodegranbyofficiel
+photo.1.link: https://www.instagram.com/zoodegranbyofficiel/
 website: https://zoodegranby.com/

--- a/zoos/canada/0096_toronto-zoo.txt
+++ b/zoos/canada/0096_toronto-zoo.txt
@@ -6,7 +6,7 @@ en.name: Toronto Zoo
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/65RpCZ7DA5T2
-photo: https://www.instagram.com/p/BmHYr5yld1C/media/?size=m
-photo.author: mcw_crawford
-photo.link: https://www.instagram.com/mcw_crawford/
+photo.1: https://www.instagram.com/p/BmHYr5yld1C/media/?size=m
+photo.1.author: mcw_crawford
+photo.1.link: https://www.instagram.com/mcw_crawford/
 website: http://www.torontozoo.com/

--- a/zoos/canada/0106_saskatoon-forestry.txt
+++ b/zoos/canada/0106_saskatoon-forestry.txt
@@ -6,7 +6,7 @@ en.name: Saskatoon Forestry Farm Park & Zoo
 flag: Canada
 language.order: en
 map: https://goo.gl/maps/1YnG95vKmtj
-photo: https://www.instagram.com/p/qu9VqANtg4/media/?size=m
-photo.author: bettychuong
-photo.link: https://www.instagram.com/bettychuong/
+photo.1: https://www.instagram.com/p/qu9VqANtg4/media/?size=m
+photo.1.author: bettychuong
+photo.1.link: https://www.instagram.com/bettychuong/
 website: https://www.saskatoon.ca/parks-recreation-attractions/events-attractions/saskatoon-forestry-farm-park-zoo

--- a/zoos/chile/0056_chilean-national-zoo.txt
+++ b/zoos/chile/0056_chilean-national-zoo.txt
@@ -9,7 +9,7 @@ es.name: Zoológico Nacional de Chile
 flag: Chile
 language.order: es, en
 map: https://goo.gl/maps/CtRXBeoUgYF2
-photo: https://www.instagram.com/p/BnWMq4RlZ83/media/?size=m
-photo.author: sibayupurnomo
-photo.link: https://www.instagram.com/sibayupurnomo/
+photo.1: https://www.instagram.com/p/BnWMq4RlZ83/media/?size=m
+photo.1.author: sibayupurnomo
+photo.1.link: https://www.instagram.com/sibayupurnomo/
 website: http://www.parquemet.cl/

--- a/zoos/china/0005_chonquing-zoo.txt
+++ b/zoos/china/0005_chonquing-zoo.txt
@@ -12,7 +12,7 @@ jp.location: unknown
 jp.name: unknown
 language.order: cn, jp, en
 map: https://goo.gl/maps/rsck5UV8B552
-photo: https://www.instagram.com/p/Bq-FcXjAyNF/media/?size=m
-photo.author: alise_tifentale
-photo.link: https://www.instagram.com/alise_tifentale/
+photo.1: https://www.instagram.com/p/Bq-FcXjAyNF/media/?size=m
+photo.1.author: alise_tifentale
+photo.1.link: https://www.instagram.com/alise_tifentale/
 website: http://www.cqzoo.com

--- a/zoos/china/0039_shanghai-zoo.txt
+++ b/zoos/china/0039_shanghai-zoo.txt
@@ -12,7 +12,7 @@ jp.location: unknown
 jp.name: unknown
 language.order: cn, jp, en
 map: https://goo.gl/maps/XGNrUzCRqB42
-photo: https://www.instagram.com/p/BiV8tnsFkdj/media/?size=m
-photo.author: c_yulu_x
-photo.link: https://www.instagram.com/c_yulu_x/
+photo.1: https://www.instagram.com/p/BiV8tnsFkdj/media/?size=m
+photo.1.author: c_yulu_x
+photo.1.link: https://www.instagram.com/c_yulu_x/
 website: http://www.shanghaizoo.cn/

--- a/zoos/japan/0001_ichikawa-zoological-gardens.txt
+++ b/zoos/japan/0001_ichikawa-zoological-gardens.txt
@@ -9,7 +9,7 @@ jp.location: 市川市千葉県
 jp.name: 市川市動植物園
 language.order: jp, en
 map: https://goo.gl/maps/WSyNu7HFhH42
-photo: https://blackcabbit.files.wordpress.com/2013/08/ichikawashi-dousyokubutsuen.jpg
-photo.author: Blackcabbit's World
-photo.link: https://blackcabbit.wordpress.com/2013/08/19/an-enjoyable-day-at-ichikawa-city-zoo/
+photo.1: https://blackcabbit.files.wordpress.com/2013/08/ichikawashi-dousyokubutsuen.jpg
+photo.1.author: Blackcabbit's World
+photo.1.link: https://blackcabbit.wordpress.com/2013/08/19/an-enjoyable-day-at-ichikawa-city-zoo/
 website: http://www.city.ichikawa.lg.jp/zoo/index.html

--- a/zoos/japan/0002_kyoto-city-zoo.txt
+++ b/zoos/japan/0002_kyoto-city-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 京都市 京都府 左京区
 jp.name: 京都市動物園
 language.order: jp, en
 map: https://goo.gl/maps/BzPvCJ64eiB2
-photo: https://www.instagram.com/p/BW1WhG-hsyy/media/?size=m
-photo.author: lespan33
-photo.link: https://www.instagram.com/lespan33/
+photo.1: https://www.instagram.com/p/BW1WhG-hsyy/media/?size=m
+photo.1.author: lespan33
+photo.1.link: https://www.instagram.com/lespan33/
 website: http://www5.city.kyoto.jp/zoo/

--- a/zoos/japan/0003_nagasaki-bio-park.txt
+++ b/zoos/japan/0003_nagasaki-bio-park.txt
@@ -9,7 +9,7 @@ jp.location: 長崎県西海市西彼町中山郷
 jp.name: 長崎バイオパーク
 language.order: jp, en
 map: https://goo.gl/maps/L1wXjRmYYeo
-photo: https://www.instagram.com/p/BnIz3TRl7au/media/?size=m
-photo.author: susumuriku
-photo.link: https://www.instagram.com/susumuriku/
+photo.1: https://www.instagram.com/p/BnIz3TRl7au/media/?size=m
+photo.1.author: susumuriku
+photo.1.link: https://www.instagram.com/susumuriku/
 website: http://www.biopark.co.jp

--- a/zoos/japan/0004_yumemigasaki-park.txt
+++ b/zoos/japan/0004_yumemigasaki-park.txt
@@ -9,7 +9,7 @@ jp.location: 川崎市 神奈川県
 jp.name: 川崎市夢見ヶ崎動物公園
 language.order: jp, en
 map: https://goo.gl/maps/kfMhVjS52Gs
-photo: https://www.instagram.com/p/BS3UzaaDI0R/media/?size=m
-photo.author: tadayuki.339
-photo.link: https://www.instagram.com/tadayuki.339/
+photo.1: https://www.instagram.com/p/BS3UzaaDI0R/media/?size=m
+photo.1.author: tadayuki.339
+photo.1.link: https://www.instagram.com/tadayuki.339/
 website: http://www.city.kawasaki.jp/saiwai/page/0000045037.html

--- a/zoos/japan/0006_tokuyama-zoo.txt
+++ b/zoos/japan/0006_tokuyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 周南市  山口県
 jp.name: 周南市徳山動物園
 language.order: jp, en
 map: https://goo.gl/maps/bMAGo54PQxq
-photo: https://www.instagram.com/p/BYSVMrkFkoo/media/?size=m
-photo.author: satoshijimnikki
-photo.link: https://www.instagram.com/satoshijimnikki/
+photo.1: https://www.instagram.com/p/BYSVMrkFkoo/media/?size=m
+photo.1.author: satoshijimnikki
+photo.1.link: https://www.instagram.com/satoshijimnikki/
 website: http://www.city.shunan.lg.jp/site/zoo/

--- a/zoos/japan/0007_maruyama-zoo.txt
+++ b/zoos/japan/0007_maruyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 中央区 札幌市 北海道
 jp.name: 札幌市円山動物園
 language.order: jp, en
 map: https://goo.gl/maps/EY3uZRXNWNr
-photo: https://www.codaworry.com/images/rpf/maruyama-zoo-winter-small.jpg
-photo.author: wumpwoast
-photo.link: https://www.instagram.com/wumpwoast/
+photo.1: https://www.codaworry.com/images/rpf/maruyama-zoo-winter-small.jpg
+photo.1.author: wumpwoast
+photo.1.link: https://www.instagram.com/wumpwoast/
 website: http://www.city.sapporo.jp/zoo/index.html

--- a/zoos/japan/0008_chiba-zoo.txt
+++ b/zoos/japan/0008_chiba-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 千葉県 関東地方
 jp.name: 千葉市動物公園
 language.order: jp, en
 map: https://goo.gl/maps/14c7BwdSTkr
-photo: https://www.instagram.com/p/Bmi34XCBmdw/media/?size=m
-photo.author: miinzel
-photo.link: https://www.instagram.com/miinzel/
+photo.1: https://www.instagram.com/p/Bmi34XCBmdw/media/?size=m
+photo.1.author: miinzel
+photo.1.link: https://www.instagram.com/miinzel/
 website: https://www.city.chiba.jp/zoo/

--- a/zoos/japan/0009_saitama-childrens-zoo.txt
+++ b/zoos/japan/0009_saitama-childrens-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 東松山市 埼玉県
 jp.name: 埼玉県こども動物自然公園
 language.order: jp, en
 map: https://goo.gl/maps/C8F9LtGktcH2
-photo: https://www.instagram.com/p/BmgEeiolqP-/media/?size=m
-photo.author: pikahonogram_3110
-photo.link: https://www.instagram.com/pikahonogram_3110/
+photo.1: https://www.instagram.com/p/BmgEeiolqP-/media/?size=m
+photo.1.author: pikahonogram_3110
+photo.1.link: https://www.instagram.com/pikahonogram_3110/
 website: http://www.parks.or.jp/sczoo/

--- a/zoos/japan/0010_chausuyama-zoo.txt
+++ b/zoos/japan/0010_chausuyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 長野市 長野県
 jp.name: 茶臼山動物園
 language.order: jp, en
 map: https://goo.gl/maps/3sQ2w9qjTdS2
-photo: https://www.instagram.com/p/BhB8O-bFLOl/media/?size=m
-photo.author: hapirac_mk
-photo.link: https://www.instagram.com/hapirac_mk/
+photo.1: https://www.instagram.com/p/BhB8O-bFLOl/media/?size=m
+photo.1.author: hapirac_mk
+photo.1.link: https://www.instagram.com/hapirac_mk/
 website: http://www.chausuyama.com/

--- a/zoos/japan/0011_kushiro-zoo.txt
+++ b/zoos/japan/0011_kushiro-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 釧路市 釧路総合振興局
 jp.name: 釧路市動物園
 language.order: jp, en
 map: https://goo.gl/maps/8JVH1ftPJHm
-photo: https://www.instagram.com/p/Bm3DLdVHrlq/media/?size=m
-photo.author: kumaiss
-photo.link: https://www.instagram.com/kumaiss/
+photo.1: https://www.instagram.com/p/Bm3DLdVHrlq/media/?size=m
+photo.1.author: kumaiss
+photo.1.link: https://www.instagram.com/kumaiss/
 website: http://www.city.kushiro.lg.jp/zoo/

--- a/zoos/japan/0012_yokohama-zoorasia.txt
+++ b/zoos/japan/0012_yokohama-zoorasia.txt
@@ -9,7 +9,7 @@ jp.location: 横浜 神奈川県
 jp.name: よこはま動物園ズーラシア
 language.order: jp, en
 map: https://goo.gl/maps/j23gm6VW4Zo
-photo: https://www.instagram.com/p/BmlifKhB2rk/media/?size=m
-photo.author: chicoto_3
-photo.link: https://www.instagram.com/chicoto_3/
+photo.1: https://www.instagram.com/p/BmlifKhB2rk/media/?size=m
+photo.1.author: chicoto_3
+photo.1.link: https://www.instagram.com/chicoto_3/
 website: http://www.hama-midorinokyokai.or.jp/zoo/zoorasia/

--- a/zoos/japan/0013_nishiyama-zoo.txt
+++ b/zoos/japan/0013_nishiyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 鯖江市 福井県
 jp.name: 鯖江市西山動物園
 language.order: jp, en
 map: https://goo.gl/maps/vVxLDci5HeE2
-photo: https://www.instagram.com/p/BnTk0l-F9Hl/media/?size=m
-photo.author: yoneyone52
-photo.link: https://www.instagram.com/yoneyone52/
+photo.1: https://www.instagram.com/p/BnTk0l-F9Hl/media/?size=m
+photo.1.author: yoneyone52
+photo.1.link: https://www.instagram.com/yoneyone52/
 website: https://www.city.sabae.fukui.jp/nishiyama_zoo/

--- a/zoos/japan/0014_himeji-central-park.txt
+++ b/zoos/japan/0014_himeji-central-park.txt
@@ -9,7 +9,7 @@ jp.location: 姫路市 兵庫県
 jp.name: 姫路セントラルパーク
 language.order: jp, en
 map: https://goo.gl/maps/QLH8LsUtgm42
-photo: https://www.instagram.com/p/Bn9Ab2FBsEI/media/?size=m
-photo.author: egoist612
-photo.link: https://www.instagram.com/egoist612/
+photo.1: https://www.instagram.com/p/Bn9Ab2FBsEI/media/?size=m
+photo.1.author: egoist612
+photo.1.link: https://www.instagram.com/egoist612/
 website: http://www.central-park.co.jp/

--- a/zoos/japan/0015_ikeda-zoo.txt
+++ b/zoos/japan/0015_ikeda-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 岡山市 岡山県 中国地方
 jp.name: 池田動物園
 language.order: jp, en
 map: https://goo.gl/maps/2bjmzYUBiqk
-photo: https://www.instagram.com/p/Bm65Nn_FKhb/media/?size=m
-photo.author: y_ka.10
-photo.link: https://www.instagram.com/y_ka.10/
+photo.1: https://www.instagram.com/p/Bm65Nn_FKhb/media/?size=m
+photo.1.author: y_ka.10
+photo.1.link: https://www.instagram.com/y_ka.10/
 website: http://www.urban.ne.jp/home/ikedazoo/

--- a/zoos/japan/0016_nihondaira-zoo.txt
+++ b/zoos/japan/0016_nihondaira-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 静岡市 静岡県
 jp.name: 静岡市立日本平動物園
 language.order: jp, en
 map: https://goo.gl/maps/wFRiaNci3Qu
-photo: https://www.instagram.com/p/BvngsjVBY1J/media/?size=m
-photo.author: hiexmas
-photo.link: https://www.instagram.com/hiexmas/
+photo.1: https://www.instagram.com/p/BvngsjVBY1J/media/?size=m
+photo.1.author: hiexmas
+photo.1.link: https://www.instagram.com/hiexmas/
 website: http://www.nhdzoo.jp/

--- a/zoos/japan/0017_tama-zoo.txt
+++ b/zoos/japan/0017_tama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 日野市 東京都
 jp.name: 多摩動物公園
 language.order: jp, en
 map: https://goo.gl/maps/Emr9wdQYAm22
-photo: https://www.instagram.com/p/BlA5hY9l2Qk/media/?size=m
-photo.author: hiro_v36
-photo.link: https://www.instagram.com/hiro_v36/
+photo.1: https://www.instagram.com/p/BlA5hY9l2Qk/media/?size=m
+photo.1.author: hiro_v36
+photo.1.link: https://www.instagram.com/hiro_v36/
 website: http://www.tokyo-zoo.net/zoo/tama/

--- a/zoos/japan/0018_tobu-zoo.txt
+++ b/zoos/japan/0018_tobu-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 宮代町 南埼玉郡 埼玉県
 jp.name: 東武動物公園
 language.order: jp, en
 map: https://goo.gl/maps/74vbDPHR5DK2
-photo: https://www.instagram.com/p/Bioo8kVhp4i/media/?size=m
-photo.author: yurika_0212
-photo.link: https://www.instagram.com/yurika_0212/
+photo.1: https://www.instagram.com/p/Bioo8kVhp4i/media/?size=m
+photo.1.author: yurika_0212
+photo.1.link: https://www.instagram.com/yurika_0212/
 website: http://www.tobuzoo.com/park/

--- a/zoos/japan/0019_morikirara.txt
+++ b/zoos/japan/0019_morikirara.txt
@@ -9,7 +9,7 @@ jp.location: 佐世保市 長崎県
 jp.name: 西海国立公園九十九島動植物園
 language.order: jp, en
 map: https://goo.gl/maps/1pRgFW9fo9v
-photo: https://www.instagram.com/p/Bmsj2UKAOi2/media/?size=m
-photo.author: yukaringo1126
-photo.link: https://www.instagram.com/yukaringo1126/
+photo.1: https://www.instagram.com/p/Bmsj2UKAOi2/media/?size=m
+photo.1.author: yukaringo1126
+photo.1.link: https://www.instagram.com/yukaringo1126/
 website: https://www.morikirara.jp/

--- a/zoos/japan/0020_hirakawa-zoo.txt
+++ b/zoos/japan/0020_hirakawa-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 鹿児島市 鹿児島県
 jp.name: 鹿児島市平川動物公園
 language.order: jp, en
 map: https://goo.gl/maps/RHkCy9Syv8G2
-photo: https://www.instagram.com/p/BKHIGMIhbiz/media/?size=m
-photo.author: otsuruw
-photo.link: https://www.instagram.com/otsuruw/
+photo.1: https://www.instagram.com/p/BKHIGMIhbiz/media/?size=m
+photo.1.author: otsuruw
+photo.1.link: https://www.instagram.com/otsuruw/
 website: http://hirakawazoo.jp/

--- a/zoos/japan/0021_omuta-city-zoo.txt
+++ b/zoos/japan/0021_omuta-city-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 大牟田市 福岡県
 jp.name: 大牟田市動物園
 language.order: jp, en
 map: https://goo.gl/maps/LwmybsWdhww
-photo: https://www.instagram.com/p/BgYYV5-l14w/media/?size=m
-photo.author: takako0814t
-photo.link: https://www.instagram.com/takako0814t/
+photo.1: https://www.instagram.com/p/BgYYV5-l14w/media/?size=m
+photo.1.author: takako0814t
+photo.1.link: https://www.instagram.com/takako0814t/
 website: http://www.omutazoo.org/

--- a/zoos/japan/0022_tennoji-zoo.txt
+++ b/zoos/japan/0022_tennoji-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 天王寺区 大阪市
 jp.name: 天王寺動物園
 language.order: jp, en
 map: https://goo.gl/maps/jgQy9DYiBJJ2
-photo: https://www.instagram.com/p/BnOimFnltP9/media/?size=m
-photo.author: yoshihiko0108
-photo.link: https://www.instagram.com/yoshihiko0108/
+photo.1: https://www.instagram.com/p/BnOimFnltP9/media/?size=m
+photo.1.author: yoshihiko0108
+photo.1.link: https://www.instagram.com/yoshihiko0108/
 website: http://www.city.osaka.lg.jp/contents/wdu170/tennojizoo/

--- a/zoos/japan/0023_fuji-safari-park.txt
+++ b/zoos/japan/0023_fuji-safari-park.txt
@@ -9,7 +9,7 @@ jp.location: 裾野市 静岡県
 jp.name: 富士サファリパーク 公式サイト
 language.order: jp, en
 map: https://goo.gl/maps/PLj4TTrSWVN2
-photo: https://www.instagram.com/p/BdXoC6Pnrlt/media/?size=m
-photo.author: fuji_safari
-photo.link: https://www.instagram.com/fuji_safari/
+photo.1: https://www.instagram.com/p/BdXoC6Pnrlt/media/?size=m
+photo.1.author: fuji_safari
+photo.1.link: https://www.instagram.com/fuji_safari/
 website: https://www.fujisafari.co.jp/

--- a/zoos/japan/0024_hamamatsu-zoo.txt
+++ b/zoos/japan/0024_hamamatsu-zoo.txt
@@ -10,7 +10,7 @@ jp.location: 浜松市 静岡県
 jp.name: 浜松市動物園
 language.order: jp, en
 map: https://goo.gl/maps/oXmmXnkH1h52
-photo: https://www.instagram.com/p/Bp8KUKqgpw1/media/?size=m
-photo.author: k5a1n7a
-photo.link: https://www.instagram.com/k5a1n7a/
+photo.1: https://www.instagram.com/p/Bp8KUKqgpw1/media/?size=m
+photo.1.author: k5a1n7a
+photo.1.link: https://www.instagram.com/k5a1n7a/
 website: http://www.hamazoo.net/

--- a/zoos/japan/0025_hitachi-kamine-zoo.txt
+++ b/zoos/japan/0025_hitachi-kamine-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 日立市 茨城県
 jp.name: 日立市かみね動物園
 language.order: jp, en
 map: https://goo.gl/maps/tBaGy6Ap8DP2
-photo: https://www.instagram.com/p/BjUhrKxHR9D/media/?size=m
-photo.author: relaxia_sokuatsu
-photo.link: https://www.instagram.com/relaxia_sokuatsu/
+photo.1: https://www.instagram.com/p/BjUhrKxHR9D/media/?size=m
+photo.1.author: relaxia_sokuatsu
+photo.1.link: https://www.instagram.com/relaxia_sokuatsu/
 website: http://www.city.hitachi.lg.jp/zoo/

--- a/zoos/japan/0026_akita-oomoriyama.txt
+++ b/zoos/japan/0026_akita-oomoriyama.txt
@@ -9,7 +9,7 @@ jp.location: 秋田市 秋田県
 jp.name: 秋田市大森山動物園ミルヴェ
 language.order: jp, en
 map: https://goo.gl/maps/6xoxQ1KCS3Q2
-photo: https://www.instagram.com/p/BqOgJkMAZp3/media/?size=m
-photo.author: saki_kitayama
-photo.link: https://www.instagram.com/saki_kitayama/
+photo.1: https://www.instagram.com/p/BqOgJkMAZp3/media/?size=m
+photo.1.author: saki_kitayama
+photo.1.link: https://www.instagram.com/saki_kitayama/
 website: https://www.city.akita.lg.jp/zoo/

--- a/zoos/japan/0027_rakujuen.txt
+++ b/zoos/japan/0027_rakujuen.txt
@@ -9,7 +9,7 @@ jp.location: 三島市 静岡県
 jp.name: 三島市立公園 楽寿園
 language.order: jp, en
 map: https://goo.gl/maps/y26QhbPcexm
-photo: https://www.instagram.com/p/BkfNFtWDa1u/media/?size=m
-photo.author: y_pierrot
-photo.link: https://www.instagram.com/y_pierrot/
+photo.1: https://www.instagram.com/p/BkfNFtWDa1u/media/?size=m
+photo.1.author: y_pierrot
+photo.1.link: https://www.instagram.com/y_pierrot/
 website: https://www.city.mishima.shizuoka.jp/rakujyu/

--- a/zoos/japan/0028_yuki-zoo.txt
+++ b/zoos/japan/0028_yuki-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 甲府市 山梨県
 jp.name: 甲府市遊亀公園附属動物園
 language.order: jp, en
 map: https://goo.gl/maps/qpxjKiF6SCu
-photo: https://www.instagram.com/p/BhdhQ-wAi2p/media/?size=m
-photo.author: bony_sho1
-photo.link: https://www.instagram.com/bony_sho1/
+photo.1: https://www.instagram.com/p/BhdhQ-wAi2p/media/?size=m
+photo.1.author: bony_sho1
+photo.1.link: https://www.instagram.com/bony_sho1/
 website: https://www.city.kofu.yamanashi.jp/zoo/

--- a/zoos/japan/0029_adventure-world.txt
+++ b/zoos/japan/0029_adventure-world.txt
@@ -9,7 +9,7 @@ jp.location: 白浜町 和歌山県
 jp.name: アドベンチャーワールド
 language.order: jp, en
 map: https://goo.gl/maps/Z2vDjBgTPAG2
-photo: https://www.instagram.com/p/BqQ4Nf8gJh4/media/?size=m
-photo.author: doubakahanshidemenbaka
-photo.link: https://www.instagram.com/doubakahanshidemenbaka/
+photo.1: https://www.instagram.com/p/BqQ4Nf8gJh4/media/?size=m
+photo.1.author: doubakahanshidemenbaka
+photo.1.link: https://www.instagram.com/doubakahanshidemenbaka/
 website: http://www.aws-s.com/

--- a/zoos/japan/0030_miyazaki-city-phoenix.txt
+++ b/zoos/japan/0030_miyazaki-city-phoenix.txt
@@ -9,7 +9,7 @@ jp.location: 宮崎市 宮崎県
 jp.name: 宮崎市フェニックス自然動物園
 language.order: jp, en
 map: https://goo.gl/maps/Gm2Rjx3mpP72
-photo: https://www.instagram.com/p/BX94xg2FnUN/media/?size=m
-photo.author: stylusesmac
-photo.link: https://www.instagram.com/stylusesmac/
+photo.1: https://www.instagram.com/p/BX94xg2FnUN/media/?size=m
+photo.1.author: stylusesmac
+photo.1.link: https://www.instagram.com/stylusesmac/
 website: http://www.miyazaki-city-zoo.jp/index.html

--- a/zoos/japan/0031_ishikawa-zoo.txt
+++ b/zoos/japan/0031_ishikawa-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 能美市 石川県
 jp.name: いしかわ動物園
 language.order: jp, en
 map: https://goo.gl/maps/45d7ga53bG62
-photo: https://www.instagram.com/p/BYkaGr-gbEo/media/?size=m
-photo.author: 2009fxdl
-photo.link: https://www.instagram.com/2009fxdl/
+photo.1: https://www.instagram.com/p/BYkaGr-gbEo/media/?size=m
+photo.1.author: 2009fxdl
+photo.1.link: https://www.instagram.com/2009fxdl/
 website: http://www.ishikawazoo.jp/

--- a/zoos/japan/0032_fukuoka-zoo.txt
+++ b/zoos/japan/0032_fukuoka-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 中央区 福岡市 福岡県
 jp.name: 福岡市動物園
 language.order: jp, en
 map: https://goo.gl/maps/XZZzwgWnAUq
-photo: https://www.instagram.com/p/BesPcyFB_-O/media/?size=m
-photo.author: fukuokazoo
-photo.link: https://www.instagram.com/fukuokazoo/
+photo.1: https://www.instagram.com/p/BesPcyFB_-O/media/?size=m
+photo.1.author: fukuokazoo
+photo.1.link: https://www.instagram.com/fukuokazoo/
 website: http://zoo.city.fukuoka.lg.jp/

--- a/zoos/japan/0033_ichihara-zonokuni.txt
+++ b/zoos/japan/0033_ichihara-zonokuni.txt
@@ -9,7 +9,7 @@ jp.location: 市原市 千葉県
 jp.name: 市原ぞうの国
 language.order: jp, en
 map: https://goo.gl/maps/t6TwYSxU2dT2
-photo: https://www.instagram.com/p/BM3ILmHjtLl/media/?size=m
-photo.author: s.okano521
-photo.link: https://www.instagram.com/s.okano521/
+photo.1: https://www.instagram.com/p/BM3ILmHjtLl/media/?size=m
+photo.1.author: s.okano521
+photo.1.link: https://www.instagram.com/s.okano521/
 website: http://www.zounokuni.com/

--- a/zoos/japan/0034_tohoku-safari-park.txt
+++ b/zoos/japan/0034_tohoku-safari-park.txt
@@ -9,7 +9,7 @@ jp.location: 二本松市 福島県
 jp.name: 東北サファリパーク
 language.order: jp, en
 map: https://goo.gl/maps/TQwcwc8PpyL2
-photo: https://www.instagram.com/p/BiSxzP1A9I0/media/?size=m
-photo.author: mayubato
-photo.link: https://www.instagram.com/mayubato/
+photo.1: https://www.instagram.com/p/BiSxzP1A9I0/media/?size=m
+photo.1.author: mayubato
+photo.1.link: https://www.instagram.com/mayubato/
 website: http://tohoku-safaripark.co.jp/

--- a/zoos/japan/0035_tokushima-zoo.txt
+++ b/zoos/japan/0035_tokushima-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 徳島市 徳島県
 jp.name: とくしま動物園
 language.order: jp, en
 map: https://goo.gl/maps/d7LpHftgkFq
-photo: https://www.instagram.com/p/BY5TZ6EgTjA/media/?size=m
-photo.author: polarbear_zoo
-photo.link: https://www.instagram.com/polarbear_zoo/
+photo.1: https://www.instagram.com/p/BY5TZ6EgTjA/media/?size=m
+photo.1.author: polarbear_zoo
+photo.1.link: https://www.instagram.com/polarbear_zoo/
 website: http://www.city.tokushima.tokushima.jp/zoo/

--- a/zoos/japan/0036_kobe-oji-zoo.txt
+++ b/zoos/japan/0036_kobe-oji-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 灘区 神戸市
 jp.name: 神戸市立王子動物園
 language.order: jp, en
 map: https://goo.gl/maps/8P5cFSjECns
-photo: https://www.instagram.com/p/BYhQfxIFWau/media/?size=m
-photo.author: nekochan_in_japan
-photo.link: https://www.instagram.com/nekochan_in_japan/
+photo.1: https://www.instagram.com/p/BYhQfxIFWau/media/?size=m
+photo.1.author: nekochan_in_japan
+photo.1.link: https://www.instagram.com/nekochan_in_japan/
 website: http://www.kobe-ojizoo.jp/

--- a/zoos/japan/0037_asahiyama-zoo.txt
+++ b/zoos/japan/0037_asahiyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 旭川市 北海道
 jp.name: 旭川市旭山動物園
 language.order: jp, en
 map: https://goo.gl/maps/pRRcmyyfEUF2
-photo: https://www.instagram.com/p/BqJqigEHRvF/media/?size=m
-photo.author: poledancer_kayo
-photo.link: https://www.instagram.com/poledancer_kayo/
+photo.1: https://www.instagram.com/p/BqJqigEHRvF/media/?size=m
+photo.1.author: poledancer_kayo
+photo.1.link: https://www.instagram.com/poledancer_kayo/
 website: http://www.city.asahikawa.hokkaido.jp/asahiyamazoo/

--- a/zoos/japan/0038_nogeyama-zoo.txt
+++ b/zoos/japan/0038_nogeyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 西区 横浜
 jp.name: 横浜市立野毛山動物園
 language.order: jp, en
 map: https://goo.gl/maps/TbqkYpePr5P2
-photo: https://www.instagram.com/p/BJphz90B8rd/media/?size=m
-photo.author: aqua_vanilla
-photo.link: https://www.instagram.com/aqua_vanilla/
+photo.1: https://www.instagram.com/p/BJphz90B8rd/media/?size=m
+photo.1.author: aqua_vanilla
+photo.1.link: https://www.instagram.com/aqua_vanilla/
 website: http://www.hama-midorinokyokai.or.jp/zoo/nogeyama/

--- a/zoos/japan/0040_hiroshima-city-asa.txt
+++ b/zoos/japan/0040_hiroshima-city-asa.txt
@@ -9,7 +9,7 @@ jp.location: 広島市 広島県
 jp.name: 広島市安佐動物公園
 language.order: jp, en
 map: https://goo.gl/maps/6RKGqYpdxew
-photo: https://www.instagram.com/p/Bn_NwpUFIC4/media/?size=m
-photo.author: nami_nami.u
-photo.link: https://www.instagram.com/nami_nami.u/
+photo.1: https://www.instagram.com/p/Bn_NwpUFIC4/media/?size=m
+photo.1.author: nami_nami.u
+photo.1.link: https://www.instagram.com/nami_nami.u/
 website: http://www.asazoo.jp/

--- a/zoos/japan/0041_itozunomori-koen.txt
+++ b/zoos/japan/0041_itozunomori-koen.txt
@@ -9,7 +9,7 @@ jp.location: 北九州市 福岡県
 jp.name: 到津の森公園
 language.order: jp, en
 map: https://goo.gl/maps/a4z75hLhZ692
-photo: https://www.instagram.com/p/BqzBnzWlREb/media/?size=m
-photo.author: kipekaila
-photo.link: https://www.instagram.com/kipekaila/
+photo.1: https://www.instagram.com/p/BqzBnzWlREb/media/?size=m
+photo.1.author: kipekaila
+photo.1.link: https://www.instagram.com/kipekaila/
 website: http://www.itozu-zoo.jp/

--- a/zoos/japan/0042_akiyoshidai-safari-land.txt
+++ b/zoos/japan/0042_akiyoshidai-safari-land.txt
@@ -9,7 +9,7 @@ jp.location: 美祢市 山口県
 jp.name: 秋吉台自然動物公園サファリランド
 language.order: jp, en
 map: https://goo.gl/maps/UT1Be9m6ukw
-photo: https://www.instagram.com/p/BqlStDKA1JS/media/?size=m
-photo.author: toys_gear
-photo.link: https://www.instagram.com/toys_gear/
+photo.1: https://www.instagram.com/p/BqlStDKA1JS/media/?size=m
+photo.1.author: toys_gear
+photo.1.link: https://www.instagram.com/toys_gear/
 website: http://www.safariland.jp/

--- a/zoos/japan/0045_zoo-paradise-yagiyama.txt
+++ b/zoos/japan/0045_zoo-paradise-yagiyama.txt
@@ -9,7 +9,7 @@ jp.location: 太白区 仙台市
 jp.name: セルコホーム ズーパラダイス八木山
 language.order: jp, en
 map: https://goo.gl/maps/S4dSPcsEcH62
-photo: https://www.instagram.com/p/BUN1bxyDizx/media/?size=m
-photo.author: zakujapan
-photo.link: https://www.instagram.com/zakujapan/
+photo.1: https://www.instagram.com/p/BUN1bxyDizx/media/?size=m
+photo.1.author: zakujapan
+photo.1.link: https://www.instagram.com/zakujapan/
 website: http://www.city.sendai.jp/zoo/index.html

--- a/zoos/japan/0046_tobe-zoo.txt
+++ b/zoos/japan/0046_tobe-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 砥部町 愛媛県 四国
 jp.name: 愛媛県立とべ動物園
 language.order: jp, en
 map: https://goo.gl/maps/AiYMttHQEdA2
-photo: https://www.instagram.com/p/Bnvxk_wFklP/media/?size=m
-photo.author: kipekaila
-photo.link: https://www.instagram.com/kipekaila/
+photo.1: https://www.instagram.com/p/Bnvxk_wFklP/media/?size=m
+photo.1.author: kipekaila
+photo.1.link: https://www.instagram.com/kipekaila/
 website: https://www.tobezoo.com/

--- a/zoos/japan/0050_misaki-park.txt
+++ b/zoos/japan/0050_misaki-park.txt
@@ -9,7 +9,7 @@ jp.location: 岬町 大阪府
 jp.name: みさき公園
 language.order: jp, en
 map: https://goo.gl/maps/13D4TFarwv12
-photo: https://www.instagram.com/p/BnSiMGOFgDP/media/?size=m
-photo.author: hirokoarikiyo
-photo.link: https://www.instagram.com/hirokoarikiyo/
+photo.1: https://www.instagram.com/p/BnSiMGOFgDP/media/?size=m
+photo.1.author: hirokoarikiyo
+photo.1.link: https://www.instagram.com/hirokoarikiyo/
 website: http://www.nankai.co.jp/misaki/

--- a/zoos/japan/0052_hirakata-park.txt
+++ b/zoos/japan/0052_hirakata-park.txt
@@ -10,7 +10,7 @@ jp.location: 枚方市 大阪府
 jp.name: ひらかたパーク
 language.order: jp, en
 map: https://goo.gl/maps/Uz15oJH5U7U2
-photo: https://www.instagram.com/p/BpJMgzQB8Lb/media/?size=m
-photo.author: hirakatapark
-photo.link: https://www.instagram.com/hirakatapark/
+photo.1: https://www.instagram.com/p/BpJMgzQB8Lb/media/?size=m
+photo.1.author: hirakatapark
+photo.1.link: https://www.instagram.com/hirakatapark/
 website: http://www.hirakatapark.co.jp/

--- a/zoos/japan/0053_nasu-animal-kingdom.txt
+++ b/zoos/japan/0053_nasu-animal-kingdom.txt
@@ -9,7 +9,7 @@ jp.location: 那須郡 栃木県
 jp.name: 那須どうぶつ王国
 language.order: jp, en
 map: https://goo.gl/maps/32qL3cSPkwP2
-photo: https://www.instagram.com/p/BoqztCmltwR/media/?size=m
-photo.author: kipekaila
-photo.link: https://www.instagram.com/kipekaila/
+photo.1: https://www.instagram.com/p/BoqztCmltwR/media/?size=m
+photo.1.author: kipekaila
+photo.1.link: https://www.instagram.com/kipekaila/
 website: http://www.nasu-oukoku.com/

--- a/zoos/japan/0054_ueno-zoo.txt
+++ b/zoos/japan/0054_ueno-zoo.txt
@@ -10,7 +10,7 @@ jp.location: 台東区 東京
 jp.name: 恩賜上野動物園
 language.order: jp, en
 map: https://goo.gl/maps/o6BBZkWDuv32
-photo: https://www.instagram.com/p/BrAEICjFn0K/media/?size=m
-photo.author: nikkoripanda1
-photo.link: https://www.instagram.com/nikkoripanda1/
+photo.1: https://www.instagram.com/p/BrAEICjFn0K/media/?size=m
+photo.1.author: nikkoripanda1
+photo.1.link: https://www.instagram.com/nikkoripanda1/
 website: http://www.tokyo-zoo.net/zoo/ueno/

--- a/zoos/japan/0057_gunma-safari-park.txt
+++ b/zoos/japan/0057_gunma-safari-park.txt
@@ -9,7 +9,7 @@ jp.location: 群馬県
 jp.name: 群馬サファリパーク
 language.order: jp, en
 map: https://goo.gl/maps/at8sz15RscJ2
-photo: https://www.instagram.com/p/wDsin_Enj_/media/?size=m
-photo.author: omisadooguro
-photo.link: https://www.instagram.com/omisadooguro/
+photo.1: https://www.instagram.com/p/wDsin_Enj_/media/?size=m
+photo.1.author: omisadooguro
+photo.1.link: https://www.instagram.com/omisadooguro/
 website: http://www.safari.co.jp/

--- a/zoos/japan/0058_kobe-animal-kingdom.txt
+++ b/zoos/japan/0058_kobe-animal-kingdom.txt
@@ -9,7 +9,7 @@ jp.location: ポートアイランド 中央区 神戸市
 jp.name: 神戸どうぶつ王国
 language.order: jp, en
 map: https://goo.gl/maps/eD1oUBUky182
-photo: https://www.instagram.com/p/Bjb0NXJhN5i/media/?size=m
-photo.author: gwen_rocco
-photo.link: https://www.instagram.com/gwen_rocco/
+photo.1: https://www.instagram.com/p/Bjb0NXJhN5i/media/?size=m
+photo.1.author: gwen_rocco
+photo.1.link: https://www.instagram.com/gwen_rocco/
 website: https://www.kobe-oukoku.com/

--- a/zoos/japan/0059_bananawani.txt
+++ b/zoos/japan/0059_bananawani.txt
@@ -10,7 +10,7 @@ jp.location: 東伊豆町 賀茂郡 静岡県
 jp.name: 熱川バナナワニ園
 language.order: jp, en
 map: https://goo.gl/maps/H7nX1JM8hAv
-photo: https://www.instagram.com/p/BmUcSR6FNwQ/media/?size=m
-photo.author: bananawani_official
-photo.link: https://www.instagram.com/bananawani_official/
+photo.1: https://www.instagram.com/p/BmUcSR6FNwQ/media/?size=m
+photo.1.author: bananawani_official
+photo.1.link: https://www.instagram.com/bananawani_official/
 website: http://bananawani.jp/

--- a/zoos/japan/0060_noichi-zoological-park.txt
+++ b/zoos/japan/0060_noichi-zoological-park.txt
@@ -9,7 +9,7 @@ jp.location: 香南市 高知県
 jp.name: 高知県立のいち動物公園
 language.order: jp, en
 map: https://goo.gl/maps/4p2bfiBPbGL2
-photo: https://www.instagram.com/p/BY-LFK0BBz0/media/?size=m
-photo.author: rinkei0326
-photo.link: https://www.instagram.com/rinkei0326/
+photo.1: https://www.instagram.com/p/BY-LFK0BBz0/media/?size=m
+photo.1.author: rinkei0326
+photo.1.link: https://www.instagram.com/rinkei0326/
 website: http://www.noichizoo.or.jp/

--- a/zoos/japan/0061_fukuchiyama-zoo.txt
+++ b/zoos/japan/0061_fukuchiyama-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 福知山市 京都府
 jp.name: 福知山市動物園
 language.order: jp, en
 map: https://goo.gl/maps/XZvhpftc9L72
-photo: https://www.instagram.com/p/BQuTZ7uALz8/media/?size=m
-photo.author: kisshan324
-photo.link: https://www.instagram.com/kisshan324/
+photo.1: https://www.instagram.com/p/BQuTZ7uALz8/media/?size=m
+photo.1.author: kisshan324
+photo.1.link: https://www.instagram.com/kisshan324/
 website: http://www.sandanike-kouen.or.jp/zoo.php

--- a/zoos/japan/0063_toyama-family-park-zoo.txt
+++ b/zoos/japan/0063_toyama-family-park-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 富山市 富山県
 jp.name: 富山市ファミリーパーク
 language.order: jp, en
 map: https://goo.gl/maps/v3zCNrq2igs
-photo: https://www.instagram.com/p/BmuiSvKBgGI/media/?size=m
-photo.author: armsnet
-photo.link: https://www.instagram.com/armsnet/
+photo.1: https://www.instagram.com/p/BmuiSvKBgGI/media/?size=m
+photo.1.author: armsnet
+photo.1.link: https://www.instagram.com/armsnet/
 website: http://www.toyama-familypark.jp/

--- a/zoos/japan/0064_oshima-park.txt
+++ b/zoos/japan/0064_oshima-park.txt
@@ -9,7 +9,7 @@ jp.location: 伊豆大島 東京都
 jp.name: 東京都立大島公園
 language.order: jp, en
 map: https://goo.gl/maps/ygjtnJ59iXw
-photo: https://www.instagram.com/p/Bg00Bl9hYZs/media/?size=m
-photo.author: dacrag
-photo.link: https://www.instagram.com/dacrag/
+photo.1: https://www.instagram.com/p/Bg00Bl9hYZs/media/?size=m
+photo.1.author: dacrag
+photo.1.link: https://www.instagram.com/dacrag/
 website: http://www.soumu.metro.tokyo.jp/11osima/park/www/htdocs/parkindex.html

--- a/zoos/japan/0069_hamura-zoo.txt
+++ b/zoos/japan/0069_hamura-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 羽村市 東京都
 jp.name: 羽村市動物公園
 language.order: jp, en
 map: https://goo.gl/maps/EwC6VTy9MEp
-photo: https://www.instagram.com/p/BhK4t9fnfyH/media/?size=m
-photo.author: soarahinata7
-photo.link: https://www.instagram.com/soarahinata7/
+photo.1: https://www.instagram.com/p/BhK4t9fnfyH/media/?size=m
+photo.1.author: soarahinata7
+photo.1.link: https://www.instagram.com/soarahinata7/
 website: http://www.t-net.ne.jp/~hamura-z/

--- a/zoos/japan/0070_himeji-municipal-zoo.txt
+++ b/zoos/japan/0070_himeji-municipal-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 姫路市 兵庫県
 jp.name: 姫路市立動物園
 language.order: jp, en
 map: https://goo.gl/maps/Em6HbHWwLHC2
-photo: https://www.instagram.com/p/BJPOAO3hTkk/media/?size=m
-photo.author: toko_2424
-photo.link: https://www.instagram.com/toko_2424/
+photo.1: https://www.instagram.com/p/BJPOAO3hTkk/media/?size=m
+photo.1.author: toko_2424
+photo.1.link: https://www.instagram.com/toko_2424/
 website: http://www.city.himeji.lg.jp/dobutuen/

--- a/zoos/japan/0073_edogawa-zoo.txt
+++ b/zoos/japan/0073_edogawa-zoo.txt
@@ -9,7 +9,7 @@ jp.location: 江戸川区 東京府
 jp.name: 江戸川区自然動物園
 language.order: jp, en
 map: https://goo.gl/maps/tDgbZr73HuQ2
-photo: https://www.instagram.com/p/Bpg_qSOFhT7/media/?size=m
-photo.author: shirokuma_jump
-photo.link: https://www.instagram.com/shirokuma_jump/
+photo.1: https://www.instagram.com/p/Bpg_qSOFhT7/media/?size=m
+photo.1.author: shirokuma_jump
+photo.1.link: https://www.instagram.com/shirokuma_jump/
 website: http://edogawa-kankyozaidan.jp/zoo/

--- a/zoos/japan/0074_osaki-park-childrens-zoo.txt
+++ b/zoos/japan/0074_osaki-park-childrens-zoo.txt
@@ -11,7 +11,7 @@ jp.name: 大崎公園
 jp.othernames: 子供動物園
 language.order: jp, en
 map: https://goo.gl/maps/g6ZCMfTFdrw
-photo: https://www.instagram.com/p/BqCMddSHxzk/media/?size=m
-photo.author: lexus_hs
-photo.link: https://www.instagram.com/lexus_hs/
+photo.1: https://www.instagram.com/p/BqCMddSHxzk/media/?size=m
+photo.1.author: lexus_hs
+photo.1.link: https://www.instagram.com/lexus_hs/
 website: http://www.city.saitama.jp/004/001/003/001/p002130.html

--- a/zoos/japan/0079_nasu-monkey-park.txt
+++ b/zoos/japan/0079_nasu-monkey-park.txt
@@ -9,7 +9,7 @@ jp.location: 那須町 栃木県
 jp.name: 那須ワールドモンキーパーク
 language.order: jp, en
 map: https://goo.gl/maps/wXxiP9TZrQG2
-photo: https://www.instagram.com/p/Bk-TVBcl8ad/media/?size=m
-photo.author: tomonobu_yasoshima
-photo.link: https://www.instagram.com/tomonobu_yasoshima/
+photo.1: https://www.instagram.com/p/Bk-TVBcl8ad/media/?size=m
+photo.1.author: tomonobu_yasoshima
+photo.1.link: https://www.instagram.com/tomonobu_yasoshima/
 website: http://www.nasumonkey.com/

--- a/zoos/japan/0190_hakkeijima-sea-paradise.txt
+++ b/zoos/japan/0190_hakkeijima-sea-paradise.txt
@@ -8,8 +8,8 @@ jp.address: 〒236-0006 神奈川県横浜市金沢区八景島
 jp.location: 八景島 横浜 神奈川県
 jp.name: 横浜・八景島シーパラダイス
 language.order: jp, en
-photo: https://www.instagram.com/p/Bvn3y3ng3K9/media/?size=m
-photo.author: luna__soleil
-photo.link: https://www.instagram.com/luna__soleil
+photo.1: https://www.instagram.com/p/Bvn3y3ng3K9/media/?size=m
+photo.1.author: luna__soleil
+photo.1.link: https://www.instagram.com/luna__soleil
 map: https://goo.gl/maps/xFgBvqMLqdrmcvSp7
 website: http://www.seaparadise.co.jp/event/redpanda.html

--- a/zoos/netherlands/0071_aquazoo-friesland.txt
+++ b/zoos/netherlands/0071_aquazoo-friesland.txt
@@ -9,7 +9,7 @@ map: https://goo.gl/maps/ZzXQeezpAo52
 nl.address: De Groene Ster 2, 8926 XE Leeuwarden, Netherlands
 nl.location: Leeuwarden, Friesland Province, Netherlands
 nl.name: Aquazoo Friesland
-photo: https://www.instagram.com/p/BU4b4vjjq98/media/?size=m
-photo.author: aquazoofriesland
-photo.link: https://www.instagram.com/aquazoofriesland/
+photo.1: https://www.instagram.com/p/BU4b4vjjq98/media/?size=m
+photo.1.author: aquazoofriesland
+photo.1.link: https://www.instagram.com/aquazoofriesland/
 website: https://www.aquazoo.nl/

--- a/zoos/netherlands/0072_rotterdam-zoo.txt
+++ b/zoos/netherlands/0072_rotterdam-zoo.txt
@@ -9,7 +9,7 @@ map: https://goo.gl/maps/yFbttoQZrP82
 nl.address: Blijdorplaan 8, 3041 JG Rotterdam, Netherlands
 nl.location: Rotterdam, Netherlands
 nl.name: Diergaarde Blijdorp
-photo: https://www.instagram.com/p/BrNDlAelKeZ/media/?size=m
-photo.author: knitwit010
-photo.link: https://www.instagram.com/knitwit010/
+photo.1: https://www.instagram.com/p/BrNDlAelKeZ/media/?size=m
+photo.1.author: knitwit010
+photo.1.link: https://www.instagram.com/knitwit010/
 website: https://www.diergaardeblijdorp.nl/

--- a/zoos/russia/0149_moscow-zoo.txt
+++ b/zoos/russia/0149_moscow-zoo.txt
@@ -6,9 +6,9 @@ en.name: Moscow Zoo
 flag: Russia
 language.order: ru, en
 map: https://goo.gl/maps/KR9xSj6sJfu
-photo: https://www.instagram.com/p/BZx1NpPh7CE/media/?size=m
-photo.author: moscow_zoo_official
-photo.link: https://www.instagram.com/moscow_zoo_official/
+photo.1: https://www.instagram.com/p/BZx1NpPh7CE/media/?size=m
+photo.1.author: moscow_zoo_official
+photo.1.link: https://www.instagram.com/moscow_zoo_official/
 ru.address: Б. Грузинская ул., 1, Москва, 123242
 ru.location: Москва
 ru.name: Московский зоопарк

--- a/zoos/south-korea/0062_everland-zoological-gardens.txt
+++ b/zoos/south-korea/0062_everland-zoological-gardens.txt
@@ -10,7 +10,7 @@ kr.location: 용인시 경기도
 kr.name: 에버랜드
 language.order: kr, en
 map: https://goo.gl/maps/e4tvYMRSY7z
-photo: https://www.instagram.com/p/BrDKTTJnd3J/media/?size=m
-photo.author: ritchzzzz
-photo.link: https://www.instagram.com/ritchzzzz/
+photo.1: https://www.instagram.com/p/BrDKTTJnd3J/media/?size=m
+photo.1.author: ritchzzzz
+photo.1.link: https://www.instagram.com/ritchzzzz/
 website: http://www.everland.com/

--- a/zoos/south-korea/0078_seoul-zoo.txt
+++ b/zoos/south-korea/0078_seoul-zoo.txt
@@ -10,7 +10,7 @@ kr.location: 경기도 한국
 kr.name: 서울대공원해양동물원
 language.order: kr, en
 map: https://goo.gl/maps/HU9yotcVBXQ2
-photo: https://www.instagram.com/p/BSxW3JIF0Kc/media/?size=m
-photo.author: anakjajan
-photo.link: https://www.instagram.com/anakjajan/
+photo.1: https://www.instagram.com/p/BSxW3JIF0Kc/media/?size=m
+photo.1.author: anakjajan
+photo.1.link: https://www.instagram.com/anakjajan/
 website: http://grandpark.seoul.go.kr

--- a/zoos/taiwan/0055_taiwan-zoo.txt
+++ b/zoos/taiwan/0055_taiwan-zoo.txt
@@ -10,7 +10,7 @@ en.othernames: Muzha Zoo
 flag: Taiwan
 language.order: cn, en
 map: https://goo.gl/maps/9vr6Usew49x
-photo: https://www.instagram.com/p/BqjdtXdn7fs/media/?size=m
-photo.author: yulixyang
-photo.link: https://www.instagram.com/yulixyang/
+photo.1: https://www.instagram.com/p/BqjdtXdn7fs/media/?size=m
+photo.1.author: yulixyang
+photo.1.link: https://www.instagram.com/yulixyang/
 website: https://www.zoo.gov.taipei/Default.aspx

--- a/zoos/thailand/0100_khao-kheow-open-zoo.txt
+++ b/zoos/thailand/0100_khao-kheow-open-zoo.txt
@@ -6,9 +6,9 @@ en.name: Khao Kheow Open Zoo
 flag: Thailand
 language.order: th, en
 map: https://goo.gl/maps/QRi8XP3ynNU2
-photo: https://www.instagram.com/p/BRAUtHuBncB/media/?size=m
-photo.author: nataly_sav
-photo.link: https://www.instagram.com/nataly_sav/
+photo.1: https://www.instagram.com/p/BRAUtHuBncB/media/?size=m
+photo.1.author: nataly_sav
+photo.1.link: https://www.instagram.com/nataly_sav/
 th.address: 235 หมู่ที่ 7 ตำบล บางพระ อำเภอ ศรีราชา ชลบุรี 20110
 th.location: เทศบาลเมืองชลบุรี
 th.name: สวนสัตว์เปิดเขาเขียว

--- a/zoos/united-states/0043_columbus-zoo.txt
+++ b/zoos/united-states/0043_columbus-zoo.txt
@@ -6,7 +6,7 @@ en.name: Columbus Zoo and Aquarium
 flag: USA
 language.order: en
 map: https://goo.gl/maps/CWVYiPe7c3S2
-photo: https://www.instagram.com/p/BqkNLkSHHZI/media/?size=m
-photo.author: believeinthemagictraci
-photo.link: https://www.instagram.com/believeinthemagictraci/
+photo.1: https://www.instagram.com/p/BqkNLkSHHZI/media/?size=m
+photo.1.author: believeinthemagictraci
+photo.1.link: https://www.instagram.com/believeinthemagictraci/
 website: https://www.columbuszoo.org/

--- a/zoos/united-states/0044_northeastern-wisconsin-zoo.txt
+++ b/zoos/united-states/0044_northeastern-wisconsin-zoo.txt
@@ -7,7 +7,7 @@ en.othernames: NEW Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/Wi6pMXofB6w
-photo: https://www.instagram.com/p/BklGCq_gm13/media/?size=m
-photo.author: newzoogb
-photo.link: https://www.instagram.com/newzoogb/
+photo.1: https://www.instagram.com/p/BklGCq_gm13/media/?size=m
+photo.1.author: newzoogb
+photo.1.link: https://www.instagram.com/newzoogb/
 website: https://newzoo.org

--- a/zoos/united-states/0047_happy-hollow.txt
+++ b/zoos/united-states/0047_happy-hollow.txt
@@ -6,7 +6,7 @@ en.name: Happy Hollow Park & Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/pXaxYuZQwYH2
-photo: https://www.instagram.com/p/BpiCsHsHLN8/media/?size=m
-photo.author: gem_warden
-photo.link: https://www.instagram.com/gem_warden/
+photo.1: https://www.instagram.com/p/BpiCsHsHLN8/media/?size=m
+photo.1.author: gem_warden
+photo.1.link: https://www.instagram.com/gem_warden/
 website: http://www.hhpz.org/

--- a/zoos/united-states/0048_bronx-zoo.txt
+++ b/zoos/united-states/0048_bronx-zoo.txt
@@ -6,7 +6,7 @@ en.name: Bronx Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/YZZd8WbFQrA2
-photo: https://www.instagram.com/p/4C0IAHr4QO/media/?size=m
-photo.author: bronxzoo
-photo.link: https://www.instagram.com/bronxzoo/
+photo.1: https://www.instagram.com/p/4C0IAHr4QO/media/?size=m
+photo.1.author: bronxzoo
+photo.1.link: https://www.instagram.com/bronxzoo/
 website: https://bronxzoo.com/

--- a/zoos/united-states/0049_national-zoo-smithsonian.txt
+++ b/zoos/united-states/0049_national-zoo-smithsonian.txt
@@ -7,7 +7,7 @@ en.othernames: National Zoo, Smithsonian's National Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/g8NQQHL5Qqw
-photo: https://www.instagram.com/p/Bo-RhjnHF4_/media/?size=m
-photo.author: smithsonianzoo
-photo.link: https://www.instagram.com/smithsonianzoo/
+photo.1: https://www.instagram.com/p/Bo-RhjnHF4_/media/?size=m
+photo.1.author: smithsonianzoo
+photo.1.link: https://www.instagram.com/smithsonianzoo/
 website: https://nationalzoo.si.edu/

--- a/zoos/united-states/0065_cincinnati-zoo.txt
+++ b/zoos/united-states/0065_cincinnati-zoo.txt
@@ -6,7 +6,7 @@ en.name: Cincinnati Zoo and Botanical Garden
 flag: USA
 language.order: en
 map: https://goo.gl/maps/N3XtwSMHnx22
-photo: https://www.instagram.com/p/BrJw4pvloHb/media/?size=m
-photo.author: sarriej3199
-photo.link: https://www.instagram.com/sarriej3199/
+photo.1: https://www.instagram.com/p/BrJw4pvloHb/media/?size=m
+photo.1.author: sarriej3199
+photo.1.link: https://www.instagram.com/sarriej3199/
 website: https://nationalzoo.si.edu/

--- a/zoos/united-states/0067_woodland-park.txt
+++ b/zoos/united-states/0067_woodland-park.txt
@@ -9,7 +9,7 @@ jp.location: シアトル ワシントン
 jp.name: 森林公園動物園
 language.order: en, jp
 map: https://goo.gl/maps/4WtXGc1ZGnp
-photo: https://www.instagram.com/p/BhVdwVDl3kO/media/?size=m
-photo.author: liabrouillard
-photo.link: https://www.instagram.com/liabrouillard/
+photo.1: https://www.instagram.com/p/BhVdwVDl3kO/media/?size=m
+photo.1.author: liabrouillard
+photo.1.link: https://www.instagram.com/liabrouillard/
 website: https://www.zoo.org/

--- a/zoos/united-states/0075_central-park-zoo.txt
+++ b/zoos/united-states/0075_central-park-zoo.txt
@@ -9,7 +9,7 @@ jp.location: ニューヨーク ニューヨーク
 jp.name: セントラルパーク動物園
 language.order: en, jp
 map: https://goo.gl/maps/Jj2bHyYZhZ92
-photo: https://www.instagram.com/p/Bj80DM7gxj6/media/?size=m
-photo.author: _pixie_dust_86
-photo.link: https://www.instagram.com/_pixie_dust_86/
+photo.1: https://www.instagram.com/p/Bj80DM7gxj6/media/?size=m
+photo.1.author: _pixie_dust_86
+photo.1.link: https://www.instagram.com/_pixie_dust_86/
 website: https://centralparkzoo.com/

--- a/zoos/united-states/0077_henry-vilas-zoo.txt
+++ b/zoos/united-states/0077_henry-vilas-zoo.txt
@@ -6,7 +6,7 @@ en.name: Henry Vilas Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/eNq2cY1kKNu
-photo: https://www.instagram.com/p/BrLyYRknhZ1/media/?size=m
-photo.author: cpelnar
-photo.link: https://www.instagram.com/cpelnar/
+photo.1: https://www.instagram.com/p/BrLyYRknhZ1/media/?size=m
+photo.1.author: cpelnar
+photo.1.link: https://www.instagram.com/cpelnar/
 website: http://www.vilaszoo.org/

--- a/zoos/united-states/0080_lincoln-childrens-zoo.txt
+++ b/zoos/united-states/0080_lincoln-childrens-zoo.txt
@@ -6,7 +6,7 @@ en.name: Lincoln Children's Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/5kHk6aS6A2R2
-photo: https://www.instagram.com/p/BdVUeFjndiT/media/?size=m
-photo.author: lincolnchildrenszoo
-photo.link: https://www.instagram.com/lincolnchildrenszoo/
+photo.1: https://www.instagram.com/p/BdVUeFjndiT/media/?size=m
+photo.1.author: lincolnchildrenszoo
+photo.1.link: https://www.instagram.com/lincolnchildrenszoo/
 website: https://www.lincolnzoo.org/

--- a/zoos/united-states/0081_philadelphia-zoo.txt
+++ b/zoos/united-states/0081_philadelphia-zoo.txt
@@ -6,7 +6,7 @@ en.name: Philadelphia Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/wE2icXwnpcN2
-photo: https://www.instagram.com/p/BRlxIGUlVaT/media/?size=m
-photo.author: philadelphiazoo
-photo.link: https://www.instagram.com/philadelphiazoo/
+photo.1: https://www.instagram.com/p/BRlxIGUlVaT/media/?size=m
+photo.1.author: philadelphiazoo
+photo.1.link: https://www.instagram.com/philadelphiazoo/
 website: https://www.philadelphiazoo.org/

--- a/zoos/united-states/0083_red-river-zoo.txt
+++ b/zoos/united-states/0083_red-river-zoo.txt
@@ -6,7 +6,7 @@ en.name: Red River Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/iDn5ZuFrH4U2
-photo: https://www.instagram.com/p/BS67gHKD95c/media/?size=m
-photo.author: jdemolee
-photo.link: https://www.instagram.com/jdemolee/
+photo.1: https://www.instagram.com/p/BS67gHKD95c/media/?size=m
+photo.1.author: jdemolee
+photo.1.link: https://www.instagram.com/jdemolee/
 website: https://redriverzoo.org/

--- a/zoos/united-states/0084_prospect-park-zoo.txt
+++ b/zoos/united-states/0084_prospect-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Prospect Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/7JRYsikRmTz
-photo: https://www.instagram.com/p/BqNk8Pbhhmg/media/?size=m
-photo.author: alyssabeckmannyc
-photo.link: https://www.instagram.com/alyssabeckmannyc/
+photo.1: https://www.instagram.com/p/BqNk8Pbhhmg/media/?size=m
+photo.1.author: alyssabeckmannyc
+photo.1.link: https://www.instagram.com/alyssabeckmannyc/
 website: https://prospectparkzoo.com/

--- a/zoos/united-states/0085_zoo-atlanta.txt
+++ b/zoos/united-states/0085_zoo-atlanta.txt
@@ -6,7 +6,7 @@ en.name: Zoo Atlanta
 flag: USA
 language.order: en
 map: https://goo.gl/maps/bD7ZfqdL6D22
-photo: https://www.instagram.com/p/BrNNOCxHzYl/media/?size=m
-photo.author: jeteyepadawan
-photo.link: https://www.instagram.com/jeteyepadawan/
+photo.1: https://www.instagram.com/p/BrNNOCxHzYl/media/?size=m
+photo.1.author: jeteyepadawan
+photo.1.link: https://www.instagram.com/jeteyepadawan/
 website: https://zooatlanta.org/

--- a/zoos/united-states/0087_lincoln-park-zoo.txt
+++ b/zoos/united-states/0087_lincoln-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Lincoln Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/HadVPFE1zaq
-photo: https://www.instagram.com/p/BT5R0oGhH7M/media/?size=m
-photo.author: cristina_chernysh
-photo.link: https://www.instagram.com/cristina_chernysh/
+photo.1: https://www.instagram.com/p/BT5R0oGhH7M/media/?size=m
+photo.1.author: cristina_chernysh
+photo.1.link: https://www.instagram.com/cristina_chernysh/
 website: https://www.lpzoo.org/

--- a/zoos/united-states/0088_houston-zoo.txt
+++ b/zoos/united-states/0088_houston-zoo.txt
@@ -6,7 +6,7 @@ en.name: Houston Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/LKkAW38D8Pz
-photo: https://www.instagram.com/p/BrRN618AZ8p/media/?size=m
-photo.author: emily.jandasek
-photo.link: https://www.instagram.com/emily.jandasek/
+photo.1: https://www.instagram.com/p/BrRN618AZ8p/media/?size=m
+photo.1.author: emily.jandasek
+photo.1.link: https://www.instagram.com/emily.jandasek/
 website: https://www.houstonzoo.org/

--- a/zoos/united-states/0089_binghamton-zoo.txt
+++ b/zoos/united-states/0089_binghamton-zoo.txt
@@ -6,7 +6,7 @@ en.name: Binghamton Zoo at Ross Park
 flag: USA
 language.order: en
 map: https://goo.gl/maps/BoeUeTysCJy
-photo: https://www.instagram.com/p/BoZZPJUluE1/media/?size=m
-photo.author: binghamtonzoo
-photo.link: https://www.instagram.com/binghamtonzoo/
+photo.1: https://www.instagram.com/p/BoZZPJUluE1/media/?size=m
+photo.1.author: binghamtonzoo
+photo.1.link: https://www.instagram.com/binghamtonzoo/
 website: https://rossparkzoo.com/

--- a/zoos/united-states/0090_nashville-zoo.txt
+++ b/zoos/united-states/0090_nashville-zoo.txt
@@ -6,7 +6,7 @@ en.name: Nashville Zoo at Grassmere
 flag: USA
 language.order: en
 map: https://goo.gl/maps/6KdEKAFz5Sy
-photo: https://www.instagram.com/p/BfL_ztGBQtx/media/?size=m
-photo.author: nashvillezoo
-photo.link: https://www.instagram.com/nashvillezoo/
+photo.1: https://www.instagram.com/p/BfL_ztGBQtx/media/?size=m
+photo.1.author: nashvillezoo
+photo.1.link: https://www.instagram.com/nashvillezoo/
 website: https://www.nashvillezoo.org/

--- a/zoos/united-states/0091_pittsburgh-zoo.txt
+++ b/zoos/united-states/0091_pittsburgh-zoo.txt
@@ -6,7 +6,7 @@ en.name: Pittsburgh Zoo and PPG Aquarium
 flag: USA
 language.order: en
 map: https://goo.gl/maps/wKD5UXtTWh42
-photo: https://www.instagram.com/p/BkQLIdzgwTy/media/?size=m
-photo.author: pghzoo
-photo.link: https://www.instagram.com/pghzoo/
+photo.1: https://www.instagram.com/p/BkQLIdzgwTy/media/?size=m
+photo.1.author: pghzoo
+photo.1.link: https://www.instagram.com/pghzoo/
 website: https://www.pittsburghzoo.org/

--- a/zoos/united-states/0093_milwaukee-county-zoo.txt
+++ b/zoos/united-states/0093_milwaukee-county-zoo.txt
@@ -6,7 +6,7 @@ en.name: Milwaukee County Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/pagD2rWWvY12
-photo: https://www.instagram.com/p/BrLDWB2Atk7/media/?size=m
-photo.author: milwaukeecozoo
-photo.link: https://www.instagram.com/milwaukeecozoo/
+photo.1: https://www.instagram.com/p/BrLDWB2Atk7/media/?size=m
+photo.1.author: milwaukeecozoo
+photo.1.link: https://www.instagram.com/milwaukeecozoo/
 website: http://www.milwaukeezoo.org/

--- a/zoos/united-states/0095_san-diego-zoo.txt
+++ b/zoos/united-states/0095_san-diego-zoo.txt
@@ -9,7 +9,7 @@ jp.location: サンディエゴ カリフォルニア
 jp.name: サンディエゴ動物園
 language.order: en, jp
 map: https://goo.gl/maps/GMmgWVbWDn82
-photo: https://www.instagram.com/p/Bm_S4eRHHrL/media/?size=m
-photo.author: sandiegozoo
-photo.link: https://www.instagram.com/sandiegozoo/
+photo.1: https://www.instagram.com/p/Bm_S4eRHHrL/media/?size=m
+photo.1.author: sandiegozoo
+photo.1.link: https://www.instagram.com/sandiegozoo/
 website: https://zoo.sandiegozoo.org/

--- a/zoos/united-states/0097_roger-williams-park-zoo.txt
+++ b/zoos/united-states/0097_roger-williams-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Roger Williams Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/5Nw7c3CJH4r
-photo: https://www.instagram.com/p/ubojzMKZVd/media/?size=m
-photo.author: rwpzoo
-photo.link: https://www.instagram.com/rwpzoo/
+photo.1: https://www.instagram.com/p/ubojzMKZVd/media/?size=m
+photo.1.author: rwpzoo
+photo.1.link: https://www.instagram.com/rwpzoo/
 website: http://www.rwpzoo.org/

--- a/zoos/united-states/0099_greensboro_science_center.txt
+++ b/zoos/united-states/0099_greensboro_science_center.txt
@@ -6,7 +6,7 @@ en.name: Greensboro Science Center
 flag: USA
 language.order: en
 map: https://goo.gl/maps/8Ecg8V5hWMz
-photo: https://www.instagram.com/p/BonIRvOHdsZ/media/?size=m
-photo.author: matthewpope28
-photo.link: https://www.instagram.com/matthewpope28/
+photo.1: https://www.instagram.com/p/BonIRvOHdsZ/media/?size=m
+photo.1.author: matthewpope28
+photo.1.link: https://www.instagram.com/matthewpope28/
 website: http://www.greensboroscience.org/

--- a/zoos/united-states/0101_minnesota-zoo.txt
+++ b/zoos/united-states/0101_minnesota-zoo.txt
@@ -6,7 +6,7 @@ en.name: Minnesota Zoological Garden
 flag: USA
 language.order: en
 map: https://goo.gl/maps/ZdJu1mLMXFu
-photo: https://www.instagram.com/p/Bj6GxUxnTlo/media/?size=m
-photo.author: bbart724
-photo.link: https://www.instagram.com/bbart724/
+photo.1: https://www.instagram.com/p/Bj6GxUxnTlo/media/?size=m
+photo.1.author: bbart724
+photo.1.link: https://www.instagram.com/bbart724/
 website: http://www.mnzoo.org/

--- a/zoos/united-states/0102_tulsa-zoo.txt
+++ b/zoos/united-states/0102_tulsa-zoo.txt
@@ -6,7 +6,7 @@ en.name: Tulsa Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/5SaB25cXkwQ2
-photo: https://www.instagram.com/p/BWLjtRMltIE/media/?size=m
-photo.author: tulsazoo
-photo.link: https://www.instagram.com/tulsazoo/
+photo.1: https://www.instagram.com/p/BWLjtRMltIE/media/?size=m
+photo.1.author: tulsazoo
+photo.1.link: https://www.instagram.com/tulsazoo/
 website: https://tulsazoo.org/

--- a/zoos/united-states/0103_staten-island-zoo.txt
+++ b/zoos/united-states/0103_staten-island-zoo.txt
@@ -6,7 +6,7 @@ en.name: Staten Island Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/1C5zcVNgMV72
-photo: https://www.instagram.com/p/Bl8e0mzgITc/media/?size=m
-photo.author: statenislandzoo
-photo.link: https://www.instagram.com/statenislandzoo/
+photo.1: https://www.instagram.com/p/Bl8e0mzgITc/media/?size=m
+photo.1.author: statenislandzoo
+photo.1.link: https://www.instagram.com/statenislandzoo/
 website: http://www.statenislandzoo.org/

--- a/zoos/united-states/0104_potawatomi-zoo.txt
+++ b/zoos/united-states/0104_potawatomi-zoo.txt
@@ -6,7 +6,7 @@ en.name: Potawatomi Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/Kn5Ao11FJ5Q2
-photo: https://www.instagram.com/p/Bp5DahOnSB-/media/?size=m
-photo.author: potawatomizoo
-photo.link: https://www.instagram.com/potawatomizoo/
+photo.1: https://www.instagram.com/p/Bp5DahOnSB-/media/?size=m
+photo.1.author: potawatomizoo
+photo.1.link: https://www.instagram.com/potawatomizoo/
 website: https://www.potawatomizoo.org/

--- a/zoos/united-states/0105_binder-park-zoo.txt
+++ b/zoos/united-states/0105_binder-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Binder Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/KNY2H8TL7a52
-photo: https://www.instagram.com/p/BaSLKVFh39Y/media/?size=m
-photo.author: don__arturo_campos
-photo.link: https://www.instagram.com/don__arturo_campos/
+photo.1: https://www.instagram.com/p/BaSLKVFh39Y/media/?size=m
+photo.1.author: don__arturo_campos
+photo.1.link: https://www.instagram.com/don__arturo_campos/
 website: https://binderparkzoo.org/

--- a/zoos/united-states/0107_cleveland-metroparks.txt
+++ b/zoos/united-states/0107_cleveland-metroparks.txt
@@ -6,7 +6,7 @@ en.name: Cleveland Metroparks Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/H1Beh6XdftG2
-photo: https://www.instagram.com/p/BbFu0YBlGua/media/?size=m
-photo.author: michael__bean
-photo.link: https://www.instagram.com/michael__bean/
+photo.1: https://www.instagram.com/p/BbFu0YBlGua/media/?size=m
+photo.1.author: michael__bean
+photo.1.link: https://www.instagram.com/michael__bean/
 website: https://www.clevelandmetroparks.com/zoo

--- a/zoos/united-states/0108_zoo-knoxville.txt
+++ b/zoos/united-states/0108_zoo-knoxville.txt
@@ -6,7 +6,7 @@ en.name: Zoo Knoxville
 flag: USA
 language.order: en
 map: https://goo.gl/maps/vnLPRS8bNrK2
-photo: https://www.instagram.com/p/Bjr44gbHVT8/media/?size=m
-photo.author: zooknoxville
-photo.link: https://www.instagram.com/zooknoxville/
+photo.1: https://www.instagram.com/p/Bjr44gbHVT8/media/?size=m
+photo.1.author: zooknoxville
+photo.1.link: https://www.instagram.com/zooknoxville/
 website: https://www.zooknoxville.org/

--- a/zoos/united-states/0109_memphis-zoo.txt
+++ b/zoos/united-states/0109_memphis-zoo.txt
@@ -6,7 +6,7 @@ en.name: Memphis Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/nQy82rrLbm32
-photo: https://www.instagram.com/memphiszoo/
-photo.author: memphiszoo
-photo.link: https://www.instagram.com/memphiszoo/
+photo.1: https://www.instagram.com/memphiszoo/
+photo.1.author: memphiszoo
+photo.1.link: https://www.instagram.com/memphiszoo/
 website: https://memphiszoo.org/

--- a/zoos/united-states/0110_brights-zoo.txt
+++ b/zoos/united-states/0110_brights-zoo.txt
@@ -6,7 +6,7 @@ en.name: Bright's Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/o1JzMwgEGPw
-photo: https://www.instagram.com/p/BrjV8nlFSmv/media/?size=m
-photo.author: brightszoo
-photo.link: https://www.instagram.com/brightszoo/
+photo.1: https://www.instagram.com/p/BrjV8nlFSmv/media/?size=m
+photo.1.author: brightszoo
+photo.1.link: https://www.instagram.com/brightszoo/
 website: http://www.brightszoo.com/

--- a/zoos/united-states/0111_john-ball-zoo.txt
+++ b/zoos/united-states/0111_john-ball-zoo.txt
@@ -6,7 +6,7 @@ en.name: John Ball Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/3gKq7TKsyQT2
-photo: https://www.instagram.com/p/BokAn1kHTgC/media/?size=m
-photo.author: johnballzoogr
-photo.link: https://www.instagram.com/johnballzoogr/
+photo.1: https://www.instagram.com/p/BokAn1kHTgC/media/?size=m
+photo.1.author: johnballzoogr
+photo.1.link: https://www.instagram.com/johnballzoogr/
 website: https://www.jbzoo.org/

--- a/zoos/united-states/0112_chattanooga-zoo.txt
+++ b/zoos/united-states/0112_chattanooga-zoo.txt
@@ -6,7 +6,7 @@ en.name: Chattanooga Zoo At Warner Park
 flag: USA
 language.order: en
 map: https://goo.gl/maps/1ZHVrRkvvs12
-photo: https://www.instagram.com/p/BkTvbxIBQRS/media/?size=m
-photo.author: chattanoogazoo
-photo.link: https://www.instagram.com/chattanoogazoo/
+photo.1: https://www.instagram.com/p/BkTvbxIBQRS/media/?size=m
+photo.1.author: chattanoogazoo
+photo.1.link: https://www.instagram.com/chattanoogazoo/
 website: http://www.chattzoo.org/

--- a/zoos/united-states/0113_potter-park.txt
+++ b/zoos/united-states/0113_potter-park.txt
@@ -6,7 +6,7 @@ en.name: Potter Park Zoological Gardens
 flag: USA
 language.order: en
 map: https://goo.gl/maps/kqsiiZNsTK72
-photo: https://www.instagram.com/p/BuWmgQ6ggHI/media/?size=m
-photo.author: potterparkzoo
-photo.link: https://www.instagram.com/potterparkzoo/
+photo.1: https://www.instagram.com/p/BuWmgQ6ggHI/media/?size=m
+photo.1.author: potterparkzoo
+photo.1.link: https://www.instagram.com/potterparkzoo/
 website: https://potterparkzoo.org/

--- a/zoos/united-states/0114_smithsonian-conservation-biology-institute.txt
+++ b/zoos/united-states/0114_smithsonian-conservation-biology-institute.txt
@@ -6,7 +6,7 @@ en.name: Smithsonian Conservation Biology Institute
 flag: USA
 language.order: en
 map: https://goo.gl/maps/nwP7UfETU292
-photo: https://www.instagram.com/p/Bol2m-AgMLT/media/?size=m
-photo.author: doctorhellbender
-photo.link: https://www.instagram.com/doctorhellbender/
+photo.1: https://www.instagram.com/p/Bol2m-AgMLT/media/?size=m
+photo.1.author: doctorhellbender
+photo.1.link: https://www.instagram.com/doctorhellbender/
 website: https://nationalzoo.si.edu/conservation

--- a/zoos/united-states/0115_kansas-city-zoo.txt
+++ b/zoos/united-states/0115_kansas-city-zoo.txt
@@ -6,7 +6,7 @@ en.name: Kansas City Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/4NYWrwy6CpT2
-photo: https://www.instagram.com/p/BfzamlinlOb/media/?size=m
-photo.author: kansascityzoo
-photo.link: https://www.instagram.com/kansascityzoo/
+photo.1: https://www.instagram.com/p/BfzamlinlOb/media/?size=m
+photo.1.author: kansascityzoo
+photo.1.link: https://www.instagram.com/kansascityzoo/
 website: https://www.kansascityzoo.org/

--- a/zoos/united-states/0116_miller-park-zoo.txt
+++ b/zoos/united-states/0116_miller-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Miller Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/k6zARq4schp
-photo: https://www.instagram.com/p/BLE33KTgYIT/media/?size=m
-photo.author: eilshermer
-photo.link: https://www.instagram.com/elishermer/
+photo.1: https://www.instagram.com/p/BLE33KTgYIT/media/?size=m
+photo.1.author: eilshermer
+photo.1.link: https://www.instagram.com/elishermer/
 website: http://www.bloomingtonparks.org/facilities/miller-park-zoo

--- a/zoos/united-states/0117_trevor-zoo.txt
+++ b/zoos/united-states/0117_trevor-zoo.txt
@@ -6,7 +6,7 @@ en.name: Trevor Zoo At Millbrook School
 flag: USA
 language.order: en
 map: https://goo.gl/maps/6pn5QUdiz5G2
-photo: https://www.instagram.com/p/ouhrIizYwh/media/?size=m
-photo.author: carlyhaefeli
-photo.link: https://www.instagram.com/carlyhaefeli/
+photo.1: https://www.instagram.com/p/ouhrIizYwh/media/?size=m
+photo.1.author: carlyhaefeli
+photo.1.link: https://www.instagram.com/carlyhaefeli/
 website: https://www.millbrook.org/page/trevor-zoo-home

--- a/zoos/united-states/0118_greenville-zoo.txt
+++ b/zoos/united-states/0118_greenville-zoo.txt
@@ -6,7 +6,7 @@ en.name: Greenville Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/yBWpJYm1Bvr
-photo: https://www.instagram.com/p/Bis7r65gI6x/media/?size=m
-photo.author: medabney
-photo.link: https://www.instagram.com/medabney/
+photo.1: https://www.instagram.com/p/Bis7r65gI6x/media/?size=m
+photo.1.author: medabney
+photo.1.link: https://www.instagram.com/medabney/
 website: https://greenvillezoo.com/

--- a/zoos/united-states/0119_great-plains-zoo.txt
+++ b/zoos/united-states/0119_great-plains-zoo.txt
@@ -6,7 +6,7 @@ en.name: Great Plains Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/cDksLi3ecVF2
-photo: https://www.instagram.com/p/BizgGNel5T6/media/?size=m
-photo.author: greatplainszoo
-photo.link: https://www.instagram.com/greatplainszoo/
+photo.1: https://www.instagram.com/p/BizgGNel5T6/media/?size=m
+photo.1.author: greatplainszoo
+photo.1.link: https://www.instagram.com/greatplainszoo/
 website: https://greatzoo.org/

--- a/zoos/united-states/0120_franklin-park-zoo.txt
+++ b/zoos/united-states/0120_franklin-park-zoo.txt
@@ -6,7 +6,7 @@ en.name: Zoo New England Franklin Park Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/ge1HYzEu1qS2
-photo: https://www.instagram.com/p/8iq7F_Etmh/media/?size=m
-photo.author: zoonewengland
-photo.link: https://www.instagram.com/zoonewengland/
+photo.1: https://www.instagram.com/p/8iq7F_Etmh/media/?size=m
+photo.1.author: zoonewengland
+photo.1.link: https://www.instagram.com/zoonewengland/
 website: https://www.zoonewengland.org/franklin-park-zoo.aspx

--- a/zoos/united-states/0122_mill-mountain-zoo.txt
+++ b/zoos/united-states/0122_mill-mountain-zoo.txt
@@ -6,7 +6,7 @@ en.name: Mill Mountain Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/npzDkr2388w
-photo: https://www.instagram.com/p/BmJogyJg4bf/media/?size=m
-photo.author: millmountainzoo
-photo.link: https://www.instagram.com/millmountainzoo/
+photo.1: https://www.instagram.com/p/BmJogyJg4bf/media/?size=m
+photo.1.author: millmountainzoo
+photo.1.link: https://www.instagram.com/millmountainzoo/
 website: http://www.mmzoo.org/

--- a/zoos/united-states/0152_brookfield-zoo.txt
+++ b/zoos/united-states/0152_brookfield-zoo.txt
@@ -7,7 +7,7 @@ en.othernames: Chicago Zoological Park
 flag: USA
 language.order: en
 map: https://goo.gl/maps/Hek8arJZBUT2
-photo: https://www.instagram.com/p/4kBa_cMfd3/media/?size=m
-photo.author: brookfieldzoo
-photo.link: https://www.instagram.com/brookfieldzoo/
+photo.1: https://www.instagram.com/p/4kBa_cMfd3/media/?size=m
+photo.1.author: brookfieldzoo
+photo.1.link: https://www.instagram.com/brookfieldzoo/
 website: https://www.czs.org/Brookfield-ZOO/Home

--- a/zoos/united-states/0165_hogle-zoo.txt
+++ b/zoos/united-states/0165_hogle-zoo.txt
@@ -6,7 +6,7 @@ en.name: Hogle Zoo
 flag: USA
 language.order: en
 map: https://goo.gl/maps/6rWGbpuKQap
-photo: https://www.instagram.com/p/BpHVqCPlRng/media/?size=m
-photo.author: mrs_r_mags
-photo.link: https://www.instagram.com/mrs_r_mags/
+photo.1: https://www.instagram.com/p/BpHVqCPlRng/media/?size=m
+photo.1.author: mrs_r_mags
+photo.1.link: https://www.instagram.com/mrs_r_mags/
 website: https://www.hoglezoo.org


### PR DESCRIPTION
It's a fact of life that people regularly delete photos from IG. This breaks links on RPF, and for zoos, which can only have a single photo, means that zoos often will go from having a photo to having no photos. This is bad if I want home-page content that includes photos of zoos.

So I've refactored a bunch of code so that zoos can get their own photo carousels, just like pandas do.

This PR may briefly break zoo photos for everything, but I've hit my limit of being able to test on a local box, and need to test the changes / update the redpanda.json data format.