### PR TITLE
Geolocation fixes 1

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -89,7 +89,7 @@ window.addEventListener('hashchange', function() {
     Page.about.hashchange();
   } else if (mode == "#links") {
     Page.links.hashchange();
-  } else if (Page.routes.delayed.includes(mode)) {
+  } else if (Query.env.output_mode == "nearby") {
     // Wait until the geolookup is done to render
     // TODO: interstitial?
     Page.current = Page.results.render;

--- a/js/init.js
+++ b/js/init.js
@@ -89,7 +89,7 @@ window.addEventListener('hashchange', function() {
     Page.about.hashchange();
   } else if (mode == "#links") {
     Page.links.hashchange();
-  } else if (Query.env.output_mode == "nearby") {
+  } else if (Page.routes.delayed.includes(mode)) {
     // Wait until the geolookup is done to render
     // TODO: interstitial?
     Page.current = Page.results.render;

--- a/js/page.js
+++ b/js/page.js
@@ -461,9 +461,6 @@ Page.routes.check = function() {
     Page.current = Page.home.render;
   }
 }
-Page.routes.delayed = [
-  "#query"
-]
 Page.routes.dynamic = [
   "#credit",
   "#links",
@@ -613,6 +610,9 @@ Page.results.render = function() {
   var input = decodeURIComponent(window.location.hash);
   // Start by just displaying info for one panda by id search
   var results = Page.routes.behavior(input);
+  if ((Query.env.output_mode != "nearby") && (results == undefined)) {
+    return;   // TODO: handle more delay-rendered results here
+  }
   var content_divs = [];
   var new_content = document.createElement('div');
   new_content.id = "hiddenContentFrame";

--- a/js/page.js
+++ b/js/page.js
@@ -610,7 +610,7 @@ Page.results.render = function() {
   var input = decodeURIComponent(window.location.hash);
   // Start by just displaying info for one panda by id search
   var results = Page.routes.behavior(input);
-  if ((Query.env.output_mode != "nearby") && (results == undefined)) {
+  if ((Query.env.output_mode != "nearby") && (results.hits == undefined)) {
     return;   // TODO: handle more delay-rendered results here
   }
   var content_divs = [];

--- a/js/page.js
+++ b/js/page.js
@@ -461,6 +461,9 @@ Page.routes.check = function() {
     Page.current = Page.home.render;
   }
 }
+Page.routes.delayed = [
+  "#query"
+]
 Page.routes.dynamic = [
   "#credit",
   "#links",


### PR DESCRIPTION
My theory was that a bug in the event loop was causing Chromium and iOS Safari to fail geolocation checks. Actually, it seems like the `navigator.geolocation.getCurrentPosition()` calls are not working on those platforms at all, and I need to diagnose things further.