### PR TITLE
Fix shuffle paging

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -422,47 +422,7 @@ Gallery.groupPhotos = function(id_list, photo_count) {
         } else {
           seen[url] = true;
         }
-        // TOWRITE: image styles based on url being medium or large
-        var img_link = document.createElement('a');
-        img_link.href = url;
-        img_link.href = img_link.href.replace("/media/?size=m", "/");
-        img_link.href = img_link.href.replace("/media/?size=l", "/");
-        var img = document.createElement('img');
-        img.src = url;
-        img_link.appendChild(img);
-        // Names of the group photos
-        var caption_names = document.createElement('h5');
-        caption_names.className = "caption groupMediaName";
-        var caption_names_span = document.createElement('span');
-        caption_names_span.innerText = Pandas.groupMediaCaption(entity, key);
-        caption_names.appendChild(caption_names_span);
-        // Credit for the group photos
-        var author = entity[key + ".author"];
-        var caption_credit_link = document.createElement('a');
-        caption_credit_link.href = "#credit/" + author;   // build from author info
-        var caption_credit = document.createElement('h5');
-        caption_credit.className = "caption groupMediaAuthor";
-        var caption_credit_span = document.createElement('span');
-        caption_credit_span.innerText = Language.L.emoji.apple + " " + author;
-        caption_credit.appendChild(caption_credit_span);
-        caption_credit_link.appendChild(caption_credit);
-        // Put it all in a frame
-        var container = document.createElement('div');
-        container.className = "photoSample";
-        if ((url.indexOf("?size=l") != -1) && 
-            (url.indexOf("instagram.com") != -1)) {
-          container.classList.add("halfPage");
-        } else if ((url.indexOf("?size=m") != -1) &&
-                   (url.indexOf("instagram.com") != -1)) {
-          container.classList.add("quarterPage");
-        } else if (url.indexOf("instagram.com") == -1) {
-          container.classList.add("fullPage");   // self-hosted images
-        } else {
-          container.classList.add("quarterPage");
-        }
-        container.appendChild(img_link);
-        container.appendChild(caption_names);
-        container.appendChild(caption_credit_link);
+        var container = Gallery.groupPhotoSingle(entity, key, url)
         photo_divs.push(container);        
       }
     }
