### PR TITLE
Correct photo diffs

### DIFF
--- a/build.py
+++ b/build.py
@@ -638,7 +638,7 @@ class PhotoEntry:
         """
         if self.filename in self.cache:
             self.entity_type = self.cache[self.filename].split(".")[0]
-            self.entity_id = self.cache[self.filename].split(".")[1]
+            self.entity_id = self.cache[self.filename][len(self.entity_type) + 1:]
             self.was_cached = True
         else:
             config = configparser.ConfigParser()

--- a/build.py
+++ b/build.py
@@ -649,7 +649,7 @@ class PhotoEntry:
             if self.filename.find(MEDIA_PATH) != -1:
                 entity = config.get("media", "_id")
                 self.entity_type = entity.split(".")[0]
-                self.entity_id = entity.split(".")[1]
+                self.entity_id = entity[len(self.entity_type) + 1:]
             elif self.filename.find(PANDA_PATH) != -1:
                 self.entity_type = "panda"
                 self.entity_id = config.get("panda", "_id")

--- a/build.py
+++ b/build.py
@@ -768,7 +768,7 @@ class UpdateFromCommits:
         self.seen["photos"] = self.count_new_photos()
         for locator in self.locator_to_photo.copy().keys():
             print(locator + " ===> ")
-            print("    " + self.locator_to_photo[locator].photo_uri + " ==> ")
+            # print("    " + self.locator_to_photo[locator].photo_uri + " ==> ")
             print("    " + str(self.locator_to_photo[locator].changes))
             if self.locator_to_photo[locator].photo_uri not in self.seen["photos"].keys():
                 # Not in the counted new photo list, so remove it

--- a/media/japan/0016_nihondaira/homer-nico.txt
+++ b/media/japan/0016_nihondaira/homer-nico.txt
@@ -1,0 +1,9 @@
+[media]
+_id: media.16.homer-nico
+panda.tags: 145, 148
+photo.1: https://www.instagram.com/p/BaOQ_VUhdcp/media/?size=m
+photo.1.author: miis_98
+photo.1.link: https://www.instagram.com/miis_98/
+photo.1.tags: baby, mother's day
+photo.1.tags.145.location: 170, 85
+photo.1.tags.148.location: 155, 205


### PR DESCRIPTION
Added logic to detect when lines are removed/changed from files as well as added. This seems to go a long way towards fixing the wild swings in new photo counts, every time I re-order photos in a panda's file.