### PR TITLE
Debug git

### DIFF
--- a/build.py
+++ b/build.py
@@ -583,6 +583,7 @@ class UpdateFromCommits:
                                            self.current_commit,
                                            ignore_blank_lines=True,
                                            ignore_space_at_eol=True)
+        print(self.diff_raw)
         self.patch = PatchSet(self.diff_raw)
         self.filenames = {}
         self.updates = {}

--- a/build.py
+++ b/build.py
@@ -605,6 +605,7 @@ class UpdateFromCommits:
         seen["pandas"] = {}
         seen["zoos"] = {}
         # Grab the last JSON file for author data
+        print(COMMIT_AGE)
         for change in self.patch:
             filename = change.path
             print(filename)

--- a/build.py
+++ b/build.py
@@ -583,7 +583,6 @@ class UpdateFromCommits:
                                            self.current_commit,
                                            ignore_blank_lines=True,
                                            ignore_space_at_eol=True)
-        print(self.diff_raw)
         self.patch = PatchSet(self.diff_raw)
         self.filenames = {}
         self.updates = {}
@@ -606,10 +605,8 @@ class UpdateFromCommits:
         seen["pandas"] = {}
         seen["zoos"] = {}
         # Grab the last JSON file for author data
-        print(COMMIT_AGE)
         for change in self.patch:
             filename = change.path
-            print(filename)
             if change.added <= 0:
                 # Don't care about removal diffs
                 continue
@@ -757,6 +754,8 @@ class UpdateFromCommits:
                 return oldest_commit
             else:
                 oldest_commit = commit
+        # If CI does a shallow clone, use the oldest commit we have
+        return oldest_commit
 
 def vitamin():
     """

--- a/build.py
+++ b/build.py
@@ -607,6 +607,7 @@ class UpdateFromCommits:
         # Grab the last JSON file for author data
         for change in self.patch:
             filename = change.path
+            print(filename)
             if change.added <= 0:
                 # Don't care about removal diffs
                 continue


### PR DESCRIPTION
TravisCI does shallow clones, with only 50 commits.

If my week of git updates includes more than 50 commits, it broke the red panda update photos on the home page! So I have it fall back to the earliest available commit if that's the best it can do.