@@ -524,6 +484,51 @@ Gallery.groupPhotosPage = function(page, id_list, photo_count) {
   return {
     "output": output
   }
+}
+
+Gallery.groupPhotoSingle = function(entity, key, url) {
+  // TOWRITE: image styles based on url being medium or large
+  var img_link = document.createElement('a');
+  img_link.href = url;
+  img_link.href = img_link.href.replace("/media/?size=m", "/");
+  img_link.href = img_link.href.replace("/media/?size=l", "/");
+  var img = document.createElement('img');
+  img.src = url;
+  img_link.appendChild(img);
+  // Names of the group photos
+  var caption_names = document.createElement('h5');
+  caption_names.className = "caption groupMediaName";
+  var caption_names_span = document.createElement('span');
+  caption_names_span.innerText = Pandas.groupMediaCaption(entity, key);
+  caption_names.appendChild(caption_names_span);
+  // Credit for the group photos
+  var author = entity[key + ".author"];
+  var caption_credit_link = document.createElement('a');
+  caption_credit_link.href = "#credit/" + author;   // build from author info
+  var caption_credit = document.createElement('h5');
+  caption_credit.className = "caption groupMediaAuthor";
+  var caption_credit_span = document.createElement('span');
+  caption_credit_span.innerText = Language.L.emoji.apple + " " + author;
+  caption_credit.appendChild(caption_credit_span);
+  caption_credit_link.appendChild(caption_credit);
+  // Put it all in a frame
+  var container = document.createElement('div');
+  container.className = "photoSample";
+  if ((url.indexOf("?size=l") != -1) && 
+      (url.indexOf("instagram.com") != -1)) {
+    container.classList.add("halfPage");
+  } else if ((url.indexOf("?size=m") != -1) &&
+              (url.indexOf("instagram.com") != -1)) {
+    container.classList.add("quarterPage");
+  } else if (url.indexOf("instagram.com") == -1) {
+    container.classList.add("fullPage");   // self-hosted images
+  } else {
+    container.classList.add("quarterPage");
+  }
+  container.appendChild(img_link);
+  container.appendChild(caption_names);
+  container.appendChild(caption_credit_link);
+  return container; 
 }
 
 // Solo photos that can be found in the group gallery. These are chosen on

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -415,14 +415,14 @@ Gallery.groupPhotos = function(id_list, photo_count) {
     var entities = Pandas.searchPandaMedia(id, only_media=true);
     for (let entity of entities) {
       var photos = Pandas.photoManifest(entity);
-      for (let key in photos) {
-        var url = photos[key];
+      for (let photo_key in photos) {
+        var url = photos[photo_key];
         if (seen[url] == true) {
           continue;   // Skip photos we've already trakced
         } else {
           seen[url] = true;
         }
-        var container = Gallery.groupPhotoSingle(entity, key, url)
+        var container = Gallery.groupPhotoSingle(entity, photo_key, url)
         photo_divs.push(container);        
       }
     }
@@ -486,7 +486,7 @@ Gallery.groupPhotosPage = function(page, id_list, photo_count) {
   }
 }
 
-Gallery.groupPhotoSingle = function(entity, key, url) {
+Gallery.groupPhotoSingle = function(entity, photo_key, url) {
   // TOWRITE: image styles based on url being medium or large
   var img_link = document.createElement('a');
   img_link.href = url;
@@ -499,10 +499,10 @@ Gallery.groupPhotoSingle = function(entity, key, url) {
   var caption_names = document.createElement('h5');
   caption_names.className = "caption groupMediaName";
   var caption_names_span = document.createElement('span');
-  caption_names_span.innerText = Pandas.groupMediaCaption(entity, key);
+  caption_names_span.innerText = Pandas.groupMediaCaption(entity, photo_key);
   caption_names.appendChild(caption_names_span);
   // Credit for the group photos
-  var author = entity[key + ".author"];
+  var author = entity[photo_key + ".author"];
   var caption_credit_link = document.createElement('a');
   caption_credit_link.href = "#credit/" + author;   // build from author info
   var caption_credit = document.createElement('h5');

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -649,8 +649,10 @@ Gallery.tagPhotosPage = function(page, results, language, max_hits, add_emoji) {
   var content_divs = [];
   var initial_max_hits = max_hits;
   var starting_point = page * Query.env.paging.results_count;
-  // Working copy of photo set, starting at the nth page of photos
-  var page_results = results["hits"].slice(starting_point);
+  // Working copy of photo set, shuffled
+  var page_results = results["hits"].slice();
+  page_results = Pandas.shuffleWithSeed(results["hits"], Query.env.paging.seed);
+  page_results = page_results.slice(starting_point);
   var hit_count = page_results.length;
   if (page == 0 && Query.env.paging.shown_pages > 1) {
     // Refresh, but show more than just the normal photo_count
@@ -675,8 +677,6 @@ Gallery.tagPhotosPage = function(page, results, language, max_hits, add_emoji) {
   }
   // Redraw footer to update the paging button
   Page.footer.redraw("results");
-  // Always randomize the ordering of result photos
-  page_results = Pandas.randomChoiceSeed(page_results, Query.env.paging.seed, max_hits);
   for (let photo of page_results) {
     if (photo["photo.index"] != "0") {   // Not a null photo result
       content_divs = content_divs.concat(Gallery.tagPhotoSingle(photo, language, add_emoji));

--- a/js/show.js
+++ b/js/show.js
@@ -2237,7 +2237,7 @@ Show.profile.where = function(animal, language) {
 */
 Show.media = {};
 Show.media.gallery = function(animal, language) {
-  var gallery = Gallery.groupPhotos([animal["_id"]], 10);
+  var gallery = Gallery.groupPhotosPage(0, [animal["_id"]], 10)["output"];
   var info = Show.acquirePandaInfo(animal, language);
   Show.profile.nameBar(info);
   var result = document.createElement('div');

--- a/media/canada/0051_calgary-zoo/linus-udaya.txt
+++ b/media/canada/0051_calgary-zoo/linus-udaya.txt
@@ -7,9 +7,3 @@ photo.1.link: https://www.instagram.com/westcoast_kathy/
 photo.1.tags: paw-up, playing
 photo.1.tags.1000.location: 845, 400
 photo.1.tags.1081.location: 340, 450
-photo.2: https://www.instagram.com/p/B7XGdWNAtpU/media/?size=m
-photo.2.author: westcoast_kathy
-photo.2.link: https://www.instagram.com/westcoast_kathy/
-photo.2.tags: paw-up, playing
-photo.2.tags.1000.location: 250, 115
-photo.2.tags.1081.location: 105, 150


### PR DESCRIPTION
This improves the quality of shuffled content in tag searches and the group panda searches. Previously, it was shuffling different sized arrays and hoping the results would be consistent. Now it shuffles the entire array, and only pages out the content post-shuffle.

There's still some kind of issue in how I'm doing the random seed selection / feedback, so that code needs to be rewritten next.