### PR TITLE
written language fallback to Latin alphabets rather than strictly English

### DIFF
--- a/js/language.js
+++ b/js/language.js
@@ -37,7 +37,7 @@ Language.init = function() {
 Language.L.bias = {
   "cn": ["latin"],
   "en": [],
-  "jp": [],
+  "jp": ["latin"],
   "np": ["latin"]
 }
 

--- a/js/language.js
+++ b/js/language.js
@@ -35,11 +35,22 @@ Language.init = function() {
 // but not Japanese -- so we should fall back to English for them, despite
 // what an entity's preferred language order might be.
 Language.L.bias = {
-  "cn": ["en"],
+  "cn": ["latin"],
   "en": [],
   "jp": [],
-  "np": ["en"]
+  "np": ["latin"]
 }
+
+// Types of alphabets, so we can fall back to an alphabet that someone
+// is capable of reading based on their language skills. In practice,
+// we opt to fall back to latin languages since that alphabet is more
+// widely understood
+Language.alphabets = {
+  "cjk": ["cn", "jp", "kr"],
+  "cyrillic": ["ru"],
+  "latin": ["de", "dk", "en", "es", "fr", "nl", "pl"],
+}
+
 
 // Character translation tables per language. Just hiragana/katakana.
 // Define this for all objects, not just for the instance.
@@ -2319,6 +2330,17 @@ Language.commaPhrase = function(pieces) {
 // doesn't include info for a language, we can overwrite that info anyways!
 Language.currentOrder = function(current_list, current_language) {
   var bias = L.bias[current_language];
+  if (bias == "latin") {
+    bias = [];
+    // Iterate through the current list of languages. If one has a latin
+    // writing system, use it as an option. This will usually fall back to
+    // English, but not always.
+    for (let lang of current_list) {
+      if (Language.alphabets["latin"].indexOf(lang) != -1) {
+        bias.push(lang);
+      }
+    }
+  }
   return bias.concat(current_list)
              .concat(current_language)
              .filter(function(value, index, self) { 


### PR DESCRIPTION
Been on my TODO list for a while, and the code was surprisingly simple.

For Chinese speakers, many of the pandas (particularly Japanese animals) will have English as the displayed fallback language, because it's more likely a Chinese can read a Latin alphabet language than Japanese hiragana/katakana.

However, if a Chinese user is browsing animals in European zoos, this would result in them seeing English information for those zoos. For authenticity I'm thinking it's preferable to display the "object-priority" language that has a Latin alphabet -- so French zoos will show French information, and so on.

Ironically this means a lot more information will fall back to English text that may have previously been in Thai or Russian, but since this is resulting in text people can read in their chosen language, I think it's the right move.