### PR TITLE
Frontpage updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - '3.4'
 sudo: false
-script: ./build.py --publish
+script: python ./build.py --publish
 after_success:
   - rm .gitignore
 deploy:

--- a/build.py
+++ b/build.py
@@ -564,20 +564,24 @@ class UpdateFromCommits:
                 # New panda! Track photos as representing a new animal
                 for hunk in change:
                     for line in hunk:
-                        raw = line.value
-                        self.pandas.append(self.new_pandas(raw, filename))
+                        if line.is_added:
+                            raw = line.value
+                            self.pandas.append(self.new_pandas(raw, filename))
             else:
                 # New photo. Track photo on its own
                 for hunk in change:
                     for line in hunk:
-                        raw = line.value
-                        self.photos.append(self.new_photos(raw))
+                        if line.is_added:
+                            raw = line.value
+                            self.photos.append(self.new_photos(raw))
 
     def new_contributor(self):
         """
-        Look at all added lines in the last diff. If any of them include a
-        photo author that isn't in the last published JSON file, return a
-        corresponding new author update for insertion into the current JSON.
+        Look at all added lines in the last diff. Then look at the author
+        counts in the current redpanda.json export. If the number of photos
+        by that author is the same as the number of photos in the changelog,
+        they are a new contributor! Return a corresponding new contributor
+        update for insertion into the current JSON.
         """
         pass
 

--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@
 
 import configparser
 import datetime
+import git
 import json
 import os
 import sys

--- a/build.py
+++ b/build.py
@@ -686,7 +686,7 @@ class UpdateFromCommits:
         """
         oldest_time = self.current_time - time_delta
         oldest_commit = None
-        for commit in self.repo.iter_commits('master'):
+        for commit in self.repo.iter_commits():
             date = commit.committed_date
             if date < oldest_time:
                 return oldest_commit

--- a/build.py
+++ b/build.py
@@ -10,8 +10,10 @@ import json
 import os
 import sys
 
+from cStringIO import StringIO
 from shared import *
 from unidiff import PatchSet
+
 
 class RedPandaGraph:
     """Class with the redpanda database and format/consistency checks.
@@ -523,12 +525,53 @@ class RedPandaGraph:
         self.check_dataset_duplicate_ids(self.zoos)
 
 
+class UpdateFromCommits:
+    """
+    Take the last two Git commits in the repository, and process any additions
+    as content that can be inserted into the front page. 
+    
+    Assumes that build.py is always ran at the root of the repository.
+    """
+    def __init__(self):
+        self.repo = git.Repo(".")
+        self.last_commit = self.repo.commit("HEAD~1")
+        self.current_commit = self.repo.commit("HEAD")
+        self.diff_raw = self.repo.git.diff(self.last_commit, 
+                                           self.current_commit,
+                                           ignore_blank_lines=True,
+                                           ignore_space_at_eol=True)
+        self.patch = PatchSet(StringIO(self.diff_raw), encoding='utf-8')
+
+    def new_contributor(self):
+        """
+        Look at all added lines in the last diff. If any of them include a
+        photo author that isn't in the last published JSON file, return a
+        corresponding new author update for insertion into the current JSON.
+        """
+        pass
+
+    def new_pandas(self):
+        """
+        Look at all added lines in the last diff. If any of them represent
+        a brand new file not represented before, return a corresponding
+        new panda update for insertion into the JSON.
+        """
+        pass
+
+    def new_photos(self):
+        """
+        Look at all added lines in the last diff. If any of them represent
+        a new photo added to an existing panda file, return a corresponding
+        new photo update for insertion into the JSON.
+        """
+        pass
+
 def vitamin():
     """
-    Based on a completed Red Panda database, and on the contents of all Javascript and
-    HTML sources here, build a unique set of characters for display in the lineage
-    interface. This character set is necessary to instruct TypeSquare on which characters
-    we want to download in our font.
+    Based on a completed Red Panda database, and on the contents of all 
+    Javascript and HTML sources here, build a unique set of characters for 
+    display in the lineage interface. This character set is necessary to instruct 
+    TypeSquare on which characters we want to download in our font.
     """
     vitamin = "&amp;&copy;&lsquo;&rsquo;&ldquo;&rdquo;&nacute;"  # &-encoded HTML characters to start
     lists = []

