### PR TITLE
Scroll restoration

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -43,9 +43,9 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Scroll restoration moves you to a specific point in a page. This breaks
   // the top and refresh buttons moving you to the top of the page.
-  if (history.scrollRestoration) {
-    history.scrollRestoration = 'manual';
-  }
+  // if (history.scrollRestoration) {
+  //  history.scrollRestoration = 'manual';
+  // }
 
   // Once the panda data is loaded, create the graph
   window.addEventListener('panda_data', function() {

--- a/js/init.js
+++ b/js/init.js
@@ -41,12 +41,6 @@ document.addEventListener("DOMContentLoaded", function() {
   L.update();      // Update buttons, displayed results, and cookie state
   Page.redraw(Page.current);   // Ready to redraw? Let's go.
 
-  // Scroll restoration moves you to a specific point in a page. This breaks
-  // the top and refresh buttons moving you to the top of the page.
-  // if (history.scrollRestoration) {
-  //  history.scrollRestoration = 'manual';
-  // }
-
   // Once the panda data is loaded, create the graph
   window.addEventListener('panda_data', function() {
     P.db.vertices.forEach(G.addVertex.bind(G));

--- a/js/init.js
+++ b/js/init.js
@@ -41,6 +41,12 @@ document.addEventListener("DOMContentLoaded", function() {
   L.update();      // Update buttons, displayed results, and cookie state
   Page.redraw(Page.current);   // Ready to redraw? Let's go.
 
+  // Scroll restoration moves you to a specific point in a page. This breaks
+  // the top and refresh buttons moving you to the top of the page.
+  if (history.scrollRestoration) {
+    history.scrollRestoration = 'manual';
+  }
+
   // Once the panda data is loaded, create the graph
   window.addEventListener('panda_data', function() {
     P.db.vertices.forEach(G.addVertex.bind(G));

--- a/js/show.js
+++ b/js/show.js
@@ -916,10 +916,12 @@ Show.button.search = {};
 Show.button.search.action = function() {
   // Used on pages where the search bar normally doesn't appear
   var active = Show.searchBar.toggle("bottomSearch");
-  var searchBar = document.getElementById("searchInput");
   if (active == true) {
-    // window.scrollTo(0, document.getElementById("searchInput").offsetTop);
-    window.scrollTo(0, 0);   // Go to the top of the page, not the input box
+    window.scrollTo(0, document.getElementById("searchInput").offsetTop);
+    // TODO: have bottom and top search bars behave differently.
+    // Top search bar will scroll to absolute top of page, while bottom
+    // should focus on the element itself.
+    // window.scrollTo(0, 0);   // Go to the top of the page, not the input box
     document.getElementById("searchInput").focus();
   }
 }

--- a/js/show.js
+++ b/js/show.js
@@ -918,7 +918,8 @@ Show.button.search.action = function() {
   var active = Show.searchBar.toggle("bottomSearch");
   var searchBar = document.getElementById("searchInput");
   if (active == true) {
-    window.scrollTo(0, document.getElementById("searchInput").offsetTop);
+    // window.scrollTo(0, document.getElementById("searchInput").offsetTop);
+    window.scrollTo(0, 0);   // Go to the top of the page, not the input box
     document.getElementById("searchInput").focus();
   }
 }

--- a/js/show.js
+++ b/js/show.js
@@ -918,10 +918,6 @@ Show.button.search.action = function() {
   var active = Show.searchBar.toggle("bottomSearch");
   if (active == true) {
     window.scrollTo(0, document.getElementById("searchInput").offsetTop);
-    // TODO: have bottom and top search bars behave differently.
-    // Top search bar will scroll to absolute top of page, while bottom
-    // should focus on the element itself.
-    // window.scrollTo(0, 0);   // Go to the top of the page, not the input box
     document.getElementById("searchInput").focus();
   }
 }
@@ -2566,6 +2562,7 @@ Show.searchBar.submit = function() {
     }, 0);
   }
   Show.button.language.hide();   // If language menu open, hide it
+  window.scrollTo(0, 0);   // Go to the top of the page
 }
 Show.searchBar.toggle = function(frame_id) {
   // Normally the search bar just appears at the top of the page.

--- a/js/show.js
+++ b/js/show.js
@@ -665,6 +665,7 @@ Show.button.home.action = function() {
   window.location = "#home";
   Show.button.language.hide();   // If language menu open, hide it
   Page.current = Page.home.render;
+  window.scrollTo(0, 0);   // Go to the top of the page
 };
 Show.button.home.render = function(class_name="results") {
   var home = Show.button.render("homeButton", L.emoji.home, L.gui.home[L.display], class_name);


### PR DESCRIPTION
Added some logic to ensure that things scroll to the top of the page like they should, and that your vertical place on the page doesn't persist after clicking home or search buttons.

I thought this might need `history.scrollRestoration = 'manual';` but I'm going to try without at first.