### PR TITLE
Japanese sort

### DIFF
--- a/js/pandas.js
+++ b/js/pandas.js
@@ -1026,10 +1026,10 @@ Pandas.sortByNameJapanese = function(nodes) {
   var build_name_list = function(node, name_field, othername_field) {
     var name_list = [];
     if (name_field in node) {
-      name_list.push(node[name_field]);
+      name_list = name_list.concat(node[name_field]);
     }
     if (othername_field in node) {
-      name_list.push(node[othername_field].split(", "));
+      name_list = name_list.concat(node[othername_field].split(", "));
     }
     return name_list;
   }
@@ -1045,23 +1045,23 @@ Pandas.sortByNameJapanese = function(nodes) {
     if (node["_id"].indexOf("media.") == 0) {
       var panda_ids = node["panda.tags"].split(", ");
       var animals = panda_ids.map(function(id) {
-        var panda = Pandas.searchPandaId(id);
+        var panda = Pandas.searchPandaId(id)[0];
         return panda;
       })
       // Sort only by the first name in the photo
       var first_group_name = node[name_field].split(connector)[0];
-      var animal = animals.filter(animal => animal[name_field] == first_group_name);
+      var animal = animals.filter(animal => animal[name_field] == first_group_name)[0];
       var name_list = build_name_list(animal, name_field, othername_field);
-      node[sort_name] = name_list.filter(function(name) {
+      node[sort_name] = name_list.map(function(name) {
         return hiragana_generate(name);
-      })[0];
+      }).filter(name => name != undefined)[0];
     } else {
       // Sort by the first hiragana name, from the "othernames"
       // list if necessary. Find the first hiragana or katakana string.
       var name_list = build_name_list(node, name_field, othername_field);
-      node[sort_name] = name_list.filter(function(name) {
+      node[sort_name] = name_list.map(function(name) {
         return hiragana_generate(name);
-      })[0];
+      }).filter(name => name != undefined)[0];
     }
     return node;
   });

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -1009,6 +1009,65 @@ Pandas.searchZooName = function(zoo_name_str) {
     Methods for sorting the output of Panda searches.
     Birthday searches use Unix epoch time and do javascript value sort.
 */
+// Sort Japanese panda names by determining the hiragana-equivalent name
+// for each animal in the dataset.
+Pandas.sortByNameJapanese = function(nodes) {
+  var hiragana_generate = function(name) {
+    var hiragana = Pandas.def.ranges['jp'][1];   // Hiragana range regex
+    var katakana = Pandas.def.ranges['jp'][2];   // Katakana range regex
+    if (hiragana.test(name) == true) {
+      return name;
+    }
+    if (katakana.test(name) == true) {
+      return Language.katakanaToHiragana(name);
+    }
+  }
+
+  var build_name_list = function(node, name_field, othername_field) {
+    var name_list = [];
+    if (name_field in node) {
+      name_list.push(node[name_field]);
+    }
+    if (othername_field in node) {
+      name_list.push(node[othername_field].split(", "));
+    }
+    return name_list;
+  }
+
+  var name_field = "jp.name";
+  var othername_field = "jp.othernames";
+  var sort_name = "jp.sortname";
+
+  var connector = Language.L.messages["and"][L.display]
+  nodes = nodes.map(function(node) {
+    // Determine which panda is first in the photo, and sort by
+    // its hiragana name in the "othernames" list if necessary
+    if (node["_id"].indexOf("media.") == 0) {
+      var panda_ids = node["panda.tags"].split(", ");
+      var animals = panda_ids.map(function(id) {
+        var panda = Pandas.searchPandaId(id);
+        return panda;
+      })
+      // Sort only by the first name in the photo
+      var first_group_name = node[name_field].split(connector)[0];
+      var animal = animals.filter(animal => animal[name_field] == first_group_name);
+      var name_list = build_name_list(animal, name_field, othername_field);
+      node[sort_name] = name_list.filter(function(name) {
+        return hiragana_generate(name);
+      })[0];
+    } else {
+      // Sort by the first hiragana name, from the "othernames"
+      // list if necessary. Find the first hiragana or katakana string.
+      var name_list = build_name_list(node, name_field, othername_field);
+      node[sort_name] = name_list.filter(function(name) {
+        return hiragana_generate(name);
+      })[0];
+    }
+    return node;
+  });
+  return Pandas.sortByName(nodes, sort_name);
+}
+
 // Sort a list of pandas by their desired "Lang.name" field.
 // Works for non-group entities (pandas and zoos).
 Pandas.sortByName = function(nodes, name_field) {
@@ -1036,7 +1095,11 @@ Pandas.sortByNameWithGroups = function(nodes, photo_list, name_field) {
     }
     return node;
   });
