### PR TITLE
Entity commitdate building

### DIFF
--- a/build.py
+++ b/build.py
@@ -602,6 +602,7 @@ class PhotoEntry:
         self.cache = cache
         self.author_name = None
         self.commitdate = None
+        self.entity_commitdate = None
         self.entity_id = None
         self.entity_type = None
         self.photo_index = None
@@ -668,9 +669,11 @@ class PhotoEntry:
             elif self.filename.find(PANDA_PATH) != -1:
                 self.entity_type = "panda"
                 self.entity_id = config.get("panda", "_id")
+                self.entity_commitdate = config.get("panda", "commitdate")
             elif self.filename.find(ZOO_PATH) != -1:
                 self.entity_type = "zoo"
                 self.entity_id = config.get("zoo", "_id")
+                self.entity_commitdate = config.get("zoo", "commitdate")
             else:
                 pass
 
@@ -703,6 +706,7 @@ class UpdateFromCommits:
         self.patch = PatchSet(self.diff_raw)
         self.locator_to_photo = {}
         self.filename_to_entity = {}
+        self.entity_to_commit_date = {}
         self.seen = {}
         self.seen["media"] = {}
         self.seen["panda"] = {}
@@ -722,10 +726,8 @@ class UpdateFromCommits:
 
     def count_new_photos(self):
         """
-        Given the locator_to_photo map, find all PhotoEntry photo_uri values
-        that are duplicated across PhotoEntry values. Record just the list
-        of changes on these values.
-        TODO: could hunt for photo duplicates here too.
+        Given the locator_to_photo map, check the commitdates of each photo.
+        If it's older than a week, ignore it.
         """
         seen_uris = {}
         # Get list of changes per photo locator
@@ -756,22 +758,38 @@ class UpdateFromCommits:
             elif change.added <= 0:
                 # Don't care about lines we removed
                 continue
-            elif change.is_added_file == True:
-                # New [media|panda|zoo]! Track change as representing a new entity
-                for hunk in change:
-                    for line in hunk:
-                        if line.is_added:
-                            self._process_raw_line(filename, line.value, added=True, counting=True)
             else:
                 # New photo. Track photo on its own
                 for hunk in change:
                     for line in hunk:
                         if line.is_added:
-                            self._process_raw_line(filename, line.value, added=True, counting=False)
+                            self._process_raw_line(filename, line.value)
+        # If this is a new panda, add it to our counts
+        weekstamp = current_date_to_unixtime() - 604800
+        for panda_id in self.seen["panda"].keys():
+            locators = self.seen["panda"][panda_id]
+            commitdate = self.entity_to_commit_date["panda." + panda_id]
+            commitstamp = datetime_to_unixtime(commitdate)
+            if commitstamp > weekstamp:
+                self.updates["pandas"] = self.updates["pandas"] + locators
+                self.updates["entities"] = self.updates["entities"] + locators
+        # If this is a new zoo, add it to our counts
+        for zoo_id in self.seen["zoo"]:
+            locators = self.seen["zoo"][zoo_id]
+            commitdate = self.entity_to_commit_date["panda." + panda_id]
+            commitstamp = datetime_to_unixtime(commitdate)
+            if commitstamp > weekstamp:
+                self.updates["zoos"] = self.updates["zoos"] + locators
+                self.updates["entities"] = self.updates["entities"] + locators
+        # Any media items that appear, consider them as new since these files
+        # should never relocate within the directory schema, and therefore
+        # don't track commitdates for the entities themselves.
+        for media_id in self.seen["media"]:
+            locators = self.seen["media"][media_id]
+            self.updates["entities"] = self.updates["entities"] + locators
         self.updates["panda_count"] = len(self.updates["pandas"])
         self.updates["zoo_count"] = len(self.updates["zoos"])
-        # Take locator_to_photo results, and de-duplicate based on whether
-        # the photo existed in multiple diffs/files or not
+        # Calculate the commitdates of all the photo locators themselves
         self.seen["photos"] = self.count_new_photos()
         for locator in self.locator_to_photo.copy().keys():
             if self.locator_to_photo[locator].photo_uri not in self.seen["photos"].keys():
@@ -828,7 +846,7 @@ class UpdateFromCommits:
             if author_diffs[author] > 0:
                 self.updates["author_count"] = self.updates["author_count"] + 1
 
-    def _process_raw_line(self, filename, raw, added=True, counting=False):
+    def _process_raw_line(self, filename, raw):
         """
         Annoying code where we use the PhotoEntry object to create locators
         for where an entity or a photo might already exist in our lookup
@@ -864,19 +882,10 @@ class UpdateFromCommits:
             actual = stub
             self.filename_to_entity[filename] = entity
             self.locator_to_photo[locator] = actual
-        # If this is a new entity, add it to our counts
-        if (self.seen[actual.entity_type].get(actual.entity_id) != True and
-            counting == True):
-            if actual.entity_type == "panda":
-                self.updates["pandas"].append(locator)
-                self.updates["entities"].append(locator)
-            if actual.entity_type == "zoo":
-                self.updates["zoos"].append(locator)
-                self.updates["entities"].append(locator)
-            if actual.entity_type == "media":
-                self.updates["entities"].append(locator)
-        if added == True:
-            self.seen[actual.entity_type][actual.entity_id] = True
+            self.entity_to_commit_date[entity] = actual.entity_commitdate
+            self.seen[actual.entity_type][actual.entity_id] = []
+        # The seen object tracks a list of locators for an id
+        self.seen[actual.entity_type][actual.entity_id].append(locator)
 
     def _starting_commit(self, time_delta):
         """

--- a/build.py
+++ b/build.py
@@ -786,7 +786,10 @@ class UpdateFromCommits:
         # don't track commitdates for the entities themselves.
         for media_id in self.seen["media"]:
             locators = self.seen["media"][media_id]
-            self.updates["entities"] = self.updates["entities"] + locators
+            commitdate = self.entity_to_commit_date["media." + media_id]
+            commitstamp = datetime_to_unixtime(commitdate)
+            if commitstamp > weekstamp:
+                self.updates["entities"] = self.updates["entities"] + locators
         self.updates["panda_count"] = len(self.updates["pandas"])
         self.updates["zoo_count"] = len(self.updates["zoos"])
         # Calculate the commitdates of all the photo locators themselves

--- a/build.py
+++ b/build.py
@@ -666,6 +666,7 @@ class PhotoEntry:
                 entity = config.get("media", "_id")
                 self.entity_type = entity.split(".")[0]
                 self.entity_id = entity[len(self.entity_type) + 1:]
+                self.entity_commitdate = config.get("media", "commitdate")
             elif self.filename.find(PANDA_PATH) != -1:
                 self.entity_type = "panda"
                 self.entity_id = config.get("panda", "_id")
@@ -765,12 +766,12 @@ class UpdateFromCommits:
                         if line.is_added:
                             self._process_raw_line(filename, line.value)
         # If this is a new panda, add it to our counts
-        weekstamp = current_date_to_unixtime() - 604800
+        lastweek = current_date_to_unixtime() - 604800
         for panda_id in self.seen["panda"].keys():
             locators = self.seen["panda"][panda_id]
             commitdate = self.entity_to_commit_date["panda." + panda_id]
             commitstamp = datetime_to_unixtime(commitdate)
-            if commitstamp > weekstamp:
+            if commitstamp > lastweek:
                 self.updates["pandas"] = self.updates["pandas"] + locators
                 self.updates["entities"] = self.updates["entities"] + locators
         # If this is a new zoo, add it to our counts
@@ -778,7 +779,7 @@ class UpdateFromCommits:
             locators = self.seen["zoo"][zoo_id]
             commitdate = self.entity_to_commit_date["panda." + panda_id]
             commitstamp = datetime_to_unixtime(commitdate)
-            if commitstamp > weekstamp:
+            if commitstamp > lastweek:
                 self.updates["zoos"] = self.updates["zoos"] + locators
                 self.updates["entities"] = self.updates["entities"] + locators
         # Any media items that appear, consider them as new since these files
@@ -788,7 +789,7 @@ class UpdateFromCommits:
             locators = self.seen["media"][media_id]
             commitdate = self.entity_to_commit_date["media." + media_id]
             commitstamp = datetime_to_unixtime(commitdate)
-            if commitstamp > weekstamp:
+            if commitstamp > lastweek:
                 self.updates["entities"] = self.updates["entities"] + locators
         self.updates["panda_count"] = len(self.updates["pandas"])
         self.updates["zoo_count"] = len(self.updates["zoos"])

--- a/build.py
+++ b/build.py
@@ -777,7 +777,7 @@ class UpdateFromCommits:
         # If this is a new zoo, add it to our counts
         for zoo_id in self.seen["zoo"]:
             locators = self.seen["zoo"][zoo_id]
-            commitdate = self.entity_to_commit_date["panda." + panda_id]
+            commitdate = self.entity_to_commit_date["zoo." + zoo_id]
             commitstamp = datetime_to_unixtime(commitdate)
             if commitstamp > lastweek:
                 self.updates["zoos"] = self.updates["zoos"] + locators

--- a/build.py
+++ b/build.py
@@ -889,7 +889,8 @@ class UpdateFromCommits:
             self.entity_to_commit_date[entity] = actual.entity_commitdate
             self.seen[actual.entity_type][actual.entity_id] = []
         # The seen object tracks a list of locators for an id
