### PR TITLE
Media name fix

### DIFF
--- a/js/pandas.js
+++ b/js/pandas.js
@@ -933,9 +933,7 @@ Pandas.gender = function(animal, language) {
 // pandas are in the photo
 Pandas.groupMediaCaption = function(entity, photo_index) {
   var tag_index = photo_index + ".tags";
-  var pandaTags = entity[tag_index].replace(/ /g, "").split(",").filter(function(tag) {
-    return parseInt(tag) > 0;
-  });
+  var pandaTags = entity["panda.tags"].replace(/ /g, "").split(",");
   var output_string = Pandas.def.animal[L.display + ".name"];
   var animals = [];
   for (let id of pandaTags) {

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -511,11 +511,13 @@ Pandas.searchPandaId = function(idnum) {
 }
 
 // Find instances of a panda's ID in the media (group) photos.
-// TODO
 Pandas.searchPandaMedia = function(idnum) {
-  var node = G.v(idnum).run();
-  // Get locations in a panda's details, or zoo if that's missing
-  // Search all media photos of those locations for photos by tag
+  var nodes = G.v().filter(function(vertex) {
+    return vertex["panda.tags"].split(",")
+                               .map(x => x.trim())
+                               .indexOf(idnum) != -1;
+  }).run();
+  return nodes;
 }
 
 // Find a panda's mother

--- a/js/query.js
+++ b/js/query.js
@@ -316,6 +316,8 @@ Query.actions = {
     var tag = captures.tagTerm.tag;
     var last_stage = captures.subjectTerm;
     var animals = Pandas.searchPanda(last_stage.query);
+    // TODO: search media photos for all the animals by id, and include
+    // in the searchPhotoTags animals set
     return {
       "hits": Pandas.searchPhotoTags(animals, [tag], mode="photos", fallback="none"),
       "query": tag + " " + last_stage.query,
@@ -387,6 +389,8 @@ Query.resolver = {
       Query.env.output_mode = "photos";
       // Find the canonical tag to do the searching by
       var tag = Query.searchTag(keyword);
+      // TODO: search media photos for all the animals by id, and include
+      // in the searchPhotoTags animals set
       return Pandas.searchPhotoTags(Pandas.allAnimals(), [tag], mode="photos", fallback="none");
     }
   },


### PR DESCRIPTION
I broke groupMediaCaptions in the credit searches, cause of moving panda ids over to `panda.tags`. Fixed!