### PR TITLE
Chinese menu

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -566,7 +566,7 @@ h3, h4 {
     text-decoration: underline;
 }
 
-h3.jp, h4.jp {
+h3.cn, h4.cn, h3.jp, h4.jp {
     /* Family headers kanji w/underlines doesn't look right */
     text-decoration: none;
     font-weight: normal;

--- a/css/panda.css
+++ b/css/panda.css
@@ -122,7 +122,7 @@ button.menu.flag {
     font-family: "Jun 201", sans-serif;
     background-color: #366938;
     height: 64px;
-    width: 160px;  /* Divide 320px by number of buttons you expect to have */
+    width: 106px;  /* Divide 320px by number of buttons you expect to have */
 }
 
 button.menu.profile, button.menu.flag.profile {

--- a/fragments/cn/about.html
+++ b/fragments/cn/about.html
@@ -1,0 +1,114 @@
+<div id="hiddenContentFrame" class="about">
+<div class="shrinker">
+
+<div id="aboutPageMenu" class="sectionMenu">
+  <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
+    Usage Guide
+  </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
+    About Red Pandas
+  </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
+    About This Site
+  </div></button>
+</div>
+  
+<div class="hidden section" id="usageGuide">
+<div class="pandaAbout onlyDesktop">
+<h2>How To Use This Site (PC)</h2>
+<ul>
+<li>Click the 🇺🇸 to change languages. English and Japanese are supported.</li>
+<li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
+<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
+<li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
+<li>Click the upper-left corner of a panda photo to see more photos.</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout onlyMobile">
+<h2>How To Use This Site (Mobile)</h2>
+<ul>
+<li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
+<li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
+<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
+<li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>
+<li>Swipe left or right on a panda photo to see more photos.</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout">
+<h2>Search Tips</h2>
+<ul>
+<li>You can search for zoos by name or location! Zoo searches will show all red pandas currently living at a zoo.</li>
+<li>You can search photos by descriptive tag! Try one of these:</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout aboutTags">
+</div><!-- pandaAbout, with tags filled in -->
+</div><!-- usageGuide -->
+
+<div class="hidden section" id="aboutRedPandas">
+<div class="pandaAbout">
+<h2>About Red Pandas</h2>
+<h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
+<p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
+<p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
+<p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+<h2>Surprising Red Panda Facts</h2>
+<ul>
+<li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
+<li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
+</ul>
+<img class="aboutFocus" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+<h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
+<ul>
+<li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
+<li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
+</ul>
+<img class="twinFocus" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+<img class="twinFocus" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+<h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
+<ul>
+<li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
+<li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
+<li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
+</ul>
+<img class="aboutFocus" src="https://www.instagram.com/p/BQkZPmwhZIu/media/?size=l" alt="Marumi and Gin, fun with mom" />
+<h5 class="caption">Marumi the Mom-terrorizer! <a href="https://www.instagram.com/sina_dw/">(📷&nbsp;sina_dw)</a></h5>
+<ul>
+<li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
+<li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
+<li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
+</ul>
+<img class="twinFocus" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+<img class="twinFocus" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+<h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
+<ul>
+<li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
+</ul>
+</div><!-- pandaAbout -->
+</div><!-- aboutRedPandas -->
+
+<div class="hidden section" id="aboutThisSite">
+<div class="pandaAbout">
+<h2>About This Site</h2>
+<p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
+<p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
+<p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
+<img class="aboutFocus" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+<h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
+<h2>Red Panda Lineage Data</h2>
+<p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>
+<h2>Contributions</h2>
+<p>If you'd like to submit new data or fixes to existing Red Panda Lineage data, we really appreciate the help! Just fill out one of the forms below:</p>
+<ul>
+<li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Lineage Request</a></li>
+</ul>
+<p>If you have a technical software-development background, you are also more than welcome to directly contribute to the dataset! We'll review any PRs or issues submitted through <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
+</div><!-- pandaAbout -->
+</div><!-- aboutThisSite -->
+
+</div><!-- shrinker -->
+</div><!-- contentFrame -->

--- a/fragments/cn/about.html
+++ b/fragments/cn/about.html
@@ -15,7 +15,7 @@
 <div class="pandaAbout onlyDesktop">
 <h2>How To Use This Site (PC)</h2>
 <ul>
-<li>Click the 🇺🇸 to change languages. English and Japanese are supported.</li>
+<li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
 <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
 <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
 <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>

--- a/fragments/en/about.html
+++ b/fragments/en/about.html
@@ -15,7 +15,7 @@
 <div class="pandaAbout onlyDesktop">
 <h2>How To Use This Site (PC)</h2>
 <ul>
-<li>Click the 🇺🇸 to change languages. English and Japanese are supported.</li>
+<li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
 <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
 <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
 <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>

--- a/js/language.js
+++ b/js/language.js
@@ -882,7 +882,28 @@ Language.L.messages = {
            "の",
            "<INSERTEMOJI>",
            "<INSERTTAG>",
-           "。"]
+           "。"],
+  },
+  "zoo_details": {
+    "cn": [Language.L.emoji.animal,
+           " ",
+           "<INSERTANIMALCOUNT>",
+           "个当前的小熊猫。(",
+           "<INSERTRECORDEDCOUNT>",
+           "个记录在数据库中)"],
+    "en": [Language.L.emoji.animal,
+           " ",
+           "<INSERTANIMALCOUNT>",
+           " current red pandas, and ",
+           "<INSERTRECORDEDCOUNT>",
+           " recorded in the database."],
+    "jp": [Language.L.emoji.animal,
+           " ",
+           "現在",
+           "<INSERTANIMALCOUNT>",
+           "頭のレッサーパンダがいます。(データベースには",
+           "<INSERTRECORDEDCOUNT>",
+           "頭の記録があります)"]
   }
 }
 

