### PR TITLE
Updates 1185 (Santi) and 1186 (Bandit) with names

### DIFF
--- a/pandas/united-states/0043_columbus-zoo/1185_santi.txt
+++ b/pandas/united-states/0043_columbus-zoo/1185_santi.txt
@@ -4,11 +4,11 @@ birthday: 2020/6/13
 birthplace: 43
 children: none
 commitdate: 2020/6/30
-en.name: Baby
+en.name: Santi
 en.nicknames: none
 en.othernames: none
 gender: f
-jp.name: 赤ちゃん
+jp.name: サンティ
 jp.nicknames: none
 jp.othernames: none
 language.order: en, jp

--- a/pandas/united-states/0043_columbus-zoo/1186_bandit.txt
+++ b/pandas/united-states/0043_columbus-zoo/1186_bandit.txt
@@ -4,11 +4,11 @@ birthday: 2020/6/13
 birthplace: 43
 children: none
 commitdate: 2020/6/30
-en.name: Baby
+en.name: Bandit
 en.nicknames: none
 en.othernames: none
 gender: m
-jp.name: 赤ちゃん
+jp.name: バンディット
 jp.nicknames: none
 jp.othernames: none
 language.order: en, jp


### PR DESCRIPTION
Updates and renames files

- 1185_baby.txt -> 1185_santi.txt (female panda cub)
- 1186_baby.txt -> 1186_bandit.txt (male panda cub)

> The red panda cubs have names! The female red panda cub, Santi (s-ahn-tea), which means peace in Nepali, was named by Terri Greenbaum & Ron Greenbaum, The Basement Doctor. The male red panda cub, Bandit, was named by long-time donors, choosing to remain anonymous.

[Source: ColumbusZoo Twitter. 2020.09.19](https://twitter.com/ColumbusZoo/status/1307318607941193729)