-        self.seen[actual.entity_type][actual.entity_id].append(locator)
+        if locator not in self.seen[actual.entity_type][actual.entity_id]:
+            self.seen[actual.entity_type][actual.entity_id].append(locator)
 
     def _starting_commit(self, time_delta):
         """

--- a/manage.py
+++ b/manage.py
@@ -695,6 +695,7 @@ def update_entity_commit_dates(starting_commit):
                 continue
             elif change.is_added_file == True:
                 compare = "./" + filename
+                print(compare)
                 dt = repo.commit(end).committed_datetime
                 date = str(dt.year) + "/" + str(dt.month) + "/" + str(dt.day)
                 just_file = filename.split("/").pop()
@@ -709,6 +710,8 @@ def update_entity_commit_dates(starting_commit):
                 elif compare.find(MEDIA_PATH) == 0:
                     just_type = "media"
                     just_id = filename   # Need full path for media files
+                else:
+                    continue    # Not a file we're tracking commitdates for
                 filename_to_commit_date[just_file] = date
                 type_id_to_commit_date[just_type + "_" + just_id] = date
             else:
@@ -726,8 +729,6 @@ def update_entity_commit_dates(starting_commit):
         for root, dirs, files in os.walk(file_path):
             for filename in files:
                 path = root + os.sep + filename
-                compare = "./" + path
-                print(compare)
                 photo_list = PhotoFile(section, path)
                 if photo_list.get_field("commitdate") == None:
                     if filename not in filename_to_commit_date:
@@ -735,15 +736,17 @@ def update_entity_commit_dates(starting_commit):
                         just_file = filename.split("/").pop()
                         just_type = None
                         just_id = None
-                        if compare.find(PANDA_PATH) == 0:
+                        if path.find(PANDA_PATH) == 0:
                             just_type = "panda"
                             just_id = just_file.split("_")[0]
-                        elif compare.find(ZOO_PATH) == 0:
+                        elif path.find(ZOO_PATH) == 0:
                             just_type = "zoo"
                             just_id = just_file.split("_")[0]
-                        elif compare.find(MEDIA_PATH) == 0:
+                        elif path.find(MEDIA_PATH) == 0:
                             just_type = "media"
                             just_id = path   # Need full path for media files
+                        else:
+                            continue    # Not a file we're tracking commitdates for
                         just_key = just_type + "_" + just_id
                         if just_key not in type_id_to_commit_date:
                             print("warning: %s commitdate undetermined" % filename)

--- a/manage.py
+++ b/manage.py
@@ -695,7 +695,6 @@ def update_entity_commit_dates(starting_commit):
                 continue
             elif change.is_added_file == True:
                 compare = "./" + filename
-                print(compare)
                 dt = repo.commit(end).committed_datetime
                 date = str(dt.year) + "/" + str(dt.month) + "/" + str(dt.day)
                 just_file = filename.split("/").pop()

--- a/manage.py
+++ b/manage.py
@@ -727,7 +727,7 @@ def update_entity_commit_dates(starting_commit):
             for filename in files:
                 path = root + os.sep + filename
                 compare = "./" + path
-                # print(filename)
+                print(compare)
                 photo_list = PhotoFile(section, path)
                 if photo_list.get_field("commitdate") == None:
                     if filename not in filename_to_commit_date:

--- a/media/belgium/0219_pairi-daiza/gwen-yushu.txt
+++ b/media/belgium/0219_pairi-daiza/gwen-yushu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.219.gwen-yushu
+commitdate: 2019/11/26
 panda.tags: 1048, 1054
 photo.1: https://www.instagram.com/p/BayPyqQAF_X/media/?size=m
 photo.1.author: pairidaizaofficial

--- a/media/belgium/0219_pairi-daiza/himiko-yin.txt
+++ b/media/belgium/0219_pairi-daiza/himiko-yin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.219.himiko-yin
+commitdate: 2019/11/24
 panda.tags: 1056, 1058
 photo.1: https://www.instagram.com/p/B2rSFP_i-Kq/media/?size=m
 photo.1.author: pairidaizaofficial

--- a/media/canada/0051_calgary-zoo/linus-udaya.txt
+++ b/media/canada/0051_calgary-zoo/linus-udaya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.51.linus-udaya
+commitdate: 2020/1/17
 panda.tags: 1000, 1081
 photo.1: https://www.instagram.com/p/B7XGdWNAtpU/media/?size=l
 photo.1.author: westcoast_kathy

--- a/media/canada/0051_calgary-zoo/sakura-udaya.txt
+++ b/media/canada/0051_calgary-zoo/sakura-udaya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.51.sakura-udaya
+commitdate: 2020/2/15
 panda.tags: 445, 1081
 photo.1: https://www.instagram.com/p/B6Uy_T3BlPq/media/?size=m
 photo.1.author: garseeyaink

--- a/media/canada/0076_assiniboine-park-zoo/xia-zorro.txt
+++ b/media/canada/0076_assiniboine-park-zoo/xia-zorro.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.76.xia-zorro
+commitdate: 2020/3/3
 panda.tags: 430, 431
 photo.1: https://www.instagram.com/p/BKet4BeBBbO/media/?size=m
 photo.1.author: assiniboineparkzoo

--- a/media/canada/0082_valley-zoo/paprika-pepper.txt
+++ b/media/canada/0082_valley-zoo/paprika-pepper.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.82.paprika-pepper
+commitdate: 2020/1/3
 panda.tags: 485, 486
 photo.1: https://www.instagram.com/p/Bc-079zgSA1/media/?size=l
 photo.1.author: buildingourzoo

--- a/media/canada/0082_valley-zoo/paprika-pip.txt
+++ b/media/canada/0082_valley-zoo/paprika-pip.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.82.paprika-pip
+commitdate: 2020/1/19
 panda.tags: 443, 486
 photo.1: https://www.instagram.com/p/Bx5Gl0VgyQo/media/?size=m
 photo.1.author: edmontonvalleyzoo

--- a/media/china/0196_ocean-park-hong-kong/rourou-taishan.txt
+++ b/media/china/0196_ocean-park-hong-kong/rourou-taishan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.196.rourou-taishan
+commitdate: 2019/7/18
 panda.tags: 930, 931
 photo.1: https://www.instagram.com/p/Bzk_snnHapm/media/?size=m
 photo.1.author: redpanda_tata

--- a/media/china/0236_hangzhou-zoo/apple-lingling.txt
+++ b/media/china/0236_hangzhou-zoo/apple-lingling.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.236.apple-lingling
+commitdate: 2020/2/5
 panda.tags: 1105, 1107
 photo.1: https://www.instagram.com/p/B7K6Jrrgl_q/media/?size=m
 photo.1.author: mkr0369

--- a/media/china/0236_hangzhou-zoo/lingling-tangyuan.txt
+++ b/media/china/0236_hangzhou-zoo/lingling-tangyuan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.236.lingling-tangyuan
+commitdate: 2020/2/5
 panda.tags: 1106, 1107
 photo.1: https://www.instagram.com/p/B7rDVDpBSXN/media/?size=m
 photo.1.author: mkr0369

--- a/media/france/0238_parc-animalier-de-sainte-croix/bao-chahua-yingtao.txt
+++ b/media/france/0238_parc-animalier-de-sainte-croix/bao-chahua-yingtao.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.238.bao-chahua-yingtao
+commitdate: 2020/3/31
 panda.tags: 1148, 1149, 1150
 photo.1: https://www.instagram.com/p/-MYjA7jwY0/media/?size=m
 photo.1.author: parcsaintecroix

--- a/media/france/0238_parc-animalier-de-sainte-croix/bao-chahua.txt
+++ b/media/france/0238_parc-animalier-de-sainte-croix/bao-chahua.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.238.bao-chahua
+commitdate: 2020/3/31
 panda.tags: 1149, 1150
 photo.1: https://www.instagram.com/p/1bUmPRDwUp/media/?size=m
 photo.1.author: parcsaintecroix

--- a/media/japan/0001_ichikawa/cocoa-himawari-milk-yuufa.txt
+++ b/media/japan/0001_ichikawa/cocoa-himawari-milk-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-himawari-milk-yuufa
+commitdate: 2019/6/6
 panda.tags: 6, 8, 246, 247
 photo.1: https://www.instagram.com/p/ByTrJoTBMBJ/media/?size=l
 photo.1.author: fetorus_mami

--- a/media/japan/0001_ichikawa/cocoa-himawari-yuufa.txt
+++ b/media/japan/0001_ichikawa/cocoa-himawari-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-himawari-yuufa
+commitdate: 2020/5/29
 panda.tags: 6, 8, 246
 photo.1: https://www.instagram.com/p/CAfs8Gih0yT/media/?size=m
 photo.1.author: na.mo.pan

--- a/media/japan/0001_ichikawa/cocoa-himawari.txt
+++ b/media/japan/0001_ichikawa/cocoa-himawari.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-himawari
+commitdate: 2019/6/21
 panda.tags: 8, 246
 photo.1: https://www.instagram.com/p/By82EHOA5ho/media/?size=m
 photo.1.author: sunnylettuce_2020

--- a/media/japan/0001_ichikawa/cocoa-milk-yuufa.txt
+++ b/media/japan/0001_ichikawa/cocoa-milk-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-milk-yuufa
+commitdate: 2019/5/15
 panda.tags: 6, 246, 247
 photo.1: https://www.instagram.com/p/Br6LkgXFIIY/media/?size=m
 photo.1.author: redpanda_nippon_takashi

--- a/media/japan/0001_ichikawa/cocoa-milk.txt
+++ b/media/japan/0001_ichikawa/cocoa-milk.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-milk
+commitdate: 2019/7/9
 panda.tags: 246, 247
 photo.1: https://www.instagram.com/p/BrLrpYDl9m4/media/?size=m
 photo.1.author: wumpwoast

--- a/media/japan/0001_ichikawa/cocoa-yuufa.txt
+++ b/media/japan/0001_ichikawa/cocoa-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.cocoa-yuufa
+commitdate: 2019/11/27
 panda.tags: 6, 246
 photo.1: https://www.instagram.com/p/B5TpU9tBQ7V/media/?size=m
 photo.1.author: _rifa_p

--- a/media/japan/0001_ichikawa/hao-sora.txt
+++ b/media/japan/0001_ichikawa/hao-sora.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.hao-sora
+commitdate: 2019/7/14
 panda.tags: 11, 12
 photo.1: https://www.instagram.com/p/Bwpury9F_op/media/?size=m
 photo.1.author: run.swim.shingo

--- a/media/japan/0001_ichikawa/harumaki-karin.txt
+++ b/media/japan/0001_ichikawa/harumaki-karin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.harumaki-karin
+commitdate: 2020/2/16
 panda.tags: 1, 10
 photo.1: https://www.instagram.com/p/Bq_6prGlFBG/media/?size=m
 photo.1.author: masa_polarbear

--- a/media/japan/0001_ichikawa/himawari-milk-yuufa.txt
+++ b/media/japan/0001_ichikawa/himawari-milk-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.himawari-milk-yuufa
+commitdate: 2019/6/3
 panda.tags: 6, 8, 247
 photo.1: https://www.instagram.com/p/BwOmVIog1CK/media/?size=m
 photo.1.author: jwg13777

--- a/media/japan/0001_ichikawa/himawari-milk.txt
+++ b/media/japan/0001_ichikawa/himawari-milk.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.himawari-milk
+commitdate: 2020/1/17
 panda.tags: 8, 247
 photo.1: https://www.instagram.com/p/BrMOcH_ljDH/media/?size=m
 photo.1.author: ck.chie

--- a/media/japan/0001_ichikawa/himawari-rifa.txt
+++ b/media/japan/0001_ichikawa/himawari-rifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.himawari-rifa
+commitdate: 2020/1/17
 panda.tags: 7, 8
 photo.1: https://www.instagram.com/p/B7W99BkhjTz/media/?size=l
 photo.1.author: _rifa_p

--- a/media/japan/0001_ichikawa/himawari-yuufa.txt
+++ b/media/japan/0001_ichikawa/himawari-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.himawari-yuufa
+commitdate: 2019/5/15
 panda.tags: 6, 8
 photo.1: https://www.instagram.com/p/Br6nEBZlF7F/media/?size=m
 photo.1.author: redpanda_nippon_takashi

--- a/media/japan/0001_ichikawa/ichimaru-karin.txt
+++ b/media/japan/0001_ichikawa/ichimaru-karin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.ichimaru-karin
+commitdate: 2019/11/29
 panda.tags: 9, 10
 photo.1: https://www.instagram.com/p/B5XneQ2hmaU/media/?size=m
 photo.1.author: na.mo.pan

--- a/media/japan/0001_ichikawa/milk-yuufa.txt
+++ b/media/japan/0001_ichikawa/milk-yuufa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.1.milk-yuufa
+commitdate: 2019/10/24
 panda.tags: 6, 247
 photo.1: https://www.instagram.com/p/B36B7EABNss/media/?size=m
 photo.1.author: ssc6105

--- a/media/japan/0002_kyoto-city/jasmine-oolong.txt
+++ b/media/japan/0002_kyoto-city/jasmine-oolong.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.2.jasmine-oolong
+commitdate: 2019/7/30
 panda.tags: 14, 15
 photo.1: https://www.instagram.com/p/BQaaXuhDrOU/media/?size=m
 photo.1.author: lespan33

--- a/media/japan/0002_kyoto-city/koto-mugi.txt
+++ b/media/japan/0002_kyoto-city/koto-mugi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.2.koto-mugi
+commitdate: 2020/5/24
 panda.tags: 5, 16
 photo.1: https://www.instagram.com/p/BHyNvhGhrNu/media/?size=l
 photo.1.author: lespan33

--- a/media/japan/0002_kyoto-city/puerh-roppo.txt
+++ b/media/japan/0002_kyoto-city/puerh-roppo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.2.puerh-roppo
+commitdate: 2020/2/5
 panda.tags: 96, 288
 photo.1: https://www.instagram.com/p/BGRoBd3sc9m/media/?size=m
 photo.1.author: lespan33

--- a/media/japan/0004_yumemigasaki/ann-fafa.txt
+++ b/media/japan/0004_yumemigasaki/ann-fafa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.4.ann-fafa
+commitdate: 2019/9/3
 panda.tags: 26, 27
 photo.1: https://www.instagram.com/p/_20fTbtG7r/media/?size=m
 photo.1.author: mariten1119

--- a/media/japan/0004_yumemigasaki/ann-karin.txt
+++ b/media/japan/0004_yumemigasaki/ann-karin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.4.ann-karin
+commitdate: 2020/6/6
 panda.tags: 10, 27
 photo.1: https://www.instagram.com/p/B_7X6vNHh3j/media/?size=m
 photo.1.author: miis_98

--- a/media/japan/0004_yumemigasaki/ann-keiko.txt
+++ b/media/japan/0004_yumemigasaki/ann-keiko.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.4.ann-keiko
+commitdate: 2019/9/3
 panda.tags: 27, 28
 photo.1: https://www.instagram.com/p/BBmxSlrtG5c/media/?size=m
 photo.1.author: mariten1119

--- a/media/japan/0004_yumemigasaki/fafa-kenta.txt
+++ b/media/japan/0004_yumemigasaki/fafa-kenta.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.4.fafa-kenta
+commitdate: 2019/9/3
 panda.tags: 26, 29
 photo.1: https://www.instagram.com/p/BIbazF1AhIx/media/?size=m
 photo.1.author: mariten1119

--- a/media/japan/0004_yumemigasaki/keiko-kenta.txt
+++ b/media/japan/0004_yumemigasaki/keiko-kenta.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.4.keiko-kenta
+commitdate: 2019/9/3
 panda.tags: 28, 29
 photo.1: https://www.instagram.com/p/BAUgx55vi1x/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0006_tokuyama/charu-fufu-nei.txt
+++ b/media/japan/0006_tokuyama/charu-fufu-nei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.6.charu-fufu-nei
+commitdate: 2020/2/16
 panda.tags: 71, 376, 378
 photo.1: https://www.instagram.com/p/B3dDpzphzhX/media/?size=l
 photo.1.author: resapanlove

--- a/media/japan/0006_tokuyama/charu-luna-nei.txt
+++ b/media/japan/0006_tokuyama/charu-luna-nei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.6.charu-luna-nei
+commitdate: 2020/2/17
 panda.tags: 73, 376, 378
 photo.1: https://www.instagram.com/p/BtMdRyolqDB/media/?size=m
 photo.1.author: craig_craig_craig

--- a/media/japan/0006_tokuyama/charu-luna.txt
+++ b/media/japan/0006_tokuyama/charu-luna.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.6.charu-luna
+commitdate: 2020/2/16
 panda.tags: 73, 378
 photo.1: https://www.instagram.com/p/BthRr0nliQx/media/?size=m
 photo.1.author: fetorus_mami

--- a/media/japan/0006_tokuyama/charu-nei.txt
+++ b/media/japan/0006_tokuyama/charu-nei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.6.charu-nei
+commitdate: 2020/2/16
 panda.tags: 376, 378
 photo.1: https://www.instagram.com/p/BpPMXrXlSwl/media/?size=m
 photo.1.author: animal_love_us

--- a/media/japan/0006_tokuyama/hiko-sumire.txt
+++ b/media/japan/0006_tokuyama/hiko-sumire.txt
@@ -1,3 +1,4 @@
 [media]
 _id: media.6.hiko-sumire
+commitdate: 2019/6/1
 panda.tags: 70, 182

--- a/media/japan/0006_tokuyama/luna-nei.txt
+++ b/media/japan/0006_tokuyama/luna-nei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.6.luna-nei
+commitdate: 2020/2/16
 panda.tags: 73, 376
 photo.1: https://www.instagram.com/p/BpWewBslT1Y/media/?size=m
 photo.1.author: animal_love_us

--- a/media/japan/0007_maruyama/coco-hokuto.txt
+++ b/media/japan/0007_maruyama/coco-hokuto.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.7.coco-hokuto
+commitdate: 2020/3/8
 panda.tags: 20, 58
 photo.1: https://www.instagram.com/p/B9eDIweh6Tw/media/?size=m
 photo.1.author: kipekaila

--- a/media/japan/0007_maruyama/gin-kin.txt
+++ b/media/japan/0007_maruyama/gin-kin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.7.gin-kin
+commitdate: 2019/7/20
 panda.tags: 17, 22
 photo.1: https://www.instagram.com/p/BldDhasHNn2/media/?size=l
 photo.1.author: cattail.sapporo

--- a/media/japan/0007_maruyama/gin-marumi.txt
+++ b/media/japan/0007_maruyama/gin-marumi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.7.gin-marumi
+commitdate: 2019/5/15
 panda.tags: 17, 18
 photo.1: https://www.instagram.com/p/BLE5X6ojiWE/media/?size=m
 photo.1.author: _sealiz

--- a/media/japan/0008_chiba/chichi-futa.txt
+++ b/media/japan/0008_chiba/chichi-futa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.chichi-futa
+commitdate: 2020/4/25
 panda.tags: 34, 53
 photo.1: https://www.instagram.com/p/ziytEvOR-w/media/?size=l
 photo.1.author: masa_polarbear

--- a/media/japan/0008_chiba/kuuta-meimei.txt
+++ b/media/japan/0008_chiba/kuuta-meimei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.kuuta-meimei
+commitdate: 2020/5/2
 panda.tags: 35, 36
 photo.1: https://www.instagram.com/p/-XkdmsPizq/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0008_chiba/lime-mii.txt
+++ b/media/japan/0008_chiba/lime-mii.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.lime-mii
+commitdate: 2019/11/24
 panda.tags: 38, 41
 photo.1: https://www.instagram.com/p/B454D4Ih0ms/media/?size=m
 photo.1.author: ifumoto88

--- a/media/japan/0008_chiba/mai-meita-mii.txt
+++ b/media/japan/0008_chiba/mai-meita-mii.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.mai-meita-mii
+commitdate: 2019/6/10
 panda.tags: 38, 39, 43
 photo.1: https://www.instagram.com/p/ByiOMPJhwfd/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0008_chiba/mai-mii.txt
+++ b/media/japan/0008_chiba/mai-mii.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.mai-mii
+commitdate: 2020/4/26
 panda.tags: 38, 43
 photo.1: https://www.instagram.com/p/BJt3_D6jlV4/media/?size=l
 photo.1.author: panda.daisuki

--- a/media/japan/0008_chiba/meimei-yui-yuu.txt
+++ b/media/japan/0008_chiba/meimei-yui-yuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.meimei-yui-yuu
+commitdate: 2019/5/31
 panda.tags: 36, 40, 47
 photo.1: https://www.instagram.com/p/BF9RTIrvi2O/media/?size=l
 photo.1.author: panda.daisuki

--- a/media/japan/0008_chiba/meimei-yui.txt
+++ b/media/japan/0008_chiba/meimei-yui.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.meimei-yui
+commitdate: 2020/5/2
 panda.tags: 36, 47
 photo.1: https://www.instagram.com/p/BESiS1nPi7V/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0008_chiba/yui-yuu.txt
+++ b/media/japan/0008_chiba/yui-yuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.8.yui-yuu
+commitdate: 2019/6/23
 panda.tags: 40, 47
 photo.1: https://www.instagram.com/p/BcpARfBDoCR/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0009_saitama/hanabi-ryuu-sei.txt
+++ b/media/japan/0009_saitama/hanabi-ryuu-sei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.hanabi-ryuu-sei
+commitdate: 2019/11/4
 panda.tags: 78, 957, 958
 photo.1: https://www.instagram.com/p/B3yoRuihZJ3/media/?size=m
 photo.1.author: kaoru_a358

--- a/media/japan/0009_saitama/hanabi-ryuu.txt
+++ b/media/japan/0009_saitama/hanabi-ryuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.hanabi-ryuu
+commitdate: 2019/11/5
 panda.tags: 78, 957
 photo.1: https://www.instagram.com/p/B4E6narhreT/media/?size=m
 photo.1.author: ifumoto88

--- a/media/japan/0009_saitama/hanabi-sei.txt
+++ b/media/japan/0009_saitama/hanabi-sei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.hanabi-sei
+commitdate: 2020/1/7
 panda.tags: 78, 958
 photo.1: https://www.instagram.com/p/B6G8ZyBBD8B/media/?size=m
 photo.1.author: ssc6105

--- a/media/japan/0009_saitama/miyabi-rin.txt
+++ b/media/japan/0009_saitama/miyabi-rin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.miyabi-rin
+commitdate: 2019/10/2
 panda.tags: 80, 242
 photo.1: https://www.instagram.com/p/B2z6qHOBKE7/media/?size=m
 photo.1.author: rie_panda55

--- a/media/japan/0009_saitama/rin-sousou.txt
+++ b/media/japan/0009_saitama/rin-sousou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.rin-sousou
+commitdate: 2020/5/14
 panda.tags: 79, 242
 photo.1: https://www.instagram.com/p/BzSFvL_BPwT/media/?size=m
 photo.1.author: saitamazoo

--- a/media/japan/0009_saitama/ryuu-sei.txt
+++ b/media/japan/0009_saitama/ryuu-sei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.9.ryuu-sei
+commitdate: 2019/11/4
 panda.tags: 957, 958
 photo.1: https://www.instagram.com/p/B3zEv6MBhsj/media/?size=m
 photo.1.author: motohin

--- a/media/japan/0010_chausuyama/hibiki-hikaru.txt
+++ b/media/japan/0010_chausuyama/hibiki-hikaru.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.10.hibiki-hikaru
+commitdate: 2019/6/9
 panda.tags: 97, 98
 photo.1: https://www.instagram.com/p/BFr3QTLvi59/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0011_kushiro-zoo/asunaro-shingen.txt
+++ b/media/japan/0011_kushiro-zoo/asunaro-shingen.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.11.asunaro-shingen
+commitdate: 2019/9/26
 panda.tags: 24, 294
 photo.1: https://www.instagram.com/p/B2y306jBn-x/media/?size=m
 photo.1.author: leonard_redmof

--- a/media/japan/0011_kushiro-zoo/kin-shingen.txt
+++ b/media/japan/0011_kushiro-zoo/kin-shingen.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.11.kin-shingen
+commitdate: 2020/4/18
 panda.tags: 22, 24
 photo.1: https://www.instagram.com/p/BMga2wDjLIY/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0012_yokohama-zoorasia/ichigo-mametarou.txt
+++ b/media/japan/0012_yokohama-zoorasia/ichigo-mametarou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.12.ichigo-mametarou
+commitdate: 2019/7/28
 panda.tags: 99, 130
 photo.1: https://www.instagram.com/p/BvHNcnxlmjm/media/?size=m
 photo.1.author: kipekaila

--- a/media/japan/0013_nishiyama/kiraly-meixiang.txt
+++ b/media/japan/0013_nishiyama/kiraly-meixiang.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.kiraly-meixiang
+commitdate: 2020/1/16
 panda.tags: 113, 121
 photo.1: https://www.instagram.com/p/B7LrZJhBnop/media/?size=m
 photo.1.author: minato.yokohama2130

--- a/media/japan/0013_nishiyama/matsuba-mochi.txt
+++ b/media/japan/0013_nishiyama/matsuba-mochi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.matsuba-mochi
+commitdate: 2019/7/16
 panda.tags: 119, 147
 photo.1: https://www.instagram.com/p/BrKWeJoFtmn/media/?size=m
 photo.1.author: minato.yokohama2130

--- a/media/japan/0013_nishiyama/matsuba-niiko-reifa.txt
+++ b/media/japan/0013_nishiyama/matsuba-niiko-reifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.matsuba-niiko-reifa
+commitdate: 2019/11/12
 panda.tags: 147, 955, 956
 photo.1: https://www.instagram.com/p/B4qcci8hbNT/media/?size=l
 photo.1.author: tomo3700

--- a/media/japan/0013_nishiyama/matsuba-niiko.txt
+++ b/media/japan/0013_nishiyama/matsuba-niiko.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.matsuba-niiko
+commitdate: 2020/1/6
 panda.tags: 147, 956
 photo.1: https://www.instagram.com/p/B6DdOnOh4Bl/media/?size=m
 photo.1.author: tetusara.ki_

--- a/media/japan/0013_nishiyama/matsuba-reifa.txt
+++ b/media/japan/0013_nishiyama/matsuba-reifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.matsuba-reifa
+commitdate: 2020/2/20
 panda.tags: 147, 955
 photo.1: https://www.instagram.com/p/B8V_24yhAzm/media/?size=m
 photo.1.author: kinkinkin0826

--- a/media/japan/0013_nishiyama/milky-taiyo.txt
+++ b/media/japan/0013_nishiyama/milky-taiyo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.milky-taiyo
+commitdate: 2020/5/9
 panda.tags: 114, 117
 photo.1: https://www.instagram.com/p/B-1frmBB9Db/media/?size=m
 photo.1.author: minato.yokohama2130

--- a/media/japan/0013_nishiyama/mochi-mutan.txt
+++ b/media/japan/0013_nishiyama/mochi-mutan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.mochi-mutan
+commitdate: 2019/6/9
 panda.tags: 118, 119
 photo.1: https://www.instagram.com/p/BvREgCylMWs/media/?size=m
 photo.1.author: yakkooo24

--- a/media/japan/0013_nishiyama/mochi-sakuya.txt
+++ b/media/japan/0013_nishiyama/mochi-sakuya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.mochi-sakuya
+commitdate: 2019/8/19
 panda.tags: 52, 119
 photo.1: https://www.instagram.com/p/B1NBaB_BQWj/media/?size=m
 photo.1.author: minato.yokohama2130

--- a/media/japan/0013_nishiyama/mutan-tiara.txt
+++ b/media/japan/0013_nishiyama/mutan-tiara.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.mutan-tiara
+commitdate: 2019/6/21
 panda.tags: 118, 120
 photo.1: https://www.instagram.com/p/By46iLXhR4j/media/?size=m
 photo.1.author: leonard_redmof

--- a/media/japan/0013_nishiyama/niiko-reifa.txt
+++ b/media/japan/0013_nishiyama/niiko-reifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.13.niiko-reifa
+commitdate: 2019/11/5
 panda.tags: 955, 956
 photo.1: https://www.instagram.com/p/B39lc2bBH_E/media/?size=m
 photo.1.author: monmon_redpanda

--- a/media/japan/0014_himeji-central-park/kenta-zsazsa.txt
+++ b/media/japan/0014_himeji-central-park/kenta-zsazsa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.14.kenta-zsazsa
+commitdate: 2020/2/16
 panda.tags: 29, 95
 photo.1: https://www.instagram.com/p/B7YVzVuhX4Y/media/?size=m
 photo.1.author: love__mitarashi

--- a/media/japan/0014_himeji-central-park/temari-zsazsa.txt
+++ b/media/japan/0014_himeji-central-park/temari-zsazsa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.14.temari-zsazsa
+commitdate: 2019/11/15
 panda.tags: 95, 1016
 photo.1: https://www.instagram.com/p/B4eIyqMB-OM/media/?size=m
 photo.1.author: love__mitarashi

--- a/media/japan/0015_ikeda-zoo/himari-taiyo.txt
+++ b/media/japan/0015_ikeda-zoo/himari-taiyo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.15.himari-taiyo
+commitdate: 2020/5/2
 panda.tags: 117, 219
 photo.1: https://www.instagram.com/p/B_pb6sSA8cc/media/?size=l
 photo.1.author: miis_98

--- a/media/japan/0015_ikeda-zoo/nonta-shizuku.txt
+++ b/media/japan/0015_ikeda-zoo/nonta-shizuku.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.15.nonta-shizuku
+commitdate: 2019/7/7
 panda.tags: 138, 140
 photo.1: https://www.instagram.com/p/BzVNFObBbjC/media/?size=m
 photo.1.author: itsuak

--- a/media/japan/0016_nihondaira/holy-homer.txt
+++ b/media/japan/0016_nihondaira/holy-homer.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.16.holy-homer
+commitdate: 2020/6/1
 panda.tags: 145, 146
 photo.1: https://www.instagram.com/p/B-_xdz7BRAb/media/?size=l
 photo.1.author: ifumoto88

--- a/media/japan/0016_nihondaira/homer-nico.txt
+++ b/media/japan/0016_nihondaira/homer-nico.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.16.homer-nico
+commitdate: 2020/4/5
 panda.tags: 145, 148
 photo.1: https://www.instagram.com/p/BaOQ_VUhdcp/media/?size=m
 photo.1.author: miis_98

--- a/media/japan/0016_nihondaira/homer-reika.txt
+++ b/media/japan/0016_nihondaira/homer-reika.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.16.homer-reika
+commitdate: 2020/1/22
 panda.tags: 145, 876
 photo.1: https://www.instagram.com/p/B7diScvBgIu/media/?size=l
 photo.1.author: ayusuke56

--- a/media/japan/0016_nihondaira/maruko-maruo-sea.txt
+++ b/media/japan/0016_nihondaira/maruko-maruo-sea.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.16.maruko-maruo-sea
+commitdate: 2019/7/11
 panda.tags: 142, 248, 249
 photo.1: https://www.instagram.com/p/BshLTOVlmVI/media/?size=l
 photo.1.author: ayusuke56

--- a/media/japan/0016_nihondaira/maruko-maruo.txt
+++ b/media/japan/0016_nihondaira/maruko-maruo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.16.maruko-maruo
+commitdate: 2019/5/18
 panda.tags: 248, 249
 photo.1: https://www.instagram.com/p/BxgmExWFkGi/media/?size=m
 photo.1.author: ayusuke56

--- a/media/japan/0017_tama/azuki-kanoko.txt
+++ b/media/japan/0017_tama/azuki-kanoko.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.azuki-kanoko
+commitdate: 2020/5/30
 panda.tags: 100, 102
 photo.1: https://www.instagram.com/p/BZlgNdTgV9_/media/?size=l
 photo.1.author: panda.daisuki

--- a/media/japan/0017_tama/azuki-rifa.txt
+++ b/media/japan/0017_tama/azuki-rifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.azuki-rifa
+commitdate: 2020/1/30
 panda.tags: 102, 240
 photo.1: https://www.instagram.com/p/B7x-wpzB3Bn/media/?size=m
 photo.1.author: mini_cochi

--- a/media/japan/0017_tama/azuki-zun.txt
+++ b/media/japan/0017_tama/azuki-zun.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.azuki-zun
+commitdate: 2019/5/21
 panda.tags: 102, 256
 photo.1: https://www.instagram.com/p/ByHau9qBWzY/media/?size=m
 photo.1.author: kotata_513

--- a/media/japan/0017_tama/booboo-fanfan.txt
+++ b/media/japan/0017_tama/booboo-fanfan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.booboo-fanfan
+commitdate: 2020/5/3
 panda.tags: 106, 107
 photo.1: https://www.instagram.com/p/BILCPLRjGDM/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0017_tama/franken-himawari.txt
+++ b/media/japan/0017_tama/franken-himawari.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.franken-himawari
+commitdate: 2020/3/6
 panda.tags: 8, 101
 photo.1: https://www.instagram.com/p/B8tds8JBjlc/media/?size=m
 photo.1.author: alto0908

--- a/media/japan/0017_tama/franken-rifa.txt
+++ b/media/japan/0017_tama/franken-rifa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.franken-rifa
+commitdate: 2019/8/21
 panda.tags: 101, 240
 photo.1: https://www.instagram.com/p/B05yId2hSh0/media/?size=l
 photo.1.author: ssc6105

--- a/media/japan/0017_tama/fufu-yanyan.txt
+++ b/media/japan/0017_tama/fufu-yanyan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.fufu-yanyan
+commitdate: 2020/4/29
 panda.tags: 71, 164
 photo.1: https://www.instagram.com/p/BAuZHVoKoN9/media/?size=m
 photo.1.author: minatomirai215

--- a/media/japan/0017_tama/kanoko-mametarou.txt
+++ b/media/japan/0017_tama/kanoko-mametarou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.kanoko-mametarou
+commitdate: 2019/7/1
 panda.tags: 99, 100
 photo.1: https://www.instagram.com/p/BLnjhTUjF4C/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0017_tama/meifa-shinfa-taofa.txt
+++ b/media/japan/0017_tama/meifa-shinfa-taofa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.meifa-shinfa-taofa
+commitdate: 2020/3/6
 panda.tags: 103, 948, 949
 photo.1: https://www.instagram.com/p/B88yHnVB5u2/media/?size=l
 photo.1.author: craig_craig_craig

--- a/media/japan/0017_tama/meifa-shinfa.txt
+++ b/media/japan/0017_tama/meifa-shinfa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.meifa-shinfa
+commitdate: 2019/10/15
 panda.tags: 948, 949
 photo.1: https://www.instagram.com/p/B3W5njyh9mC/media/?size=m
 photo.1.author: ifumoto88

--- a/media/japan/0017_tama/meifa-taofa.txt
+++ b/media/japan/0017_tama/meifa-taofa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.meifa-taofa
+commitdate: 2020/1/31
 panda.tags: 103, 949
 photo.1: https://www.instagram.com/p/B7xvh-ghJ98/media/?size=m
 photo.1.author: ssc6105

--- a/media/japan/0017_tama/rifa-taofa.txt
+++ b/media/japan/0017_tama/rifa-taofa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.17.rifa-taofa
+commitdate: 2019/5/15
 panda.tags: 103, 240
 photo.1: https://www.instagram.com/p/BqN6JedlDVA/media/?size=m
 photo.1.author: sb23megumi

--- a/media/japan/0018_tobu/chihiro-kokoro.txt
+++ b/media/japan/0018_tobu/chihiro-kokoro.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.18.chihiro-kokoro
+commitdate: 2019/5/15
 panda.tags: 123, 220
 photo.1: https://www.instagram.com/p/BZH0jiHBOgE/media/?size=m
 photo.1.author: _rifa_p

--- a/media/japan/0019_morikirara/kabosu-mikan.txt
+++ b/media/japan/0019_morikirara/kabosu-mikan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.19.kabosu-mikan
+commitdate: 2019/7/1
 panda.tags: 253, 255
 photo.1: https://www.instagram.com/p/Bw39wcsFi6u/media/?size=m
 photo.1.author: re_ichimaru

--- a/media/japan/0021_omuta-city-zoo/mai-rei.txt
+++ b/media/japan/0021_omuta-city-zoo/mai-rei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.21.mai-rei
+commitdate: 2019/6/23
 panda.tags: 43, 243
 photo.1: https://www.instagram.com/p/Bqjc3R6l88l/media/?size=m
 photo.1.author: monmon_redpanda

--- a/media/japan/0022_tennoji/mel-sakuya-shuuna.txt
+++ b/media/japan/0022_tennoji/mel-sakuya-shuuna.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.22.mel-sakuya-shuuna
+commitdate: 2020/3/29
 panda.tags: 44, 51, 52
 photo.1: https://www.instagram.com/p/B-JoFANBzi7/media/?size=l
 photo.1.author: bubbles_octi

--- a/media/japan/0022_tennoji/mel-sakuya.txt
+++ b/media/japan/0022_tennoji/mel-sakuya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.22.mel-sakuya
+commitdate: 2019/10/13
 panda.tags: 51, 52
 photo.1: https://www.instagram.com/p/B3HVBlJBdTZ/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0024_hamamatsu/arata-kirara-mirai.txt
+++ b/media/japan/0024_hamamatsu/arata-kirara-mirai.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.24.arata-kirara-mirai
+commitdate: 2019/11/27
 panda.tags: 65, 962, 963
 photo.1: https://www.instagram.com/p/B4-XMrwBXum/media/?size=l
 photo.1.author: hamiiiii831_

--- a/media/japan/0024_hamamatsu/arata-kirara.txt
+++ b/media/japan/0024_hamamatsu/arata-kirara.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.24.arata-kirara
+commitdate: 2020/1/30
 panda.tags: 65, 962
 photo.1: https://www.instagram.com/p/B5SuapfBAe0/media/?size=m
 photo.1.author: mini_cochi

--- a/media/japan/0024_hamamatsu/arata-mirai.txt
+++ b/media/japan/0024_hamamatsu/arata-mirai.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.24.arata-mirai
+commitdate: 2019/11/18
 panda.tags: 962, 963
 photo.1: https://www.instagram.com/p/B2wY0xghkuE/media/?size=m
 photo.1.author: taka__3428

--- a/media/japan/0024_hamamatsu/chiita-tell.txt
+++ b/media/japan/0024_hamamatsu/chiita-tell.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.24.chiita-tell
+commitdate: 2020/4/9
 panda.tags: 3, 46
 photo.1: https://www.instagram.com/p/BWkQkCCB0De/media/?size=m
 photo.1.author: miis_98

--- a/media/japan/0024_hamamatsu/kirara-mirai.txt
+++ b/media/japan/0024_hamamatsu/kirara-mirai.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.24.kirara-mirai
+commitdate: 2019/11/18
 panda.tags: 65, 963
 photo.1: https://www.instagram.com/p/B2sKPZtBYbb/media/?size=m
 photo.1.author: taka__3428

--- a/media/japan/0025_hitachi-kamine/ichi-sakura.txt
+++ b/media/japan/0025_hitachi-kamine/ichi-sakura.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.25.ichi-sakura
+commitdate: 2020/3/8
 panda.tags: 156, 157
 photo.1: https://www.instagram.com/p/B9dTAcBhTO-/media/?size=m
 photo.1.author: takahisakaneuchi

--- a/media/japan/0025_hitachi-kamine/yamato-yui.txt
+++ b/media/japan/0025_hitachi-kamine/yamato-yui.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.25.yamato-yui
+commitdate: 2020/1/3
 panda.tags: 47, 158
 photo.1: https://www.instagram.com/p/B60btoyhbuY/media/?size=m
 photo.1.author: takahisakaneuchi

--- a/media/japan/0026_akita-oomoriyama/hinata-kanta-sayuri-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-kanta-sayuri-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-kanta-sayuri-yuri
+commitdate: 2019/5/31
 panda.tags: 213, 214, 250, 251
 photo.1: https://www.instagram.com/p/BxyVzxAlYb_/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0026_akita-oomoriyama/hinata-kanta-sayuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-kanta-sayuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-kanta-sayuri
+commitdate: 2020/3/6
 panda.tags: 213, 250, 251
 photo.1: https://www.instagram.com/p/B8mJzWeBTm5/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0026_akita-oomoriyama/hinata-kanta-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-kanta-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-kanta-yuri
+commitdate: 2019/5/15
 panda.tags: 214, 250, 251
 photo.1: https://www.instagram.com/p/Bp9M7Hel4aL/media/?size=m
 photo.1.author: daniele.tokyo

--- a/media/japan/0026_akita-oomoriyama/hinata-kanta.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-kanta.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-kanta
+commitdate: 2019/6/9
 panda.tags: 250, 251
 photo.1: https://www.instagram.com/p/Byc2QrrhRTn/media/?size=m
 photo.1.author: fetorus_mami

--- a/media/japan/0026_akita-oomoriyama/hinata-sayuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-sayuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-sayuri
+commitdate: 2019/7/28
 panda.tags: 213, 250
 photo.1: https://www.instagram.com/p/B0SyFBKBZ_B/media/?size=m
 photo.1.author: miis_98

--- a/media/japan/0026_akita-oomoriyama/hinata-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/hinata-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.hinata-yuri
+commitdate: 2019/11/27
 panda.tags: 214, 250
 photo.1: https://www.instagram.com/p/B5J-YhcBwFD/media/?size=m
 photo.1.author: zoowfreedom299

--- a/media/japan/0026_akita-oomoriyama/kanta-sayuri-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/kanta-sayuri-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.kanta-sayuri-yuri
+commitdate: 2019/9/22
 panda.tags: 213, 214, 251
 photo.1: https://www.instagram.com/p/B2b9Yb4h5uO/media/?size=l
 photo.1.author: grskus_tk

--- a/media/japan/0026_akita-oomoriyama/kanta-sayuri.txt
+++ b/media/japan/0026_akita-oomoriyama/kanta-sayuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.kanta-sayuri
+commitdate: 2019/6/6
 panda.tags: 213, 251
 photo.1: https://www.instagram.com/p/BySflAOhT8e/media/?size=m
 photo.1.author: craig_craig_craig

--- a/media/japan/0026_akita-oomoriyama/kanta-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/kanta-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.kanta-yuri
+commitdate: 2019/5/30
 panda.tags: 214, 251
 photo.1: https://www.instagram.com/p/Bq_Y-1nl5jI/media/?size=m
 photo.1.author: mifko55

--- a/media/japan/0026_akita-oomoriyama/kenta-sayuri-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/kenta-sayuri-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.kenta-sayuri-yuri
+commitdate: 2020/5/26
 panda.tags: 212, 213, 214
 photo.1: https://www.instagram.com/p/BTXcfmrAD4j/media/?size=l
 photo.1.author: nakacchi_desu

--- a/media/japan/0026_akita-oomoriyama/kenta-sayuri.txt
+++ b/media/japan/0026_akita-oomoriyama/kenta-sayuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.kenta-sayuri
+commitdate: 2019/9/21
 panda.tags: 212, 213
 photo.1: https://www.instagram.com/p/B2ZPLxUB8rA/media/?size=m
 photo.1.author: craig_craig_craig

--- a/media/japan/0026_akita-oomoriyama/sayuri-yuri.txt
+++ b/media/japan/0026_akita-oomoriyama/sayuri-yuri.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.26.sayuri-yuri
+commitdate: 2019/6/1
 panda.tags: 213, 214
 photo.1: https://www.instagram.com/p/ByEzYQ0Bt5V/media/?size=m
 photo.1.author: craig_craig_craig

--- a/media/japan/0027_rakujuen/kokoro-ruru.txt
+++ b/media/japan/0027_rakujuen/kokoro-ruru.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.27.kokoro-ruru
+commitdate: 2019/11/12
 panda.tags: 54, 55
 photo.1: https://www.instagram.com/p/B4pXcCOBwlX/media/?size=l
 photo.1.author: kisshan324

--- a/media/japan/0028_yuki-zoo/hokuto-kuu.txt
+++ b/media/japan/0028_yuki-zoo/hokuto-kuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.28.hokuto-kuu
+commitdate: 2020/4/12
 panda.tags: 58, 59
 photo.1: https://www.instagram.com/p/B-wwzRchr9o/media/?size=m
 photo.1.author: minatomirai215

--- a/media/japan/0029_adventure-world/jin-laila.txt
+++ b/media/japan/0029_adventure-world/jin-laila.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.29.jin-laila
+commitdate: 2020/4/15
 panda.tags: 60, 63
 photo.1: https://www.instagram.com/p/BYIop-qA-n0/media/?size=l
 photo.1.author: mifko55

--- a/media/japan/0029_adventure-world/laila-mugi.txt
+++ b/media/japan/0029_adventure-world/laila-mugi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.29.laila-mugi
+commitdate: 2019/8/23
 panda.tags: 60, 305
 photo.1: https://www.instagram.com/p/BqmJx72lQg7/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0029_adventure-world/maruru-shinshin.txt
+++ b/media/japan/0029_adventure-world/maruru-shinshin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.29.maruru-shinshin
+commitdate: 2020/2/16
 panda.tags: 62, 66
 photo.1: https://www.instagram.com/p/B7bEB0VBrSu/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0031_ishikawa/haru-sun.txt
+++ b/media/japan/0031_ishikawa/haru-sun.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.31.haru-sun
+commitdate: 2019/12/5
 panda.tags: 183, 201
 photo.1: https://www.instagram.com/p/B5g5p9ShNG7/media/?size=l
 photo.1.author: bee_san.13

--- a/media/japan/0031_ishikawa/marine-sumire.txt
+++ b/media/japan/0031_ishikawa/marine-sumire.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.31.marine-sumire
+commitdate: 2020/4/25
 panda.tags: 181, 182
 photo.1: https://www.instagram.com/p/B-_9MC8hB3C/media/?size=l
 photo.1.author: craig_craig_craig

--- a/media/japan/0032_fukuoka/marimo-nozomu.txt
+++ b/media/japan/0032_fukuoka/marimo-nozomu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.32.marimo-nozomu
+commitdate: 2019/8/21
 panda.tags: 74, 75
 photo.1: https://www.instagram.com/p/BukElvKlPzl/media/?size=l
 photo.1.author: yossi929

--- a/media/japan/0034_tohoku/chuihowa-rairai.txt
+++ b/media/japan/0034_tohoku/chuihowa-rairai.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.34.chuihowa-rairai
+commitdate: 2019/8/21
 panda.tags: 185, 206
 photo.1: https://www.instagram.com/p/B1OLfO4h-9d/media/?size=m
 photo.1.author: daniele.tokyo

--- a/media/japan/0034_tohoku/mulan-riirii.txt
+++ b/media/japan/0034_tohoku/mulan-riirii.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.34.mulan-riirii
+commitdate: 2019/10/24
 panda.tags: 205, 950
 photo.1: https://www.instagram.com/p/B30p08Ehv-H/media/?size=m
 photo.1.author: rie_panda55

--- a/media/japan/0034_tohoku/riirii-shiryu.txt
+++ b/media/japan/0034_tohoku/riirii-shiryu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.34.riirii-shiryu
+commitdate: 2019/8/13
 panda.tags: 205, 207
 photo.1: https://www.instagram.com/p/BooOsOKlN-t/media/?size=m
 photo.1.author: daniele.tokyo

--- a/media/japan/0035_tokushima/minmin-sakura-yomogi.txt
+++ b/media/japan/0035_tokushima/minmin-sakura-yomogi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.35.minmin-sakura-yomogi
+commitdate: 2019/7/7
 panda.tags: 109, 203, 204
 photo.1: https://www.instagram.com/p/BzNuUFFhZAW/media/?size=m
 photo.1.author: leonard_redmof

--- a/media/japan/0036_kobe-oji/gaia-minfa.txt
+++ b/media/japan/0036_kobe-oji/gaia-minfa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.gaia-minfa
+commitdate: 2019/7/22
 panda.tags: 111, 165
 photo.1: https://www.instagram.com/p/B0LWchABtXb/media/?size=m
 photo.1.author: i.satosato

--- a/media/japan/0036_kobe-oji/gaia-nohana.txt
+++ b/media/japan/0036_kobe-oji/gaia-nohana.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.gaia-nohana
+commitdate: 2019/10/2
 panda.tags: 134, 165
 photo.1: https://www.instagram.com/p/B2vNuSPBWUa/media/?size=m
 photo.1.author: tomo3700

--- a/media/japan/0036_kobe-oji/jazz-melody-minfa.txt
+++ b/media/japan/0036_kobe-oji/jazz-melody-minfa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.jazz-melody-minfa
+commitdate: 2019/8/31
 panda.tags: 111, 166, 167
 photo.1: https://www.instagram.com/p/B1tcK1ABHGs/media/?size=l
 photo.1.author: i.satosato

--- a/media/japan/0036_kobe-oji/jazz-melody.txt
+++ b/media/japan/0036_kobe-oji/jazz-melody.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.jazz-melody
+commitdate: 2019/7/10
 panda.tags: 166, 167
 photo.1: https://www.instagram.com/p/Brbbzb_ljGa/media/?size=m
 photo.1.author: wumpwoast

--- a/media/japan/0036_kobe-oji/jazz-minfa.txt
+++ b/media/japan/0036_kobe-oji/jazz-minfa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.jazz-minfa
+commitdate: 2019/5/15
 panda.tags: 111, 166
 photo.1: https://www.instagram.com/p/Bd7NrUMDmUv/media/?size=m
 photo.1.author: colette.jp

--- a/media/japan/0036_kobe-oji/minfa-tiara.txt
+++ b/media/japan/0036_kobe-oji/minfa-tiara.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.36.minfa-tiara
+commitdate: 2020/5/23
 panda.tags: 111, 120
 photo.1: https://www.instagram.com/p/B_ZSW8QHXBN/media/?size=m
 photo.1.author: tomo3700

--- a/media/japan/0037_asahiyama/charmin-reirei-shoushou.txt
+++ b/media/japan/0037_asahiyama/charmin-reirei-shoushou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.37.charmin-reirei-shoushou
+commitdate: 2019/11/2
 panda.tags: 124, 225, 233
 photo.1: https://www.instagram.com/p/B4Ua1nJBsbs/media/?size=l
 photo.1.author: sasapan34

--- a/media/japan/0037_asahiyama/charmin-reirei.txt
+++ b/media/japan/0037_asahiyama/charmin-reirei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.37.charmin-reirei
+commitdate: 2019/10/20
 panda.tags: 124, 225
 photo.1: https://www.instagram.com/p/B3O96UyBqyP/media/?size=m
 photo.1.author: tama67photo

--- a/media/japan/0037_asahiyama/charmin-shoushou.txt
+++ b/media/japan/0037_asahiyama/charmin-shoushou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.37.charmin-shoushou
+commitdate: 2019/6/14
 panda.tags: 124, 233
 photo.1: https://www.instagram.com/p/BuD3RMvlm-U/media/?size=m
 photo.1.author: asahiyamazoo1

--- a/media/japan/0037_asahiyama/reirei-shoushou.txt
+++ b/media/japan/0037_asahiyama/reirei-shoushou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.37.reirei-shoushou
+commitdate: 2020/1/6
 panda.tags: 225, 233
 photo.1: https://www.instagram.com/p/B6r_y_aBHaS/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0037_asahiyama/riirii-taotao.txt
+++ b/media/japan/0037_asahiyama/riirii-taotao.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.37.riirii-taotao
+commitdate: 2019/7/9
 panda.tags: 235, 236
 photo.1: https://www.instagram.com/p/Bzb5SqVgI3U/media/?size=m
 photo.1.author: takahisakaneuchi

--- a/media/japan/0038_nogeyama/kenken-kinta.txt
+++ b/media/japan/0038_nogeyama/kenken-kinta.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.38.kenken-kinta
+commitdate: 2020/4/12
 panda.tags: 125, 126
 photo.1: https://www.instagram.com/p/BPoAEL7grhN/media/?size=l
 photo.1.author: tabechum

--- a/media/japan/0038_nogeyama/kinta-umi.txt
+++ b/media/japan/0038_nogeyama/kinta-umi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.38.kinta-umi
+commitdate: 2020/5/2
 panda.tags: 125, 368
 photo.1: https://www.instagram.com/p/B_aAUA9ncOM/media/?size=l
 photo.1.author: miis_98

--- a/media/japan/0040_hiroshima-city-asa/kaka-pupu-yuuyuu.txt
+++ b/media/japan/0040_hiroshima-city-asa/kaka-pupu-yuuyuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.kaka-pupu-yuuyuu
+commitdate: 2019/11/12
 panda.tags: 224, 994, 995
 photo.1: https://www.instagram.com/p/B4kLgY4BLYt/media/?size=l
 photo.1.author: nakacchi_desu

--- a/media/japan/0040_hiroshima-city-asa/kaka-pupu.txt
+++ b/media/japan/0040_hiroshima-city-asa/kaka-pupu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.kaka-pupu
+commitdate: 2019/11/18
 panda.tags: 994, 995
 photo.1: https://www.instagram.com/p/B3r0MVMAQpY/media/?size=m
 photo.1.author: nakacchi_desu

--- a/media/japan/0040_hiroshima-city-asa/kaka-yuuyuu.txt
+++ b/media/japan/0040_hiroshima-city-asa/kaka-yuuyuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.kaka-yuuyuu
+commitdate: 2020/5/9
 panda.tags: 227, 994
 photo.1: https://www.instagram.com/p/B8hXdQNBkPN/media/?size=l
 photo.1.author: kipekaila

--- a/media/japan/0040_hiroshima-city-asa/kiku-maru.txt
+++ b/media/japan/0040_hiroshima-city-asa/kiku-maru.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.kiku-maru
+commitdate: 2020/2/14
 panda.tags: 127, 237
 photo.1: https://www.instagram.com/p/BtgIxpRF1Fa/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0040_hiroshima-city-asa/kira-maru.txt
+++ b/media/japan/0040_hiroshima-city-asa/kira-maru.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.kira-maru
+commitdate: 2019/10/29
 panda.tags: 197, 237
 photo.1: https://www.instagram.com/p/B4La_1FBvbw/media/?size=m
 photo.1.author: resapanlove

--- a/media/japan/0040_hiroshima-city-asa/pupu-yuuyuu.txt
+++ b/media/japan/0040_hiroshima-city-asa/pupu-yuuyuu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.40.pupu-yuuyuu
+commitdate: 2019/11/29
 panda.tags: 224, 995
 photo.1: https://www.instagram.com/p/B5YwuHmhThf/media/?size=m
 photo.1.author: leonard_redmof

--- a/media/japan/0041_itozunomori/ashitaba-couscous.txt
+++ b/media/japan/0041_itozunomori/ashitaba-couscous.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.41.ashitaba-couscous
+commitdate: 2019/7/28
 panda.tags: 131, 295
 photo.1: https://www.instagram.com/p/BtiE79ylfPB/media/?size=m
 photo.1.author: yossi929

--- a/media/japan/0041_itozunomori/nohana-nokaze.txt
+++ b/media/japan/0041_itozunomori/nohana-nokaze.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.41.nohana-nokaze
+commitdate: 2019/5/15
 panda.tags: 133, 134
 photo.1: https://www.instagram.com/p/BcJ4WpHlinR/media/?size=m
 photo.1.author: yossi929

--- a/media/japan/0041_itozunomori/nokaze-rinrin.txt
+++ b/media/japan/0041_itozunomori/nokaze-rinrin.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.41.nokaze-rinrin
+commitdate: 2019/10/16
 panda.tags: 132, 133
 photo.1: https://www.instagram.com/p/B3mLZssBo_R/media/?size=m
 photo.1.author: re_ichimaru

--- a/media/japan/0042_akiyoshidai-safari-land/fuuka-nonoka.txt
+++ b/media/japan/0042_akiyoshidai-safari-land/fuuka-nonoka.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.42.fuuka-nonoka
+commitdate: 2019/6/23
 panda.tags: 257, 258
 photo.1: https://www.instagram.com/p/BbGAok9Aa1b/media/?size=m
 photo.1.author: peek_a_boo00

--- a/media/japan/0042_akiyoshidai-safari-land/haru-yuuka.txt
+++ b/media/japan/0042_akiyoshidai-safari-land/haru-yuuka.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.42.haru-yuuka
+commitdate: 2019/6/23
 panda.tags: 176, 201
 photo.1: https://www.instagram.com/p/BY9arfHDydX/media/?size=m
 photo.1.author: resapanlove

--- a/media/japan/0042_akiyoshidai-safari-land/hikaru-yao-yuuka.txt
+++ b/media/japan/0042_akiyoshidai-safari-land/hikaru-yao-yuuka.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.42.hikaru-yao-yuuka
+commitdate: 2019/7/20
 panda.tags: 176, 177, 178
 photo.1: https://www.instagram.com/p/BlP3_K1FDcB/media/?size=l
 photo.1.author: colette.jp

--- a/media/japan/0042_akiyoshidai-safari-land/hikaru-yao.txt
+++ b/media/japan/0042_akiyoshidai-safari-land/hikaru-yao.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.42.hikaru-yao
+commitdate: 2019/6/23
 panda.tags: 177, 178
 photo.1: https://www.instagram.com/p/BubUMEyFWmm/media/?size=m
 photo.1.author: animal_love_us

--- a/media/japan/0042_akiyoshidai-safari-land/ichiha-yuuka.txt
+++ b/media/japan/0042_akiyoshidai-safari-land/ichiha-yuuka.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.42.ichiha-yuuka
+commitdate: 2019/6/23
 panda.tags: 176, 260
 photo.1: https://www.instagram.com/p/BtScFM_ltOu/media/?size=m
 photo.1.author: animal_love_us

--- a/media/japan/0045_zoo-paradise-yagiyama/konatsu-kurumi.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/konatsu-kurumi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.konatsu-kurumi
+commitdate: 2020/6/8
 panda.tags: 160, 163
 photo.1: https://www.instagram.com/p/BWRAPxjBbRE/media/?size=m
 photo.1.author: tabechum

--- a/media/japan/0045_zoo-paradise-yagiyama/kurumi-natsume-yuzu.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/kurumi-natsume-yuzu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.kurumi-natsume-yuzu
+commitdate: 2019/10/20
 panda.tags: 160, 244, 245
 photo.1: https://www.instagram.com/p/Bw7DEH8l_nt/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0045_zoo-paradise-yagiyama/kurumi-natsume.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/kurumi-natsume.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.kurumi-natsume
+commitdate: 2020/2/23
 panda.tags: 160, 245
 photo.1: https://www.instagram.com/p/B8gNaXvBK4c/media/?size=m
 photo.1.author: ssc6105

--- a/media/japan/0045_zoo-paradise-yagiyama/kurumi-yuzu.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/kurumi-yuzu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.kurumi-yuzu
+commitdate: 2020/2/16
 panda.tags: 160, 244
 photo.1: https://www.instagram.com/p/B6DFXrkh3yW/media/?size=m
 photo.1.author: pink.b22

--- a/media/japan/0045_zoo-paradise-yagiyama/natsume-yuzu.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/natsume-yuzu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.natsume-yuzu
+commitdate: 2019/5/18
 panda.tags: 244, 245
 photo.1: https://www.instagram.com/p/Bt7NjNEFFjb/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0045_zoo-paradise-yagiyama/sumomo-yanyan.txt
+++ b/media/japan/0045_zoo-paradise-yagiyama/sumomo-yanyan.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.45.sumomo-yanyan
+commitdate: 2020/3/5
 panda.tags: 162, 164
 photo.1: https://www.instagram.com/p/B9IZg28hRht/media/?size=m
 photo.1.author: alto0908

--- a/media/japan/0046_tobe-zoo/koume-totomaru.txt
+++ b/media/japan/0046_tobe-zoo/koume-totomaru.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.46.koume-totomaru
+commitdate: 2019/12/7
 panda.tags: 159, 173
 photo.1: https://www.instagram.com/p/B5ncOfmhLhZ/media/?size=m
 photo.1.author: itsuak

--- a/media/japan/0046_tobe-zoo/koume-xianchi.txt
+++ b/media/japan/0046_tobe-zoo/koume-xianchi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.46.koume-xianchi
+commitdate: 2020/1/20
 panda.tags: 159, 172
 photo.1: https://www.instagram.com/p/B6dWwj7BRUQ/media/?size=m
 photo.1.author: itsuak

--- a/media/japan/0050_misaki-park/karin-luka.txt
+++ b/media/japan/0050_misaki-park/karin-luka.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.50.karin-luca
+commitdate: 2019/7/31
 panda.tags: 69, 194
 photo.1: https://www.instagram.com/p/BoeGgpWlQ2K/media/?size=m
 photo.1.author: makimaru18

--- a/media/japan/0053_nasu-animal-kingdom/daizu-gigi.txt
+++ b/media/japan/0053_nasu-animal-kingdom/daizu-gigi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.53.daizu-gigi
+commitdate: 2019/11/30
 panda.tags: 186, 187
 photo.1: https://www.instagram.com/p/B4_AnIdhqxH/media/?size=m
 photo.1.author: sasapan34

--- a/media/japan/0053_nasu-animal-kingdom/eisaku-ronron-yosaku.txt
+++ b/media/japan/0053_nasu-animal-kingdom/eisaku-ronron-yosaku.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.53.eisaku-ronron-yosaku
+commitdate: 2019/7/22
 panda.tags: 190, 344, 345
 photo.1: https://www.instagram.com/p/B0JNR65hon3/media/?size=l
 photo.1.author: panda.daisuki

--- a/media/japan/0053_nasu-animal-kingdom/eisaku-ronron.txt
+++ b/media/japan/0053_nasu-animal-kingdom/eisaku-ronron.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.53.eisaku-ronron
+commitdate: 2019/8/31
 panda.tags: 190, 344
 photo.1: https://www.instagram.com/p/B1tUhDhBw6M/media/?size=m
 photo.1.author: o_deka_ke

--- a/media/japan/0053_nasu-animal-kingdom/eisaku-yosaku.txt
+++ b/media/japan/0053_nasu-animal-kingdom/eisaku-yosaku.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.53.eisaku-yosaku
+commitdate: 2019/7/16
 panda.tags: 344, 345
 photo.1: https://www.instagram.com/p/Bz7TrSUh4gS/media/?size=m
 photo.1.author: grskus_tk

--- a/media/japan/0058_kobe-animal-kingdom/asahi-hina-suzu.txt
+++ b/media/japan/0058_kobe-animal-kingdom/asahi-hina-suzu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.58.asahi-hina-suzu
+commitdate: 2019/9/5
 panda.tags: 261, 262, 263
 photo.1: https://www.instagram.com/p/BHH2HYqDJVs/media/?size=m
 photo.1.author: minatomirai215

--- a/media/japan/0058_kobe-animal-kingdom/hina-suzu.txt
+++ b/media/japan/0058_kobe-animal-kingdom/hina-suzu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.58.hina-suzu
+commitdate: 2019/9/6
 panda.tags: 262, 263
 photo.1: https://www.instagram.com/p/BHlPpicD5i5/media/?size=m
 photo.1.author: minatomirai215

--- a/media/japan/0059_bananawani/akatsuki-akebono-asahi.txt
+++ b/media/japan/0059_bananawani/akatsuki-akebono-asahi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.59.akatsuki-akebono-asahi
+commitdate: 2019/8/29
 panda.tags: 317, 318, 319
 photo.1: https://www.instagram.com/p/BsE_UQklTc6/media/?size=l
 photo.1.author: bananawani_official

--- a/media/japan/0059_bananawani/akebono-asahi.txt
+++ b/media/japan/0059_bananawani/akebono-asahi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.59.akebono-asahi
+commitdate: 2020/1/9
 panda.tags: 317, 318
 photo.1: https://www.instagram.com/p/BsVSV04F7nc/media/?size=l
 photo.1.author: minatomirai215

--- a/media/japan/0059_bananawani/kagayaki-tsubasa.txt
+++ b/media/japan/0059_bananawani/kagayaki-tsubasa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.59.kagayaki-tsubasa
+commitdate: 2019/10/13
 panda.tags: 277, 278
 photo.1: https://www.instagram.com/p/Bcg-PEQFCi4/media/?size=m
 photo.1.author: fetorus_mami

--- a/media/japan/0059_bananawani/mitsuba-yotsuba.txt
+++ b/media/japan/0059_bananawani/mitsuba-yotsuba.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.59.mitsuba-yotsuba
+commitdate: 2019/10/31
 panda.tags: 275, 276
 photo.1: https://www.instagram.com/p/Bc53IX8lOCY/media/?size=m
 photo.1.author: fetorus_mami

--- a/media/japan/0060_noichi-zoological-park/kai-kai.txt
+++ b/media/japan/0060_noichi-zoological-park/kai-kai.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.60.kai-kai
+commitdate: 2019/6/20
 panda.tags: 280, 281
 photo.1: https://www.instagram.com/p/Bz0GpdiBrSI/media/?size=m
 photo.1.author: yossi929

--- a/media/japan/0060_noichi-zoological-park/maron-mitarashi.txt
+++ b/media/japan/0060_noichi-zoological-park/maron-mitarashi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.60.maron-mitarashi
+commitdate: 2019/9/19
 panda.tags: 282, 283
 photo.1: https://www.instagram.com/p/B2jUQkthgTe/media/?size=m
 photo.1.author: love__mitarashi

--- a/media/japan/0061_fukuchiyama-zoo/cara-mitsu.txt
+++ b/media/japan/0061_fukuchiyama-zoo/cara-mitsu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.61.cara-mitsu
+commitdate: 2019/10/22
 panda.tags: 284, 286
 photo.1: https://www.instagram.com/p/B3vk7yLBlFf/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0061_fukuchiyama-zoo/hide-mitsu-shiratama.txt
+++ b/media/japan/0061_fukuchiyama-zoo/hide-mitsu-shiratama.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.61.hide-mitsu-shiratama
+commitdate: 2020/5/1
 panda.tags: 184, 285, 286
 photo.1: https://www.instagram.com/p/B_gJ1SaHRVn/media/?size=l
 photo.1.author: tomo3700

--- a/media/japan/0061_fukuchiyama-zoo/hide-mitsu.txt
+++ b/media/japan/0061_fukuchiyama-zoo/hide-mitsu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.61.hide-mitsu
+commitdate: 2019/6/22
 panda.tags: 184, 286
 photo.1: https://www.instagram.com/p/By-eGqIBpmp/media/?size=m
 photo.1.author: love__mitarashi

--- a/media/japan/0061_fukuchiyama-zoo/reimei-shiratama.txt
+++ b/media/japan/0061_fukuchiyama-zoo/reimei-shiratama.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.61.reimei-shiratama
+commitdate: 2019/10/22
 panda.tags: 285, 959
 photo.1: https://www.instagram.com/p/B3T9yfuh0Dr/media/?size=m
 photo.1.author: framereim

--- a/media/japan/0063_toyama-zoo/anko-kazu-rei.txt
+++ b/media/japan/0063_toyama-zoo/anko-kazu-rei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.63.anko-kazu-rei
+commitdate: 2019/12/3
 panda.tags: 289, 946, 947
 photo.1: https://www.instagram.com/p/B4zXxdlhUiR/media/?size=l
 photo.1.author: framereim

--- a/media/japan/0063_toyama-zoo/anko-kazu.txt
+++ b/media/japan/0063_toyama-zoo/anko-kazu.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.63.anko-kazu
+commitdate: 2020/3/21
 panda.tags: 289, 947
 photo.1: https://www.instagram.com/p/B9Ot8KLBL7P/media/?size=l
 photo.1.author: kinkinkin0826

--- a/media/japan/0063_toyama-zoo/kazu-rei.txt
+++ b/media/japan/0063_toyama-zoo/kazu-rei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.63.rei-kazu
+commitdate: 2019/12/1
 panda.tags: 946, 947
 photo.1: https://www.instagram.com/p/B3en7Qjh1Z2/media/?size=m
 photo.1.author: mikaamihara

--- a/media/japan/0064_oshima-park/ashitaba-asunaro.txt
+++ b/media/japan/0064_oshima-park/ashitaba-asunaro.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.64.ashitaba-asunaro
+commitdate: 2019/7/10
 panda.tags: 294, 295
 photo.1: https://www.instagram.com/p/BzoheiIhDZn/media/?size=m
 photo.1.author: craig_craig_craig

--- a/media/japan/0064_oshima-park/ginga-tsubaki.txt
+++ b/media/japan/0064_oshima-park/ginga-tsubaki.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.64.ginga-tsubaki
+commitdate: 2020/4/29
 panda.tags: 293, 297
 photo.1: https://www.instagram.com/p/Bfb9bpZh_T9/media/?size=l
 photo.1.author: miis_98

--- a/media/japan/0069_hamura-zoo/latte-sora.txt
+++ b/media/japan/0069_hamura-zoo/latte-sora.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.69.latte-sora
+commitdate: 2020/3/17
 panda.tags: 315, 347
 photo.1: https://www.instagram.com/p/B9ok1s8hEex/media/?size=m
 photo.1.author: ifumoto88

--- a/media/japan/0073_edogawa-zoo/buna-youyou.txt
+++ b/media/japan/0073_edogawa-zoo/buna-youyou.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.73.buna-youyou
+commitdate: 2019/10/12
 panda.tags: 336, 337
 photo.1: https://www.instagram.com/p/3M-yLnPi8Q/media/?size=l
 photo.1.author: panda.daisuki

--- a/media/japan/0143_izu-shaboten-zoo/konatsu-yomogi.txt
+++ b/media/japan/0143_izu-shaboten-zoo/konatsu-yomogi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.143.konatsu-yomogi
+commitdate: 2019/7/9
 panda.tags: 163, 203
 photo.1: https://www.instagram.com/p/Bwgu_8DlxZD/media/?size=m
 photo.1.author: panda.daisuki

--- a/media/japan/0143_izu-shaboten-zoo/meixiang-nonta.txt
+++ b/media/japan/0143_izu-shaboten-zoo/meixiang-nonta.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.143.meixiang-nonta
+commitdate: 2020/3/19
 panda.tags: 121, 140
 photo.1: https://www.instagram.com/p/B9ywJQJh9iF/media/?size=m
 photo.1.author: ifumoto88

--- a/media/new-zealand/0203_auckland-zoo/khela-ramesh-tashi.txt
+++ b/media/new-zealand/0203_auckland-zoo/khela-ramesh-tashi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.203.khela-ramesh-tashi
+commitdate: 2019/8/24
 panda.tags: 965, 974, 975
 photo.1: https://www.instagram.com/p/BvUto_fAlSd/media/?size=l
 photo.1.author: aucklandzoo

--- a/media/new-zealand/0203_auckland-zoo/khela-tashi.txt
+++ b/media/new-zealand/0203_auckland-zoo/khela-tashi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.203.khela-tashi
+commitdate: 2019/8/24
 panda.tags: 965, 974
 photo.1: https://www.instagram.com/p/BxVkdWIAbdU/media/?size=m
 photo.1.author: aucklandzoo

--- a/media/new-zealand/0204_wellington-zoo/khusi-ngima.txt
+++ b/media/new-zealand/0204_wellington-zoo/khusi-ngima.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.204.khusi-ngima
+commitdate: 2019/8/24
 panda.tags: 966, 985
 photo.1: https://www.instagram.com/p/BqLQAoqhj2R/media/?size=m
 photo.1.author: kiwizookeeper

--- a/media/spain/0245_loro-parque/annapurna-posee.txt
+++ b/media/spain/0245_loro-parque/annapurna-posee.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.245.annapurna-posee
+commitdate: 2020/5/15
 panda.tags: 1154, 1155
 photo.1: https://www.instagram.com/p/B9WsyjNDLTg/media/?size=m
 photo.1.author: loroparque

--- a/media/sweden/0246_kolmarden/pandora-pimpim.txt
+++ b/media/sweden/0246_kolmarden/pandora-pimpim.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.246.pandora-pimpim
+commitdate: 2020/5/6
 panda.tags: 1156, 1160
 photo.1: https://www.instagram.com/p/8NPJaekG_L/media/?size=m
 photo.1.author: kolmardensjurpark

--- a/media/united-kingdom/0135_zsl-whipsnade/blue-tashi.txt
+++ b/media/united-kingdom/0135_zsl-whipsnade/blue-tashi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.135.blue-tashi
+commitdate: 2019/10/19
 panda.tags: 537, 538
 photo.1: https://www.instagram.com/p/BGP4TzhDLYN/media/?size=m
 photo.1.author: cheryl_2303

--- a/media/united-kingdom/0137_colchester-zoo/kalaiya-kamala.txt
+++ b/media/united-kingdom/0137_colchester-zoo/kalaiya-kamala.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.137.kalaiya-kamala
+commitdate: 2019/10/25
 panda.tags: 996, 997
 photo.1: https://www.instagram.com/p/B4C_vGvBi0A/media/?size=m
 photo.1.author: wumpwoast

--- a/media/united-kingdom/0213_highland-wildlife-park/pokhara-shimla.txt
+++ b/media/united-kingdom/0213_highland-wildlife-park/pokhara-shimla.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.213.pokhara-shimla
+commitdate: 2019/11/2
 panda.tags: 1013, 1014
 photo.1: https://scontent.fybz1-1.fna.fbcdn.net/v/t1.0-9/50705118_10156698979416708_3443977379507077120_n.jpg?_nc_cat=100&_nc_oc=AQka7K_-sFAWy8eH54Ipo3jrsq7NPAf77kEN62d9WB0ylttA3VlyLWnc-3sgaQ_rW2c&_nc_ht=scontent.fybz1-1.fna&oh=d6153478e33330ea761384bd9f862146&oe=5E183A39
 photo.1.author: Alison McTavish

--- a/media/united-states/0065_cincinnati-zoo/audra-lenore.txt
+++ b/media/united-states/0065_cincinnati-zoo/audra-lenore.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.65.audra-lenore
+commitdate: 2020/1/3
 panda.tags: 1001, 1002
 photo.1: https://www.instagram.com/p/B3LHiLmowqM/media/?size=l
 photo.1.author: cincinnatizoo

--- a/media/united-states/0065_cincinnati-zoo/kola-kora-linus.txt
+++ b/media/united-states/0065_cincinnati-zoo/kola-kora-linus.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.65.kola-kora-linus
+commitdate: 2020/1/3
 panda.tags: 434, 999, 1000
 photo.1: https://www.instagram.com/p/BpE1NHmD6Fb/media/?size=l
 photo.1.author: cincinnatizoo

--- a/media/united-states/0065_cincinnati-zoo/kora-lin-linus.txt
+++ b/media/united-states/0065_cincinnati-zoo/kora-lin-linus.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.65.kora-lin-linus
+commitdate: 2020/1/3
 panda.tags: 390, 999, 1000
 photo.1: https://www.instagram.com/p/BoZUIHKlxhy/media/?size=m
 photo.1.author: cincinnatizoo

--- a/media/united-states/0065_cincinnati-zoo/kora-linus.txt
+++ b/media/united-states/0065_cincinnati-zoo/kora-linus.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.65.kora-linus
+commitdate: 2020/2/28
 panda.tags: 999, 1000
 photo.1: https://www.instagram.com/p/BpwtCuKAMow/media/?size=m
 photo.1.author: cincinnatizoo

--- a/media/united-states/0067_woodland-park-zoo/hazel-ila.txt
+++ b/media/united-states/0067_woodland-park-zoo/hazel-ila.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.67.hazel-ila
+commitdate: 2019/6/21
 panda.tags: 323, 324
 photo.1: https://www.instagram.com/p/By9RvFKA6sc/media/?size=m
 photo.1.author: westcoast_kathy

--- a/media/united-states/0067_woodland-park-zoo/ila-zeya.txt
+++ b/media/united-states/0067_woodland-park-zoo/ila-zeya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.67.ila-zeya
+commitdate: 2019/6/21
 panda.tags: 324, 325
 photo.1: https://www.instagram.com/p/By5bYf3hW3H/media/?size=m
 photo.1.author: carsontheredpanda

--- a/media/united-states/0077_henry-vilas-zoo/tai-tarrei.txt
+++ b/media/united-states/0077_henry-vilas-zoo/tai-tarrei.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.77.tai-tarrei
+commitdate: 2020/3/8
 panda.tags: 354, 383
 photo.1: https://www.instagram.com/p/B4ugxqhjJFA/media/?size=m
 photo.1.author: henryvilaszoo

--- a/media/united-states/0080_lincoln-childrens-zoo/carson-willa.txt
+++ b/media/united-states/0080_lincoln-childrens-zoo/carson-willa.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.80.carson-willa
+commitdate: 2020/5/29
 panda.tags: 311, 527
 photo.1: https://www.instagram.com/p/B4BvniKBcZ6/media/?size=l
 photo.1.author: carsontheredpanda

--- a/media/united-states/0081_philadelphia-zoo/pingjing-yeren.txt
+++ b/media/united-states/0081_philadelphia-zoo/pingjing-yeren.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.81.pingjing-yeren
+commitdate: 2020/3/2
 panda.tags: 543, 544
 photo.1: https://www.instagram.com/p/Bax4DpQFKUL/media/?size=m
 photo.1.author: zooborns

--- a/media/united-states/0084_prospect-park-zoo/liu-qi-willow.txt
+++ b/media/united-states/0084_prospect-park-zoo/liu-qi-willow.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.84.liu-qi-willow
+commitdate: 2020/1/20
 panda.tags: 481, 1079, 1080
 photo.1: https://www.instagram.com/p/B6fw57kgYuZ/media/?size=l
 photo.1.author: prospectparkzoo

--- a/media/united-states/0092_utica-zoo/meilin-mingyue-xiabo.txt
+++ b/media/united-states/0092_utica-zoo/meilin-mingyue-xiabo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.92.meilin-mingyue-xiabo
+commitdate: 2020/2/29
 panda.tags: 493, 1082, 1083
 photo.1: https://www.instagram.com/p/B2XWNVMHcue/media/?size=m
 photo.1.author: uticazoo

--- a/media/united-states/0093_milwaukee-county-zoo/drerincurry-kiki.txt
+++ b/media/united-states/0093_milwaukee-county-zoo/drerincurry-kiki.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.93.drerincurry-kiki
+commitdate: 2020/6/7
 panda.tags: 392, 998
 photo.1: https://www.instagram.com/p/B_KhBWOj7Rr/media/?size=l
 photo.1.author: milwaukeecozoo

--- a/media/united-states/0104_potawatomi-zoo/justin-maiya.txt
+++ b/media/united-states/0104_potawatomi-zoo/justin-maiya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.104.justin-maiya
+commitdate: 2020/5/9
 panda.tags: 553, 820
 photo.1: https://www.instagram.com/p/B4YKCwnnvKb/media/?size=l
 photo.1.author: potawatomizoo

--- a/media/united-states/0108_zoo-knoxville/ahsa-vali.txt
+++ b/media/united-states/0108_zoo-knoxville/ahsa-vali.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.108.ahsa-vali
+commitdate: 2020/1/2
 panda.tags: 1074, 1075
 photo.1: https://www.instagram.com/p/B5gCpbGBMPQ/media/?size=m
 photo.1.author: worldthathesees

--- a/media/united-states/0108_zoo-knoxville/marvin-tia.txt
+++ b/media/united-states/0108_zoo-knoxville/marvin-tia.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.108.marvin-tia
+commitdate: 2019/12/4
 panda.tags: 468, 1076
 photo.1: https://www.instagram.com/p/B5g6rqZBt5W/media/?size=m
 photo.1.author: worldthathesees

--- a/media/united-states/0108_zoo-knoxville/tia-vali.txt
+++ b/media/united-states/0108_zoo-knoxville/tia-vali.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.108.tia-vali
+commitdate: 2020/1/2
 panda.tags: 1074, 1076
 photo.1: https://www.instagram.com/p/B5g7IW_BADs/media/?size=m
 photo.1.author: worldthathesees

--- a/media/united-states/0116_miller-park-zoo/burma-china-kashmir.txt
+++ b/media/united-states/0116_miller-park-zoo/burma-china-kashmir.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.116.burma-china-kashmir
+commitdate: 2020/3/13
 panda.tags: 1127, 1128, 1129
 photo.1: https://www.instagram.com/p/B2g194zl-7T/media/?size=l
 photo.1.author: millerparkzoo

--- a/media/united-states/0116_miller-park-zoo/china-kashmir-masala.txt
+++ b/media/united-states/0116_miller-park-zoo/china-kashmir-masala.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.116.china-kashmir-masala
+commitdate: 2020/3/13
 panda.tags: 536, 1127, 1128
 photo.1: https://www.instagram.com/p/B3NT4E5htxk/media/?size=l
 photo.1.author: millerparkzoo

--- a/media/united-states/0116_miller-park-zoo/china-kashmir.txt
+++ b/media/united-states/0116_miller-park-zoo/china-kashmir.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.116.china-kashmir
+commitdate: 2020/3/13
 panda.tags: 1127, 1128
 photo.1: https://www.instagram.com/p/B4hsXg-F2L1/media/?size=m
 photo.1.author: millerparkzoo

--- a/media/united-states/0116_miller-park-zoo/ernie-princesslily.txt
+++ b/media/united-states/0116_miller-park-zoo/ernie-princesslily.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.116.ernie-princesslily
+commitdate: 2019/12/5
 panda.tags: 575, 642
 photo.1: https://www.instagram.com/p/BYLngjEhcAd/media/?size=l
 photo.1.author: millerparkzoo

--- a/media/united-states/0118_greenville-zoo/anne-frank.txt
+++ b/media/united-states/0118_greenville-zoo/anne-frank.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.118.anne-frank
+commitdate: 2020/1/25
 panda.tags: 991, 993
 photo.1: https://www.instagram.com/p/BynmNy0gU3P/media/?size=m
 photo.1.author: greenvilleaazk

--- a/media/united-states/0120_franklin-park-zoo/banli-nisha.txt
+++ b/media/united-states/0120_franklin-park-zoo/banli-nisha.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.120.banli-nisha
+commitdate: 2020/1/16
 panda.tags: 462, 484
 photo.1: https://www.instagram.com/p/Bt1Iy4lAQPP/media/?size=m
 photo.1.author: zoonewengland

--- a/media/united-states/0120_franklin-park-zoo/fia-hoppy.txt
+++ b/media/united-states/0120_franklin-park-zoo/fia-hoppy.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.120.fia-hoppy
+commitdate: 2020/2/16
 panda.tags: 513, 653
 photo.1: https://www.instagram.com/p/B2rIuhaH8zR/media/?size=m
 photo.1.author: zoonewengland

--- a/media/united-states/0120_franklin-park-zoo/fia-priya.txt
+++ b/media/united-states/0120_franklin-park-zoo/fia-priya.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.120.fia-priya
+commitdate: 2019/8/2
 panda.tags: 653, 936
 photo.1: https://www.instagram.com/p/B0Mr495lRxM/media/?size=m
 photo.1.author: toxicsoul666

--- a/media/united-states/0121_zoo-boise/dolly-jerry-joanie.txt
+++ b/media/united-states/0121_zoo-boise/dolly-jerry-joanie.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.121.dolly-jerry-joanie
+commitdate: 2020/3/21
 panda.tags: 819, 1138, 1139
 photo.1: https://www.instagram.com/p/B29wL-6nLeT/media/?size=l
 photo.1.author: zooboise

--- a/media/united-states/0121_zoo-boise/jerry-joanie.txt
+++ b/media/united-states/0121_zoo-boise/jerry-joanie.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.121.jerry-joanie
+commitdate: 2020/3/21
 panda.tags: 1138, 1139
 photo.1: https://www.instagram.com/p/B2mS4EInNLm/media/?size=l
 photo.1.author: zooboise

--- a/media/united-states/0124_detroit-zoological-society/ash-ravi.txt
+++ b/media/united-states/0124_detroit-zoological-society/ash-ravi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.124.ash-ravi
+commitdate: 2019/12/2
 panda.tags: 654, 854
 photo.1: https://www.instagram.com/p/B3R_HA-HN6_/media/?size=l
 photo.1.author: detroitzoo

--- a/media/united-states/0134_sequoia-park-zoo/cinni-sumo.txt
+++ b/media/united-states/0134_sequoia-park-zoo/cinni-sumo.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.134.cinni-sumo
+commitdate: 2019/6/20
 panda.tags: 533, 535
 photo.1: https://www.instagram.com/p/BHnj25MBXWY/media/?size=m
 photo.1.author: sequoiaparkzoo

--- a/media/united-states/0146_oklahoma-city-zoo/khyana-leela-ravi.txt
+++ b/media/united-states/0146_oklahoma-city-zoo/khyana-leela-ravi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.146.khyana-leela-ravi
+commitdate: 2019/10/15
 panda.tags: 847, 877, 878
 photo.1: https://www.instagram.com/p/B2l-VTwA6eO/media/?size=m
 photo.1.author: okczoo

--- a/media/united-states/0146_oklahoma-city-zoo/khyana-leela.txt
+++ b/media/united-states/0146_oklahoma-city-zoo/khyana-leela.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.146.khyana-leela
+commitdate: 2020/5/23
 panda.tags: 847, 877
 photo.1: https://www.instagram.com/p/B54G9Z3AWqs/media/?size=m
 photo.1.author: mandalaybay22

--- a/media/united-states/0146_oklahoma-city-zoo/khyana-ravi.txt
+++ b/media/united-states/0146_oklahoma-city-zoo/khyana-ravi.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.146.khyana-ravi
+commitdate: 2019/10/15
 panda.tags: 877, 878
 photo.1: https://www.instagram.com/p/BzOpAzQHt-l/media/?size=l
 photo.1.author: okczoo

--- a/media/united-states/0148_buttonwood-park-zoo/jacob-marie.txt
+++ b/media/united-states/0148_buttonwood-park-zoo/jacob-marie.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.148.jacob-marie
+commitdate: 2019/10/12
 panda.tags: 581, 992
 photo.1: https://www.instagram.com/p/B1rG6SzhSY4/media/?size=m
 photo.1.author: buttonwoodparkzoo

--- a/media/united-states/0153_mesker-park-zoo/aurora-xena.txt
+++ b/media/united-states/0153_mesker-park-zoo/aurora-xena.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.153.aurora-xena
+commitdate: 2019/12/2
 panda.tags: 1072, 1073
 photo.1: https://www.instagram.com/p/B5cwPA3BgNy/media/?size=m
 photo.1.author: worldthathesees

--- a/media/united-states/0157_turtle-back-zoo/jingli-sebastian.txt
+++ b/media/united-states/0157_turtle-back-zoo/jingli-sebastian.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.157.jingli-sebastian
+commitdate: 2020/3/5
 panda.tags: 672, 920
 photo.1: https://www.instagram.com/p/B2o8ER5lh5k/media/?size=m
 photo.1.author: officialturtlebackzoo

--- a/media/united-states/0160_pueblo-zoo/leela-yanhua.txt
+++ b/media/united-states/0160_pueblo-zoo/leela-yanhua.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.160.leela-yanhua
+commitdate: 2020/1/23
 panda.tags: 633, 870
 photo.1: https://www.instagram.com/p/Bq3nMwTHpY7/media/?size=l
 photo.1.author: keepermerlo

--- a/media/united-states/0177_scovill-zoo/roji-xena.txt
+++ b/media/united-states/0177_scovill-zoo/roji-xena.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.177.roji-xena
+commitdate: 2019/12/7
 panda.tags: 861, 862
 photo.1: https://www.instagram.com/p/Bt3fhYZggix/media/?size=l
 photo.1.author: jimbowlingphoto

--- a/media/united-states/0186_cape-may-county-park-zoo/benjamin-luna.txt
+++ b/media/united-states/0186_cape-may-county-park-zoo/benjamin-luna.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.186.benjamin-luna
+commitdate: 2020/5/27
 panda.tags: 616, 806
 photo.1: https://www.codaworry.com/images/rpf/benjamin-luna-1-capemay.jpg
 photo.1.author: aimless_amos

--- a/media/united-states/0193_wnc-nature-center/leafa-phoenix.txt
+++ b/media/united-states/0193_wnc-nature-center/leafa-phoenix.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.193.leafa-phoenix
+commitdate: 2020/4/28
 panda.tags: 399, 400
 photo.1: https://www.instagram.com/p/B5oLo8pHCaK/media/?size=l
 photo.1.author: wncnaturecenter

--- a/media/united-states/0212_roosevelt-park-zoo/fred-george.txt
+++ b/media/united-states/0212_roosevelt-park-zoo/fred-george.txt
@@ -1,5 +1,6 @@
 [media]
 _id: media.212.fred-george
+commitdate: 2019/11/2
 panda.tags: 1006, 1007
 photo.1: https://www.instagram.com/p/ByJyBjmAdnz/media/?size=m
 photo.1.author: bhamzoo


### PR DESCRIPTION
Yet another gross change.

I started refactoring the code for checking if a panda was new or not, using commitdate fields per entity (not just per photo). Once I wrote the logic for using this, I had left out media files. As soon as the logic focused on commitdate and not diff.is_file_added, the media files were all "new files".

My solution involved adding commitdate fields for media entities as well, and making everything as consistent as I could. Think this is finally done, judging by the similarity of new redpanda.json files from the old ones.