--- a/js/language.js
+++ b/js/language.js
@@ -1300,13 +1300,13 @@ Language.L.tags = {
         "jp": ["べろ"]
   },
   "toys": {
-        "cn": ["TOWRITE"],
+        "cn": ["玩具"],
      "emoji": [Language.L.emoji.football],
         "en": ["toy", "toys"],
         "jp": ["遊具", "おもちゃ", "おもちゃ"]
   },
   "tree": {
-        "cn": ["TOWRITE"],
+        "cn": ["树"],
      "emoji": [Language.L.emoji.tree],
         "en": ["tree", "trees"],
         "jp": ["木"]

--- a/js/language.js
+++ b/js/language.js
@@ -270,7 +270,7 @@ Language.L.gui = {
     "jp": ""
   },
   "instagramLinks_button": {
-    "cn": "TOWRITE",
+    "cn": "IG",
     "en": "Instagram",
     "jp": "インスタグラム"
   },
@@ -439,12 +439,12 @@ Language.L.gui = {
   "spring": {
     "cn": "春",
     "en": "Spring",
-    "jp": "TOWRITE"
+    "jp": "春"
   },
   "summer": {
     "cn": "夏",
     "en": "Summer",
-    "jp": "TOWRITE"
+    "jp": "夏"
   },
   "title": {
     "cn": "查找小熊猫",
@@ -523,7 +523,8 @@ Language.L.messages = {
     "jp": "と"
   },
   "footer": {
-    "cn": ["TOWRITE"],
+    "cn": ["<INSERTLINK>",
+           " ©2019 Justin Fairchild"],
     "en": ["All information courtesy of the ",
            "<INSERTLINK>",
            " and red panda fans worldwide. ",

--- a/js/language.js
+++ b/js/language.js
@@ -1483,6 +1483,30 @@ Language.L.fallbackInfo = function(info, original) {
   if ((info.birthplace != undefined) && (info.birthplace != Pandas.def.zoo)) {
     bundle.birthplace = this.fallbackEntity(info.birthplace);
   }
+  if ((info.mom != undefined) && (info.mom != Pandas.def.animal)) {
+    bundle.mom = this.fallbackEntity(info.mom);
+  }
+  if ((info.dad != undefined) && (info.dad != Pandas.def.animal)) {
+    bundle.dad = this.fallbackEntity(info.dad);
+  }
+  for (let index in info.litter) {
+    if ((info.litter[index] != undefined) && 
+        (info.litter[index] != Pandas.def.animal)) {
+       info.litter[index] = this.fallbackEntity(info.litter[index]);
+    }
+  }
+  for (let index in info.siblings) {
+    if ((info.siblings[index] != undefined) && 
+        (info.siblings[index] != Pandas.def.animal)) {
+       info.siblings[index] = this.fallbackEntity(info.siblings[index]);
+    }
+  }
+  for (let index in info.children) {
+    if ((info.children[index] != undefined) && 
+        (info.children[index] != Pandas.def.animal)) {
+       info.children[index] = this.fallbackEntity(info.children[index]);
+    }
+  }
   return bundle;
 }
 

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -69,6 +69,9 @@ Pandas.def.animal = {
   "birthday": "1970/1/1",
   "birthplace": "0",
   "children": "0",
+  "cn.name": "TOWRITE",
+  "cn.nicknames": "TOWRITE",
+  "cn.othernames": "TOWRITE",
   "death": "1970/1/1",
   "en.name": "Panda Not Found",
   "en.nicknames": "No Nicknames Recorded",
@@ -124,7 +127,8 @@ Pandas.def.no_name = {
 // definition used within this project's code.
 Pandas.def.languages = {
   "en": "en",
-  "ja": "jp"
+  "ja": "jp",
+  "zh": "cn"
 }
 
 // Character ranges
@@ -182,7 +186,7 @@ Pandas.def.relations = {
     "jp": "おばあちゃん"
   },
   "litter": {
-    "cn": "litter",
+    "cn": "轿子",
     "en": "litter",
     "jp": "双子"   /* "同腹仔" */
   },
@@ -250,6 +254,9 @@ Pandas.def.unknown = {
 // Slightly different default zoo listing, to account for wild-born animals
 Pandas.def.wild = {
   "_id": "wild.0",
+  "cn.address": "TOWRITE",
+  "cn.location": "TOWRITE",
+  "cn.name": "TOWRITE",
   "en.address": "Captured or Rescued Wild Animal",
   "en.location": "No City, District, or State Info Listed",
   "en.name": "Zoo Not Found",
@@ -263,6 +270,9 @@ Pandas.def.wild = {
 
 Pandas.def.zoo = {
   "_id": "0",
+  "cn.address": "TOWRITE",
+  "cn.location": "TOWRITE",
+  "cn.name": "TOWRITE",
   "en.address": "No Google Maps Address Recorded",
   "en.location": "No City, District, or State Info Listed",
   "en.name": "Zoo Not Found",

--- a/js/show.js
+++ b/js/show.js
@@ -2141,22 +2141,21 @@ Show.results.zooDetails = function(info) {
   // This is the purple "dossier" information stripe for a zoo.
   var language = info.language;
   var counts = document.createElement('p');
-  var count_text = {
-    "en": [ 
-      info.animal_count,
-      "current red pandas, and",
-      info.recorded_count,
-      "recorded in the database."
-    ].join(' '),
-    "jp": [
-      "現在",
-      info.animal_count,
-      "頭のレッサーパンダがいます。(データベースには",
-      info.recorded_count,
-      "頭の記録があります)"
-    ].join('')
+  for (var i in L.messages.zoo_details[language]) {
+    var field = L.messages.zoo_details[language][i];
+    if (field == "<INSERTANIMALCOUNT>") {
+      field = info.animal_count;
+      var msg = document.createTextNode(field);
+      counts.appendChild(msg);
+    } else if (field == "<INSERTRECORDEDCOUNT>") {
+      field = info.recorded_count;
+      var msg = document.createTextNode(field);
+      counts.appendChild(msg);
+    } else {
+      var msg = document.createTextNode(field);
+      counts.appendChild(msg);
+    }
   }
-  counts.innerText = L.emoji.animal + " " + count_text[language];
   var address = document.createElement('p');
   var address_link = document.createElement('a');
   address_link.innerText = L.emoji.travel + " " + info.address;


### PR DESCRIPTION
So this is not totally perfect yet, but I fixed some bugs in how fallback text is calculated for siblings/litter/parents/children pandas, so the Chinese panda search seems to be usable.

Two major things remain untranslated:
* the footer and copyright text (it's just a simplified version for now)
* the about-page contents, which I need to update to say Chinese is supported :heart:

Tagging @underwatering to celebrate this feature getting turned on!