### PR TITLE
rename media files by panda members, not by photo/video

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -368,7 +368,7 @@ Gallery.special = {};
 Gallery.special.mothersday = {};
 Gallery.special.mothersday.photos = [
   {
-    "photo.1": ["media.7", "photo.1"],
+    "photo.1": ["media.7.gin-marumi", "photo.1"],
     "photo.1.format": "medium",
     "photo.1.message": {
       "en": "Marumi & Gin " + Language.L.emoji.mother,
@@ -376,7 +376,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.2": ["media.7", "photo.2"],
+    "photo.2": ["media.7.gin-marumi", "photo.2"],
     "photo.2.format": "medium",
     "photo.2.message": {
       "en": "Gin " + Language.L.emoji.mother + " & Marumi",
@@ -384,7 +384,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.3": ["media.26", "photo.1"],
+    "photo.3": ["media.26.hinata-kanta-yuri", "photo.1"],
     "photo.3.format": "large",
     "photo.3.message": {
       "en": "Yuri " + Language.L.emoji.mother + ", Kanta & Hinata",
@@ -392,7 +392,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.4": ["media.29", "photo.1"],
+    "photo.4": ["media.29.akachan-laila", "photo.1"],
     "photo.4.format": "medium",
     "photo.4.message": {
       "en": "Aka-chan & Laila " + Language.L.emoji.mother,
@@ -400,7 +400,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.5": ["media.29", "photo.2"],
+    "photo.5": ["media.29.akachan-laila", "photo.2"],
     "photo.5.format": "medium",
     "photo.5.message": {
       "en": "Aka-chan & Laila " + Language.L.emoji.mother,
@@ -408,7 +408,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.6": ["media.7", "photo.3"],
+    "photo.6": ["media.7.gin-marumi", "photo.3"],
     "photo.6.format": "medium",
     "photo.6.message": {
       "en": "Gin " + Language.L.emoji.mother + " & Marumi",
@@ -416,7 +416,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.7": ["media.7", "photo.4"],
+    "photo.7": ["media.7.gin-marumi", "photo.4"],
     "photo.7.format": "medium",
     "photo.7.message": {
       "en": "Marumi & Gin " + Language.L.emoji.mother,
@@ -424,7 +424,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.8": ["media.36", "photo.1"],
+    "photo.8": ["media.36.jazz-minfa", "photo.1"],
     "photo.8.format": "large",
     "photo.8.message": {
       "en": "Min-fa " + Language.L.emoji.mother + " & Jazz",
@@ -432,7 +432,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.9": ["media.9", "photo.1"],
+    "photo.9": ["media.9.hanabi-miyabi", "photo.1"],
     "photo.9.format": "medium",
     "photo.9.message": {
       "en": "Miyabi & Hanabi " + Language.L.emoji.mother,
@@ -440,7 +440,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.10": ["media.18", "photo.1"],
+    "photo.10": ["media.18.chihiro-kokoro", "photo.1"],
     "photo.10.format": "medium",
     "photo.10.message": {
       "en": "Kokoro & Chihiro " + Language.L.emoji.mother,
@@ -448,7 +448,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.11": ["media.41", "photo.1"],
+    "photo.11": ["media.41.nohana-nokaze", "photo.1"],
     "photo.11.format": "medium",
     "photo.11.message": {
       "en": "Nokaze " + Language.L.emoji.mother + " & Nohana",
@@ -456,7 +456,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.12": ["media.50", "photo.1"],
+    "photo.12": ["media.50.karin-luca", "photo.1"],
     "photo.12.format": "medium",
     "photo.12.message": {
       "en": "Luca & Karin " + Language.L.emoji.mother,
@@ -464,7 +464,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.13": ["media.17", "photo.1"],
+    "photo.13": ["media.17.rifa-taofa", "photo.1"],
     "photo.13.format": "large",
     "photo.13.message": {
       "en": "Rifa & Taofa " + Language.L.emoji.mother,
@@ -472,7 +472,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.14": ["media.7", "photo.5"],
+    "photo.14": ["media.7.gin-marumi", "photo.5"],
     "photo.14.format": "medium",
     "photo.14.message": {
       "en": "Gin " + Language.L.emoji.mother + " & Marumi",
@@ -480,7 +480,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.15": ["media.7", "photo.6"],
+    "photo.15": ["media.7.gin-marumi", "photo.6"],
     "photo.15.format": "medium",
     "photo.15.message": {
       "en": "Marumi & Gin " + Language.L.emoji.mother,
@@ -488,7 +488,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.16": ["media.1", "photo.1"],
+    "photo.16": ["media.1.cocoa-milk-yuufa", "photo.1"],
     "photo.16.format": "medium",
     "photo.16.message": {
       "en": "Yuufa " + Language.L.emoji.mother + " & Milk & Cocoa",
@@ -496,7 +496,7 @@ Gallery.special.mothersday.photos = [
     },
   },
   {
-    "photo.17": ["media.1", "photo.2"],
+    "photo.17": ["media.1.himawari-yuufa", "photo.1"],
     "photo.17.format": "medium",
     "photo.17.message": {
       "en": "Himawari & Yuufa " + Language.L.emoji.mother,
@@ -504,7 +504,7 @@ Gallery.special.mothersday.photos = [
     }
   },
   {
-    "photo.18": ["media.7", "photo.7"],
+    "photo.18": ["media.7.gin-marumi", "photo.7"],
     "photo.18.format": "large",
     "photo.18.message": {
       "en": "Marumi & Gin " + Language.L.emoji.mother,

--- a/media/japan/0001_ichikawa/cocoa-milk-yuufa.txt
+++ b/media/japan/0001_ichikawa/cocoa-milk-yuufa.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.1
+_id: media.1.cocoa-milk-yuufa
 photo.1: https://www.instagram.com/p/Br6LkgXFIIY/media/?size=m
 photo.1.author: redpanda_nippon_takashi
 photo.1.link: https://www.instagram.com/redpanda_nippon_takashi/
@@ -7,9 +7,3 @@ photo.1.tags: 6, 246, 247, mother's day
 photo.1.tags.6.location: 135, 145
 photo.1.tags.246.location: 245, 165
 photo.1.tags.247.location: 190, 160
-photo.2: https://www.instagram.com/p/Br6nEBZlF7F/media/?size=m
-photo.2.author: redpanda_nippon_takashi
-photo.2.link: https://www.instagram.com/redpanda_nippon_takashi/
-photo.2.tags: 6, 8, mother's day
-photo.2.tags.6.location: 240, 90
-photo.2.tags.8.location: 70, 215

--- a/media/japan/0001_ichikawa/himawari-yuufa.txt
+++ b/media/japan/0001_ichikawa/himawari-yuufa.txt
@@ -1,0 +1,8 @@
+[media]
+_id: media.1.himawari-yuufa
+photo.1: https://www.instagram.com/p/Br6nEBZlF7F/media/?size=m
+photo.1.author: redpanda_nippon_takashi
+photo.1.link: https://www.instagram.com/redpanda_nippon_takashi/
+photo.1.tags: 6, 8, mother's day
+photo.1.tags.6.location: 240, 90
+photo.1.tags.8.location: 70, 215

--- a/media/japan/0007_maruyama/gin-marumi.txt
+++ b/media/japan/0007_maruyama/gin-marumi.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.7
+_id: media.7.gin-marumi
 photo.1: https://www.instagram.com/p/BNobsDShO_0/media/?size=m
 photo.1.author: sina_dw
 photo.1.link: https://www.instagram.com/sina_dw/

--- a/media/japan/0009_saitama/hanabi-miyabi.txt
+++ b/media/japan/0009_saitama/hanabi-miyabi.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.9
+_id: media.9.hanabi-miyabi
 photo.1: https://www.instagram.com/p/BccAw_gFxb1/media/?size=m
 photo.1.author: l_ma_photos
 photo.1.link: https://www.instagram.com/l_ma_photos/

--- a/media/japan/0017_tama/rifa-taofa.txt
+++ b/media/japan/0017_tama/rifa-taofa.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.17
+_id: media.17.rifa-taofa
 photo.1: https://www.instagram.com/p/BqN6JedlDVA/media/?size=m
 photo.1.author: sb23megumi
 photo.1.link: https://www.instagram.com/sb23megumi/

--- a/media/japan/0018_tobu/chihiro-kokoro.txt
+++ b/media/japan/0018_tobu/chihiro-kokoro.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.18
+_id: media.18.chihiro-kokoro
 photo.1: https://www.instagram.com/p/BZH0jiHBOgE/media/?size=m
 photo.1.author: _rifa_p
 photo.1.link: https://www.instagram.com/_rifa_p/

--- a/media/japan/0026_akita-oomoriyama/hinata-kanta-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-kanta-yuri.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.26
+_id: media.26.hinata-kanta-yuri
 photo.1: https://www.instagram.com/p/Bp9M7Hel4aL/media/?size=m
 photo.1.author: daniele.tokyo
 photo.1.link: https://www.instagram.com/daniele.tokyo/

--- a/media/japan/0029_adventure-world/akachan-laila.txt
+++ b/media/japan/0029_adventure-world/akachan-laila.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.29
+_id: media.29.akachan-laila
 photo.1: https://www.instagram.com/p/BrZQdseFUNI/media/?size=m
 photo.1.author: kipekaila
 photo.1.link: https://www.instagram.com/kipekaila/

--- a/media/japan/0036_kobe-oji/jazz-minfa.txt
+++ b/media/japan/0036_kobe-oji/jazz-minfa.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.36
+_id: media.36.jazz-minfa
 photo.1: https://www.instagram.com/p/Bd7NrUMDmUv/media/?size=m
 photo.1.author: colette.jp
 photo.1.link: https://www.instagram.com/colette.jp/

--- a/media/japan/0041_itozunomori/nohana-nokaze.txt
+++ b/media/japan/0041_itozunomori/nohana-nokaze.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.41
+_id: media.41.nohana-nokaze
 photo.1: https://www.instagram.com/p/BcJ4WpHlinR/media/?size=m
 photo.1.author: yossi929
 photo.1.link: https://www.instagram.com/yossi929/

--- a/media/japan/0050_misaki-park/karin-luca.txt
+++ b/media/japan/0050_misaki-park/karin-luca.txt
@@ -1,5 +1,5 @@
 [media]
-_id: media.50
+_id: media.50.karin-luca
 photo.1: https://www.instagram.com/p/BoeGgpWlQ2K/media/?size=m
 photo.1.author: makimaru18
 photo.1.link: https://www.instagram.com/makimaru18/


### PR DESCRIPTION
Group indicators are attached to the `media.ZOO_ID` in the media files now.

Makes it easier at a glance to know what you have for any set of pandas at a particular zoo.