-  return Pandas.sortByName(nodes, name_field);
+  if (L.display == "jp") {
+    return Pandas.sortByNameJapanese(nodes);
+  } else {
+    return Pandas.sortByName(nodes, name_field);
+  }
 }
 
 Pandas.sortPhotosByName = function(photo_list, name_field) {

--- a/pandas/japan/0007_maruyama/0017_gin.txt
+++ b/pandas/japan/0007_maruyama/0017_gin.txt
@@ -521,5 +521,9 @@ photo.129: https://www.instagram.com/p/B7U5sG9BOUX/media/?size=m
 photo.129.author: minatomirai215
 photo.129.link: https://www.instagram.com/minatomirai215/
 photo.129.tags: climb, paws, portrait
+photo.130: https://www.instagram.com/p/B7YIXI8B3uN/media/?size=m
+photo.130.author: https://www.instagram.com/izu_108/
+photo.130.link: https://www.instagram.com/izu_108/
+photo.130.tags: paws, portrait, whiskers
 species: 2
 zoo: 7

--- a/pandas/japan/0007_maruyama/0019_eita.txt
+++ b/pandas/japan/0007_maruyama/0019_eita.txt
@@ -579,5 +579,9 @@ photo.143: https://www.instagram.com/p/B6ypjl8glhx/media/?size=m
 photo.143.author: cattail.sapporo
 photo.143.link: https://www.instagram.com/cattail.sapporo/
 photo.143.tags: air tasting, portrait, tongue
+photo.144: https://www.instagram.com/p/B7Yl22iBD1S/media/?size=m
+photo.144.author: an920000
+photo.144.link: https://www.instagram.com/an920000/
+photo.144.tags: climb, paws, portrait, tongue
 species: 2
 zoo: 7

--- a/pandas/japan/0017_tama/0240_rifa.txt
+++ b/pandas/japan/0017_tama/0240_rifa.txt
@@ -767,5 +767,9 @@ photo.191: https://www.instagram.com/p/B7RuDAxBD0O/media/?size=m
 photo.191.author: ck.chie
 photo.191.link: https://www.instagram.com/ck.chie/
 photo.191.tags: door, paws, portrait
+photo.192: https://www.instagram.com/p/B7YaL8ZBUBW/media/?size=m
+photo.192.author: osopanda551
+photo.192.link: https://www.instagram.com/osopanda551/
+photo.192.tags: bamboo, bite, paws, portrait, smile, tongue
 species: 2
 zoo: 17

--- a/zoos/canada/0051_calgary-zoo.txt
+++ b/zoos/canada/0051_calgary-zoo.txt
@@ -15,4 +15,7 @@ photo.2: https://www.instagram.com/p/B2xrtqCpUEX/media/?size=m
 photo.2.author: saikrisnow
 photo.2.link: https://www.instagram.com/saikrisnow/
 photo.2.tags: profile
+photo.3: https://www.instagram.com/p/B5gBH4DJgom/media/?size=m
+photo.3.author: xsaikomaikox
+photo.3.link: https://www.instagram.com/xsaikomaikox/
 website: https://www.calgaryzoo.com/


### PR DESCRIPTION
When in Japanese mode and sorting by name, there is now logic that will sort by the Hiragana-equivalent name. Which means Hiragana, Katakana, and Kanji will all sort based on their "pronounced" names.

This might break if there isn't a hiragana or katakana alternative name in the "jp.othernames" field, but those will get sorted prior to the others I think.