### PR TITLE
try scaling width of gallery photos to 100% for larger phones

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -1189,7 +1189,7 @@ div.photoSample h5.caption.familyTitle > span.ultraCondensed {
     }
 
     div.pandaPhoto img, div.zooPhoto img {
-        width: auto;
+        width: 100%;
         height: auto;
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
Here is a small but significant UX change for people that use phones with large-width screens in portrait mode. The change gets rid of black bars along the edges of photos when viewing them in the dog-ear galleries, on anything larger than the classic iPhones. I'm going to give it a day of testing before I decide to merge this or not.