--- a/build.py
+++ b/build.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from shared import *
+from unidiff import PatchSet
 
 class RedPandaGraph:
     """Class with the redpanda database and format/consistency checks.

--- a/build.py
+++ b/build.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 
-from cStringIO import StringIO
+from io import StringIO
 from shared import *
 from unidiff import PatchSet
 

--- a/media/japan/0053_nasu-animal-kingdom/eisaku-yosaku.txt
+++ b/media/japan/0053_nasu-animal-kingdom/eisaku-yosaku.txt
@@ -13,3 +13,9 @@ photo.2.link: https://www.instagram.com/resapan.suki/
 photo.2.tags: brothers, smile
 photo.2.tags.344.location: 175, 115
 photo.2.tags.345.location: 190, 260
+photo.3: https://www.instagram.com/p/B0Lsh1ABe2s/media/?size=m
+photo.3.author: panda.daisuki
+photo.3.link: https://www.instagram.com/panda.daisuki/
+photo.3.tags: brothers, paws
+photo.3.tags.344.location: 155, 180
+photo.3.tags.345.location: 60, 200

--- a/pandas/china/0196_ocean-park-hong-kong/0931_rourou.txt
+++ b/pandas/china/0196_ocean-park-hong-kong/0931_rourou.txt
@@ -29,5 +29,9 @@ photo.3: https://www.instagram.com/p/BzaSdqzH-jc/media/?size=m
 photo.3.author: redpanda_tata
 photo.3.link: https://www.instagram.com/redpanda_tata/
 photo.3.tags: nose, paws
+photo.4: https://www.instagram.com/p/B0OGIwFBCbn/media/?size=m
+photo.4.author: redpanda_tata
+photo.4.link: https://www.instagram.com/redpanda_tata/
+photo.4.tags: mofumofu, portrait
 species: 2
 zoo: 196

--- a/pandas/japan/0001_ichikawa/0001_harumaki.txt
+++ b/pandas/japan/0001_ichikawa/0001_harumaki.txt
@@ -214,6 +214,10 @@ photo.52: https://www.instagram.com/p/Bz-vwxphEpH/media/?size=m
 photo.52.author: panda.daisuki
 photo.52.link: https://www.instagram.com/panda.daisuki/
 photo.52.tags: portrait, smile, tongue
+photo.53: https://www.instagram.com/p/B0M6jRXhj1B/media/?size=m
+photo.53.author: sulfa2
+photo.53.link: https://www.instagram.com/sulfa2/
+photo.53.tags: apple time
 species: 2
 video.1: https://www.youtube.com/watch?v=9m89fVLit44
 video.1.author: vitamin z

--- a/pandas/japan/0001_ichikawa/0005_mugi.txt
+++ b/pandas/japan/0001_ichikawa/0005_mugi.txt
@@ -257,5 +257,9 @@ photo.63: https://www.instagram.com/p/B0IFLeGBKj_/media/?size=m
 photo.63.author: 218_yu
 photo.63.link: https://www.instagram.com/218_yu/
 photo.63.tags: paws, smile
+photo.64: https://www.instagram.com/p/B0LzL66B3Kj/media/?size=m
+photo.64.author: hamiiiii831
+photo.64.link: https://www.instagram.com/hamiiiii831/
+photo.64.tags: portrait, whiskers
 species: 2
 zoo: 1

--- a/pandas/japan/0001_ichikawa/0246_cocoa.txt
+++ b/pandas/japan/0001_ichikawa/0246_cocoa.txt
@@ -284,5 +284,9 @@ photo.68: https://www.instagram.com/p/B0H50Akh5EJ/media/?size=m
 photo.68.author: panda.daisuki
 photo.68.link: https://www.instagram.com/panda.daisuki/
 photo.68.tags: portrait, smile, tongue
+photo.69: https://www.instagram.com/p/B0Kb9eFBfwu/media/?size=m
+photo.69.author: na.mo.pan
+photo.69.link: https://www.instagram.com/na.mo.pan/
+photo.69.tags: laying down, tail, tree
 species: 2
 zoo: 1

--- a/pandas/japan/0001_ichikawa/0247_milk.txt
+++ b/pandas/japan/0001_ichikawa/0247_milk.txt
@@ -437,5 +437,9 @@ photo.107: https://www.instagram.com/p/B0GF5MFBB6Y/media/?size=m
 photo.107.author: tama67photo
 photo.107.link: https://www.instagram.com/tama67photo/
 photo.107.tags: bamboo, smile, tongue
+photo.108: https://www.instagram.com/p/B0K0bZbB10D/media/?size=m
+photo.108.author: panda.daisuki
+photo.108.link: https://www.instagram.com/panda.daisuki/
+photo.108.tags: itchy, portrait
 species: 2
 zoo: 1

--- a/pandas/japan/0002_kyoto-city/0015_oolong.txt
+++ b/pandas/japan/0002_kyoto-city/0015_oolong.txt
@@ -222,5 +222,9 @@ photo.53: https://www.instagram.com/p/B0Gdt0Lh6ZS/media/?size=m
 photo.53.author: redpan22
 photo.53.link: https://www.instagram.com/redpan22/
 photo.53.tags: laying down, portrait, smile
+photo.54: https://www.instagram.com/p/B0IXKn2hIPE/media/?size=m
+photo.54.author: gloryeui
+photo.54.link: https://www.instagram.com/gloryeui/
+photo.54.tags: dish, portrait
 species: 2
 zoo: 2

--- a/pandas/japan/0004_yumemigasaki/0028_keiko.txt
+++ b/pandas/japan/0004_yumemigasaki/0028_keiko.txt
@@ -95,5 +95,9 @@ photo.22: https://www.instagram.com/p/B0A7bSqB7EO/media/?size=m
 photo.22.author: miis_98
 photo.22.link: https://www.instagram.com/miis_98/
 photo.22.tags: bamboo, bite, paws, portrait, smile
+photo.23: https://www.instagram.com/p/B0LkYb-BY74/media/?size=m
+photo.23.author: grskus_tk
+photo.23.link: https://www.instagram.com/grskus_tk/
+photo.23.tags: air tasting, portrait, tongue, tree
 species: 2
 zoo: 4

--- a/pandas/japan/0007_maruyama/0017_gin.txt
+++ b/pandas/japan/0007_maruyama/0017_gin.txt
@@ -277,5 +277,9 @@ photo.68: https://www.instagram.com/p/B0IwVCuhcUR/media/?size=m
 photo.68.author: tama67photo
 photo.68.link: https://www.instagram.com/tama67photo/
 photo.68.tags: portrait, tail
+photo.69: https://www.instagram.com/p/B0Iu8HbBmJU/media/?size=m
+photo.69.author: nishicotolo
+photo.69.link: https://www.instagram.com/nishicotolo/
+photo.69.tags: paws
 species: 2
 zoo: 7

--- a/pandas/japan/0007_maruyama/0018_marumi.txt
+++ b/pandas/japan/0007_maruyama/0018_marumi.txt
@@ -387,5 +387,9 @@ photo.96: https://www.instagram.com/p/B0GeqHHhI-9/media/?size=m
 photo.96.author: minatomirai215
 photo.96.link: https://www.instagram.com/minatomirai215/
 photo.96.tags: climb, paws, portrait, tree
+photo.97: https://www.instagram.com/p/B0M0zgshqqT/media/?size=m
+photo.97.author: minatomirai215
+photo.97.link: https://www.instagram.com/minatomirai215/
+photo.97.tags: portrait, smile
 species: 2
 zoo: 7

--- a/pandas/japan/0007_maruyama/0021_seita.txt
+++ b/pandas/japan/0007_maruyama/0021_seita.txt
@@ -249,5 +249,9 @@ photo.60: https://www.instagram.com/p/B0IxI52hzAP/media/?size=m
 photo.60.author: tama67photo
 photo.60.link: https://www.instagram.com/tama67photo/
 photo.60.tags: portrait
+photo.61: https://www.instagram.com/p/B0K9G7YBN40/media/?size=m
+photo.61.author: izu_108
+photo.61.link: https://www.instagram.com/izu_108/
+photo.61.tags: laying down, portrait, tongue
 species: 2
 zoo: 7

--- a/pandas/japan/0008_chiba/0035_kuuta.txt
+++ b/pandas/japan/0008_chiba/0035_kuuta.txt
@@ -144,5 +144,9 @@ photo.33: https://www.instagram.com/p/BwUIkHKls9F/media/?size=m
 photo.33.author: mari_neko3
 photo.33.link: https://www.instagram.com/mari_neko3/
 photo.33.tags: apple time, portrait, praying, standing
+photo.34: https://www.instagram.com/p/B0NsAy4hkCM/media/?size=m
+photo.34.author: hamiiiii831
+photo.34.link: https://www.instagram.com/hamiiiii831/
+photo.34.tags: mofumofu, portrait
 species: 2
 zoo: 8

--- a/pandas/japan/0010_chausuyama/0083_ajisai.txt
+++ b/pandas/japan/0010_chausuyama/0083_ajisai.txt
@@ -92,5 +92,9 @@ photo.20: https://www.instagram.com/p/Bzx4dAehD5G/media/?size=m
 photo.20.author: redpan22
 photo.20.link: https://www.instagram.com/redpan22/
 photo.20.tags: laying down, portrait, tail, tree
+photo.21: https://www.instagram.com/p/B0KuuTwBAYv/media/?size=m
+photo.21.author: tabechum
+photo.21.link: https://www.instagram.com/tabechum/
+photo.21.tags: portrait, smile
 species: 2
 zoo: 10

--- a/pandas/japan/0010_chausuyama/0091_nene.txt
+++ b/pandas/japan/0010_chausuyama/0091_nene.txt
@@ -128,5 +128,9 @@ photo.29: https://www.instagram.com/p/BvfwYA7l7jK/media/?size=m
 photo.29.author: resapan.suki
 photo.29.link: https://www.instagram.com/resapan.suki/
 photo.29.tags: mofumofu, portrait, white face
+photo.30: https://www.instagram.com/p/B0KLCb0BoEU/media/?size=m
+photo.30.author: framereim
+photo.30.link: https://www.instagram.com/framereim/
+photo.30.tags: smile, tree
 species: 2
 zoo: 10

--- a/pandas/japan/0013_nishiyama/0111_minfa.txt
+++ b/pandas/japan/0013_nishiyama/0111_minfa.txt
@@ -299,5 +299,9 @@ photo.71: https://www.instagram.com/p/BzrH4a6h4iI/media/?size=m
 photo.71.author: tomo3700
 photo.71.link: https://www.instagram.com/tomo3700/
 photo.71.tags: bamboo, portrait, smile, tongue
+photo.72: https://www.instagram.com/p/B0K274Thrza/media/?size=m
+photo.72.author: minato.yokohama2130
+photo.72.link: https://www.instagram.com/minato.yokohama2130/
+photo.72.tags: apple time, dish, portrait, smile
 species: 2
 zoo: 13

--- a/pandas/japan/0024_hamamatsu/0046_chiita.txt
+++ b/pandas/japan/0024_hamamatsu/0046_chiita.txt
@@ -300,6 +300,14 @@ photo.73: https://www.instagram.com/p/B0Dls3Nhx3F/media/?size=m
 photo.73.author: taka__3428
 photo.73.link: https://www.instagram.com/taka__3428/
 photo.73.tags: apple time, keeper, paw-up, tail
+photo.74: https://www.instagram.com/p/B0K8sGmhSnp/media/?size=m
+photo.74.author: taka__3428
+photo.74.link: https://www.instagram.com/taka__3428/
+photo.74.tags: smile, window
+photo.75: https://www.instagram.com/p/B0IiT8LBd9k/media/?size=m
+photo.75.author: taka__3428
+photo.75.link: https://www.instagram.com/taka__3428/
+photo.75.tags: bamboo, smile
 species: 2
 video.1: https://youtu.be/-WMjIqoEK1U
 video.1.author: しもだちゃんねる

--- a/pandas/japan/0032_fukuoka/0074_marimo.txt
+++ b/pandas/japan/0032_fukuoka/0074_marimo.txt
@@ -222,5 +222,8 @@ photo.53: https://www.instagram.com/p/B0FKFiBhnOG/media/?size=m
 photo.53.author: yossi929
 photo.53.link: https://www.instagram.com/yossi929/
 photo.53.tags: bamboo, portrait, paws, standing
+photo.54: https://www.instagram.com/p/B0OG9QTBojH/media/?size=m
+photo.54.author: nozo.mari
+photo.54.link: https://www.instagram.com/nozo.mari/
 species: 2
 zoo: 32

--- a/pandas/japan/0032_fukuoka/0075_nozomu.txt
+++ b/pandas/japan/0032_fukuoka/0075_nozomu.txt
@@ -289,5 +289,9 @@ photo.70: https://www.instagram.com/p/Bz6furihd4h/media/?size=m
 photo.70.author: yossi929
 photo.70.link: https://www.instagram.com/yossi929/
 photo.70.tags: portrait, smile
+photo.71: https://www.instagram.com/p/B0MlEOcBjsc/media/?size=m
+photo.71.author: yossi929
+photo.71.link: https://www.instagram.com/yossi929/
+photo.71.tags: apple time, bamboo, portrait, tanabata
 species: 2
 zoo: 32

--- a/pandas/japan/0038_nogeyama/0126_kenken.txt
+++ b/pandas/japan/0038_nogeyama/0126_kenken.txt
@@ -152,5 +152,9 @@ photo.35: https://www.instagram.com/p/B0DSzPABMLk/media/?size=m
 photo.35.author: miis_98
 photo.35.link: https://www.instagram.com/miis_98/
 photo.35.tags: mofumofu, portrait, smile, tree
+photo.36: https://www.instagram.com/p/B0MomsHARtc/media/?size=m
+photo.36.author: miis_98
+photo.36.link: https://www.instagram.com/miis_98/
+photo.36.tags: apple time, bridge, keeper, paws, smile, tail
 species: 2
 zoo: 38

--- a/pandas/japan/0038_nogeyama/0127_kiku.txt
+++ b/pandas/japan/0038_nogeyama/0127_kiku.txt
@@ -190,5 +190,9 @@ photo.45: https://www.instagram.com/p/BzK36ALhIsU/media/?size=m
 photo.45.author: pantasanzoo1
 photo.45.link: https://www.instagram.com/pantasanzoo1/
 photo.45.tags: air tasting, paws, tongue, tree
+photo.46: https://www.instagram.com/p/B0KYocKgzE_/media/?size=m
+photo.46.author: miis_98
+photo.46.link: https://www.instagram.com/miis_98/
+photo.46.tags: paws, portrait, tree
 species: 2
 zoo: 38

--- a/pandas/japan/0050_misaki-park/0069_karin.txt
+++ b/pandas/japan/0050_misaki-park/0069_karin.txt
@@ -106,5 +106,9 @@ photo.23: https://www.instagram.com/p/By7mrC2BBEf/media/?size=m
 photo.23.author: kinkinkin0826
 photo.23.link: https://www.instagram.com/kinkinkin0826/
 photo.23.tags: paws, smile
+photo.24: https://www.instagram.com/p/B0JF0p_h38j/media/?size=m
+photo.24.author: makimaru18
+photo.24.link: https://www.instagram.com/makimaru18/
+photo.24.tags: home, paws, portrait, slobber, smile
 species: 2
 zoo: 50

--- a/pandas/japan/0053_nasu-animal-kingdom/0186_gigi.txt
+++ b/pandas/japan/0053_nasu-animal-kingdom/0186_gigi.txt
@@ -68,6 +68,10 @@ photo.13.tags: portrait, white face
 photo.14: https://www.instagram.com/p/B0ICGOph-_E/media/?size=m
 photo.14.author: ifumoto88
 photo.14.link: https://www.instagram.com/ifumoto88/
-photo.14.tags: laying down, portrait
+photo.14.tags: laying down
+photo.15: https://www.instagram.com/p/B0KkVR_BpZL/media/?size=m
+photo.15.author: panda.daisuki
+photo.15.link: https://www.instagram.com/panda.daisuki/
+photo.15.tags: laying down, portrait
 species: 2
 zoo: 53

--- a/pandas/japan/0053_nasu-animal-kingdom/0188_yoichi.txt
+++ b/pandas/japan/0053_nasu-animal-kingdom/0188_yoichi.txt
@@ -82,6 +82,10 @@ photo.18: https://www.instagram.com/p/B0ICuCuBVjk/media/?size=m
 photo.18.author: ifumoto88
 photo.18.link: https://www.instagram.com/ifumoto88/
 photo.18.tags: laying down, paws, tail
+photo.19: https://www.instagram.com/p/B0Kko4phZyH/media/?size=m
+photo.19.author: panda.daisuki
+photo.19.link: https://www.instagram.com/panda.daisuki/
+photo.19.tags: mofumofu, portrait, tail
 species: 2
 video.1: https://www.youtube.com/watch?v=HeXUvkKeMpg
 video.1.author: 963293 ride

--- a/pandas/japan/0053_nasu-animal-kingdom/0190_ronron.txt
+++ b/pandas/japan/0053_nasu-animal-kingdom/0190_ronron.txt
@@ -9,7 +9,7 @@ en.othernames: Ronron
 gender: f
 jp.name: 栄栄
 jp.nicknames: none
-jp.othernames: none
+jp.othernames: ロンロン
 language.order: jp, en
 litter: none
 location.1: 37, 2013/7/19
@@ -82,6 +82,10 @@ photo.17: https://www.instagram.com/p/B0GkCg2BrJg/media/?size=m
 photo.17.author: panda.daisuki
 photo.17.link: https://www.instagram.com/panda.daisuki/
 photo.17.tags: paws, profile
+photo.18: https://www.instagram.com/p/B0I999sByIj/media/?size=m
+photo.18.author: ifumoto88
+photo.18.link: https://www.instagram.com/ifumoto88/
+photo.18.tags: bridge, portrait, smile, tail
 species: 2
 video.1: https://youtu.be/HQ_OsRtj6T0
 video.1.author: mmovies21

--- a/pandas/japan/0053_nasu-animal-kingdom/0344_eisaku.txt
+++ b/pandas/japan/0053_nasu-animal-kingdom/0344_eisaku.txt
@@ -52,5 +52,13 @@ photo.10: https://www.instagram.com/p/Bz75K5ZFmb9/media/?size=m
 photo.10.author: yakkooo24
 photo.10.link: https://www.instagram.com/yakkooo24/
 photo.10.tags: bamboo, laying down, portrait, upside-down
+photo.11: https://www.instagram.com/p/B0I053UBJB2/media/?size=m
+photo.11.author: ifumoto88
+photo.11.link: https://www.instagram.com/ifumoto88/
+photo.11.tags: portrait, smile, tongue
+photo.12: https://www.instagram.com/p/B0I9xSqhAAy/media/?size=m
+photo.12.author: ifumoto88
+photo.12.link: https://www.instagram.com/ifumoto88/
+photo.12.tags: mofumofu, portrait
 species: 2
 zoo: 53

--- a/pandas/japan/0053_nasu-animal-kingdom/0345_yosaku.txt
+++ b/pandas/japan/0053_nasu-animal-kingdom/0345_yosaku.txt
@@ -36,5 +36,9 @@ photo.6: https://www.instagram.com/p/Bz4Dx6MBHpz/media/?size=m
 photo.6.author: grskus_tk
 photo.6.link: https://www.instagram.com/grskus_tk/
 photo.6.tags: bridge, laying down
+photo.7: https://www.instagram.com/p/B0I18jKhX1k/media/?size=m
+photo.7.author: ifumoto88
+photo.7.link: https://www.instagram.com/ifumoto88/
+photo.7.tags: smile
 species: 2
 zoo: 53

--- a/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
+++ b/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
@@ -295,6 +295,14 @@ photo.74: https://www.instagram.com/p/B0BA9dOBVjO/media/?size=m
 photo.74.author: tama67photo
 photo.74.link: https://www.instagram.com/tama67photo/
 photo.74.tags: laying down, tail
+photo.75: https://www.instagram.com/p/B0LXEyWBJ_c/media/?size=m
+photo.75.author: chocopan102
+photo.75.link: https://www.instagram.com/chocopan102/
+photo.75.tags: paws
+photo.76: https://www.instagram.com/p/B0M3jfRh1_d/media/?size=m
+photo.76.author: chocopan102
+photo.76.link: https://www.instagram.com/chocopan102/
+photo.76.tags: bridge, laying down, mofumofu
 species: 2
 video.1: https://youtu.be/f-hoQdNnqA0
 video.1.author: kosaru 323

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+unidiff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+gitpython>=2.1.12
 unidiff>=0.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-unidiff
+unidiff>=0.5.5

--- a/shared.py
+++ b/shared.py
@@ -5,7 +5,10 @@ MEDIA_PATH = "./media"
 PANDA_PATH = "./pandas"
 OUTPUT_PATH = "./export/redpanda.json"
 WILD_PATH = "./wild" 
-ZOO_PATH = "./zoos" 
+ZOO_PATH = "./zoos"
+
+# Go back no more than this amount of time to get commits
+COMMIT_AGE = 7 * 24 * 60 * 60   # 7 days
 
 class DateConsistencyError(ValueError):
     pass


### PR DESCRIPTION
This PR does a whole lot of nothing on the front end. On the backend, it establishes a 7-day window within which the `redpanda.json` records a set of new _photos_, _entities_, and _authors_ that have contributed new content to Red Panda Finder.

Once this commits, I can start goofing around with whatever front end code that will display these results most nicely.