### PR TITLE
New world bump

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -509,6 +509,7 @@ def update_ig_link(photo_uri):
     RPF JS code to identify the IG links that it needs to use the FB oembed API for.
     """
     if "https://www.instagram.com/p/" in photo_uri:
+        print(photo_uri)
         photo_split = photo_uri.split("/")
         shortcode = photo_split[4]
         size = photo_split[6].split("=")[1]

--- a/manage.py
+++ b/manage.py
@@ -307,6 +307,8 @@ def sort_ig_hashes(path):
             continue
         # Convert IG photo formats to use new event handler
         photo = update_ig_link(photo)
+        photo_list.set_field(photo_option, photo)
+        # If our updated photo link has an ig:// uri, do the moving
         if "ig://" in photo:
             # Track the photo and index as a tuple
             ig_photos.append([photo, photo_index])
@@ -509,7 +511,6 @@ def update_ig_link(photo_uri):
     RPF JS code to identify the IG links that it needs to use the FB oembed API for.
     """
     if "https://www.instagram.com/p/" in photo_uri:
-        print(photo_uri)
         photo_split = photo_uri.split("/")
         shortcode = photo_split[4]
         size = photo_split[6].split("=")[1]

--- a/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
+++ b/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
@@ -1,0 +1,10 @@
+[media]
+_id: media.61.cara-reimei
+panda.tags: 284, 959
+photo.1: https://www.instagram.com/p/CFhOR_KBYm7/media/?size=l
+photo.1.author: bubbles_octi
+photo.1.link: https://www.instagram.com/bubbles_octi/
+photo.1.tags: father's day, playing, top-to-bottom
+photo.1.tags.284.location: 90, 30
+photo.1.tags.959.location: 80, 100
+uncertainty: photo.1 location exact pixel locations

--- a/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
+++ b/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
@@ -2,7 +2,7 @@
 _id: media.61.cara-reimei
 commitdate: 2020/10/25
 panda.tags: 284, 959
-photo.1: https://www.instagram.com/p/CFhOR_KBYm7/media/?size=l
+photo.1: ig://CFhOR_KBYm7/l
 photo.1.author: bubbles_octi
 photo.1.commitdate: 2020/10/25
 photo.1.link: https://www.instagram.com/bubbles_octi/

--- a/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
+++ b/media/japan/0061_fukuchiyama-zoo/cara-reimei.txt
@@ -1,8 +1,10 @@
 [media]
 _id: media.61.cara-reimei
+commitdate: 2020/10/25
 panda.tags: 284, 959
 photo.1: https://www.instagram.com/p/CFhOR_KBYm7/media/?size=l
 photo.1.author: bubbles_octi
+photo.1.commitdate: 2020/10/25
 photo.1.link: https://www.instagram.com/bubbles_octi/
 photo.1.tags: father's day, playing, top-to-bottom
 photo.1.tags.284.location: 90, 30

--- a/pandas/japan/0004_yumemigasaki/0027_ann.txt
+++ b/pandas/japan/0004_yumemigasaki/0027_ann.txt
@@ -219,6 +219,10 @@ photo.41.author: miis_98
 photo.41.commitdate: 2020/9/26
 photo.41.link: https://www.instagram.com/miis_98/
 photo.41.tags: portrait
+photo.42: https://www.instagram.com/p/CGieC3nBvQr/media/?size=m
+photo.42.author: ssc6105
+photo.42.link: https://www.instagram.com/ssc6105/
+photo.42.tags: paws, tail
 species: 2
 studbook.id: 1094
 zoo: 4

--- a/pandas/japan/0004_yumemigasaki/0027_ann.txt
+++ b/pandas/japan/0004_yumemigasaki/0027_ann.txt
@@ -221,6 +221,7 @@ photo.41.link: https://www.instagram.com/miis_98/
 photo.41.tags: portrait
 photo.42: https://www.instagram.com/p/CGieC3nBvQr/media/?size=m
 photo.42.author: ssc6105
+photo.42.commitdate: 2020/10/25
 photo.42.link: https://www.instagram.com/ssc6105/
 photo.42.tags: paws, tail
 species: 2

--- a/pandas/japan/0004_yumemigasaki/0027_ann.txt
+++ b/pandas/japan/0004_yumemigasaki/0027_ann.txt
@@ -219,7 +219,7 @@ photo.41.author: miis_98
 photo.41.commitdate: 2020/9/26
 photo.41.link: https://www.instagram.com/miis_98/
 photo.41.tags: portrait
-photo.42: https://www.instagram.com/p/CGieC3nBvQr/media/?size=m
+photo.42: ig://CGieC3nBvQr/m
 photo.42.author: ssc6105
 photo.42.commitdate: 2020/10/25
 photo.42.link: https://www.instagram.com/ssc6105/

--- a/pandas/japan/0011_kushiro/0024_shingen.txt
+++ b/pandas/japan/0011_kushiro/0024_shingen.txt
@@ -446,7 +446,7 @@ photo.87.author: an920000
 photo.87.commitdate: 2020/9/27
 photo.87.link: https://www.instagram.com/an920000/
 photo.87.tags: bamboo, home, laying down, portrait
-photo.88: https://www.instagram.com/p/CGuaPvjhh3y/media/?size=m
+photo.88: ig://CGuaPvjhh3y/m
 photo.88.author: minatomirai215
 photo.88.commitdate: 2020/10/25
 photo.88.link: https://www.instagram.com/minatomirai215/

--- a/pandas/japan/0011_kushiro/0024_shingen.txt
+++ b/pandas/japan/0011_kushiro/0024_shingen.txt
@@ -446,6 +446,10 @@ photo.87.author: an920000
 photo.87.commitdate: 2020/9/27
 photo.87.link: https://www.instagram.com/an920000/
 photo.87.tags: bamboo, home, laying down, portrait
+photo.88: https://www.instagram.com/p/CGuaPvjhh3y/media/?size=m
+photo.88.author: minatomirai215
+photo.88.link: https://www.instagram.com/minatomirai215/
+photo.88.tags: autumn, peek, portrait, tree
 species: 2
 studbook.id: 1195
 zoo: 11

--- a/pandas/japan/0011_kushiro/0024_shingen.txt
+++ b/pandas/japan/0011_kushiro/0024_shingen.txt
@@ -448,6 +448,7 @@ photo.87.link: https://www.instagram.com/an920000/
 photo.87.tags: bamboo, home, laying down, portrait
 photo.88: https://www.instagram.com/p/CGuaPvjhh3y/media/?size=m
 photo.88.author: minatomirai215
+photo.88.commitdate: 2020/10/25
 photo.88.link: https://www.instagram.com/minatomirai215/
 photo.88.tags: autumn, peek, portrait, tree
 species: 2

--- a/pandas/japan/0011_kushiro/0294_asunaro.txt
+++ b/pandas/japan/0011_kushiro/0294_asunaro.txt
@@ -404,6 +404,10 @@ photo.78.author: an920000
 photo.78.commitdate: 2020/10/1
 photo.78.link: https://www.instagram.com/an920000/
 photo.78.tags: bridge, portrait
+photo.79: https://www.instagram.com/p/CGws4XXhLLB/media/?size=m
+photo.79.author: minatomirai215
+photo.79.link: https://www.instagram.com/minatomirai215/
+photo.79.tags: autumn, portrait, smile
 species: 2
 studbook.id: 1681
 zoo: 11

--- a/pandas/japan/0011_kushiro/0294_asunaro.txt
+++ b/pandas/japan/0011_kushiro/0294_asunaro.txt
@@ -404,7 +404,7 @@ photo.78.author: an920000
 photo.78.commitdate: 2020/10/1
 photo.78.link: https://www.instagram.com/an920000/
 photo.78.tags: bridge, portrait
-photo.79: https://www.instagram.com/p/CGws4XXhLLB/media/?size=m
+photo.79: ig://CGws4XXhLLB/m
 photo.79.author: minatomirai215
 photo.79.commitdate: 2020/10/25
 photo.79.link: https://www.instagram.com/minatomirai215/

--- a/pandas/japan/0011_kushiro/0294_asunaro.txt
+++ b/pandas/japan/0011_kushiro/0294_asunaro.txt
@@ -406,6 +406,7 @@ photo.78.link: https://www.instagram.com/an920000/
 photo.78.tags: bridge, portrait
 photo.79: https://www.instagram.com/p/CGws4XXhLLB/media/?size=m
 photo.79.author: minatomirai215
+photo.79.commitdate: 2020/10/25
 photo.79.link: https://www.instagram.com/minatomirai215/
 photo.79.tags: autumn, portrait, smile
 species: 2

--- a/pandas/japan/0018_tobu/0037_genta.txt
+++ b/pandas/japan/0018_tobu/0037_genta.txt
@@ -358,6 +358,10 @@ photo.69.author: panda.daisuki
 photo.69.commitdate: 2020/10/1
 photo.69.link: https://www.instagram.com/panda.daisuki/
 photo.69.tags: paws, portrait, smile
+photo.70: https://www.instagram.com/p/CGcF4MHhGXM/media/?size=m
+photo.70.author: pink.b22
+photo.70.link: https://www.instagram.com/pink.b22/
+photo.70.tags: portrait, smile, tail
 species: 2
 studbook.id: 12105
 zoo: 18

--- a/pandas/japan/0018_tobu/0037_genta.txt
+++ b/pandas/japan/0018_tobu/0037_genta.txt
@@ -358,7 +358,7 @@ photo.69.author: panda.daisuki
 photo.69.commitdate: 2020/10/1
 photo.69.link: https://www.instagram.com/panda.daisuki/
 photo.69.tags: paws, portrait, smile
-photo.70: https://www.instagram.com/p/CGcF4MHhGXM/media/?size=m
+photo.70: ig://CGcF4MHhGXM/m
 photo.70.author: pink.b22
 photo.70.commitdate: 2020/10/25
 photo.70.link: https://www.instagram.com/pink.b22/

--- a/pandas/japan/0018_tobu/0037_genta.txt
+++ b/pandas/japan/0018_tobu/0037_genta.txt
@@ -360,6 +360,7 @@ photo.69.link: https://www.instagram.com/panda.daisuki/
 photo.69.tags: paws, portrait, smile
 photo.70: https://www.instagram.com/p/CGcF4MHhGXM/media/?size=m
 photo.70.author: pink.b22
+photo.70.commitdate: 2020/10/25
 photo.70.link: https://www.instagram.com/pink.b22/
 photo.70.tags: portrait, smile, tail
 species: 2

--- a/pandas/japan/0023_fuji/0122_rairai.txt
+++ b/pandas/japan/0023_fuji/0122_rairai.txt
@@ -141,6 +141,7 @@ photo.25.link: https://www.instagram.com/mini_cochi/
 photo.25.tags: peek, portrait
 photo.26: https://www.instagram.com/p/CGxLhq4B_wq/media/?size=m
 photo.26.author: miis_98
+photo.26.commitdate: 2020/10/25
 photo.26.link: https://www.instagram.com/miis_98/
 photo.26.tags: bamboo, home, paws, smile
 species: 2

--- a/pandas/japan/0023_fuji/0122_rairai.txt
+++ b/pandas/japan/0023_fuji/0122_rairai.txt
@@ -139,6 +139,10 @@ photo.25.author: mini_cochi
 photo.25.commitdate: 2020/8/17
 photo.25.link: https://www.instagram.com/mini_cochi/
 photo.25.tags: peek, portrait
+photo.26: https://www.instagram.com/p/CGxLhq4B_wq/media/?size=m
+photo.26.author: miis_98
+photo.26.link: https://www.instagram.com/miis_98/
+photo.26.tags: bamboo, home, paws, smile
 species: 2
 studbook.id: 0867
 zoo: 23

--- a/pandas/japan/0023_fuji/0122_rairai.txt
+++ b/pandas/japan/0023_fuji/0122_rairai.txt
@@ -139,7 +139,7 @@ photo.25.author: mini_cochi
 photo.25.commitdate: 2020/8/17
 photo.25.link: https://www.instagram.com/mini_cochi/
 photo.25.tags: peek, portrait
-photo.26: https://www.instagram.com/p/CGxLhq4B_wq/media/?size=m
+photo.26: ig://CGxLhq4B_wq/m
 photo.26.author: miis_98
 photo.26.commitdate: 2020/10/25
 photo.26.link: https://www.instagram.com/miis_98/

--- a/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
+++ b/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
@@ -85,7 +85,7 @@ photo.15.author: fetorus_mami
 photo.15.commitdate: 2020/5/2
 photo.15.link: https://www.instagram.com/fetorus_mami/
 photo.15.tags: grooming
-photo.16: https://www.instagram.com/p/CGw2oNkhbwi/media/?size=m
+photo.16: ig://CGw2oNkhbwi/m
 photo.16.author: ssc6105
 photo.16.commitdate: 2020/10/25
 photo.16.link: https://www.instagram.com/ssc6105/

--- a/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
+++ b/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
@@ -85,6 +85,10 @@ photo.15.author: fetorus_mami
 photo.15.commitdate: 2020/5/2
 photo.15.link: https://www.instagram.com/fetorus_mami/
 photo.15.tags: grooming
+photo.16: https://www.instagram.com/p/CGw2oNkhbwi/media/?size=m
+photo.16.author: ssc6105
+photo.16.link: https://www.instagram.com/ssc6105/
+photo.16.tags: laying down, paws, whiskers
 species: 2
 studbook.id: 14156
 zoo: 33

--- a/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
+++ b/pandas/japan/0033_ichihara-zonokuni/0300_ichiro.txt
@@ -87,6 +87,7 @@ photo.15.link: https://www.instagram.com/fetorus_mami/
 photo.15.tags: grooming
 photo.16: https://www.instagram.com/p/CGw2oNkhbwi/media/?size=m
 photo.16.author: ssc6105
+photo.16.commitdate: 2020/10/25
 photo.16.link: https://www.instagram.com/ssc6105/
 photo.16.tags: laying down, paws, whiskers
 species: 2

--- a/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
+++ b/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
@@ -199,17 +199,17 @@ photo.37.author: sakikukeco
 photo.37.commitdate: 2020/9/24
 photo.37.link: https://www.instagram.com/sakikukeco/
 photo.37.tags: ear, portrait
-photo.38: https://www.instagram.com/p/CGevJIhB3vZ/media/?size=m
+photo.38: ig://CGevJIhB3vZ/m
 photo.38.author: love__mitarashi
 photo.38.commitdate: 2020/10/25
 photo.38.link: https://www.instagram.com/love__mitarashi/
 photo.38.tags: ear, mofumofu, portrait, standing, whiskers
-photo.39: https://www.instagram.com/p/CGpcMKsh5bC/media/?size=m
+photo.39: ig://CGpcMKsh5bC/m
 photo.39.author: apple_jasmine33
 photo.39.commitdate: 2020/10/25
 photo.39.link: https://www.instagram.com/apple_jasmine33/
 photo.39.tags: close-up, ear, whiskers
-photo.40: https://www.instagram.com/p/CGvtDfXhfCK/media/?size=m
+photo.40: ig://CGvtDfXhfCK/m
 photo.40.author: redpanda_nippon_takashi
 photo.40.commitdate: 2020/10/25
 photo.40.link: https://www.instagram.com/redpanda_nippon_takashi/

--- a/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
+++ b/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
@@ -201,16 +201,19 @@ photo.37.link: https://www.instagram.com/sakikukeco/
 photo.37.tags: ear, portrait
 photo.38: https://www.instagram.com/p/CGevJIhB3vZ/media/?size=m
 photo.38.author: love__mitarashi
+photo.38.commitdate: 2020/10/25
 photo.38.link: https://www.instagram.com/love__mitarashi/
 photo.38.tags: ear, mofumofu, portrait, standing, whiskers
-photo.39: https://www.instagram.com/p/CGvtDfXhfCK/media/?size=m
-photo.39.author: redpanda_nippon_takashi
-photo.39.link: https://www.instagram.com/redpanda_nippon_takashi/
-photo.39.tags: ear, mofumofu, portrait, whiskers
-photo.40: https://www.instagram.com/p/CGpcMKsh5bC/media/?size=m
-photo.40.author: apple_jasmine33
-photo.40.link: https://www.instagram.com/apple_jasmine33/
-photo.40.tags: close-up, ear, whiskers
+photo.39: https://www.instagram.com/p/CGpcMKsh5bC/media/?size=m
+photo.39.author: apple_jasmine33
+photo.39.commitdate: 2020/10/25
+photo.39.link: https://www.instagram.com/apple_jasmine33/
+photo.39.tags: close-up, ear, whiskers
+photo.40: https://www.instagram.com/p/CGvtDfXhfCK/media/?size=m
+photo.40.author: redpanda_nippon_takashi
+photo.40.commitdate: 2020/10/25
+photo.40.link: https://www.instagram.com/redpanda_nippon_takashi/
+photo.40.tags: ear, mofumofu, portrait, whiskers
 species: 2
 studbook.id: 13165
 zoo: 61

--- a/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
+++ b/pandas/japan/0061_fukuchiyama-zoo/0284_cara.txt
@@ -199,6 +199,18 @@ photo.37.author: sakikukeco
 photo.37.commitdate: 2020/9/24
 photo.37.link: https://www.instagram.com/sakikukeco/
 photo.37.tags: ear, portrait
+photo.38: https://www.instagram.com/p/CGevJIhB3vZ/media/?size=m
+photo.38.author: love__mitarashi
+photo.38.link: https://www.instagram.com/love__mitarashi/
+photo.38.tags: ear, mofumofu, portrait, standing, whiskers
+photo.39: https://www.instagram.com/p/CGvtDfXhfCK/media/?size=m
+photo.39.author: redpanda_nippon_takashi
+photo.39.link: https://www.instagram.com/redpanda_nippon_takashi/
+photo.39.tags: ear, mofumofu, portrait, whiskers
+photo.40: https://www.instagram.com/p/CGpcMKsh5bC/media/?size=m
+photo.40.author: apple_jasmine33
+photo.40.link: https://www.instagram.com/apple_jasmine33/
+photo.40.tags: close-up, ear, whiskers
 species: 2
 studbook.id: 13165
 zoo: 61

--- a/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
+++ b/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
@@ -972,6 +972,22 @@ photo.194.author: rie_panda55
 photo.194.commitdate: 2020/9/21
 photo.194.link: https://www.instagram.com/rie_panda55/
 photo.194.tags: home, laying down, portrait
+photo.195: https://www.instagram.com/p/CGlwYhVhwUS/media/?size=m
+photo.195.author: wumpwoast
+photo.195.link: https://www.instagram.com/wumpwoast/
+photo.195.tags: portrait, whiskers
+photo.196: https://www.instagram.com/p/CGuQq1Uh5mP/media/?size=m
+photo.196.author: ssc6105
+photo.196.link: https://www.instagram.com/ssc6105/
+photo.196.tags: door, paws, whiskers
+photo.197: https://www.instagram.com/p/CGdXvK0hZR6/media/?size=m
+photo.197.author: ssc6105
+photo.197.link: https://www.instagram.com/ssc6105/
+photo.197.tags: keeper, paws, standing, tail
+photo.198: https://www.instagram.com/p/CGme7nqh8q9/media/?size=m
+photo.198.author: ssc6105
+photo.198.link: https://www.instagram.com/ssc6105/
+photo.198.tags: keeper, paws, portrait
 species: 2
 studbook.id: 1774
 video.1: https://youtu.be/f-hoQdNnqA0

--- a/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
+++ b/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
@@ -34,7 +34,7 @@ photo.4.author: minatomirai215
 photo.4.commitdate: 2020/6/27
 photo.4.link: https://www.instagram.com/minatomirai215/
 photo.4.tags: baby, close-up, whiskers
-photo.5: https://www.instagram.com/p/BdRtMHChNGn/media?size=m
+photo.5: https://www.instagram.com/p/BdRtMHChNGn/media/?size=m
 photo.5.author: mifko55
 photo.5.commitdate: 2020/4/30
 photo.5.link: https://www.instagram.com/mifko55/
@@ -972,22 +972,26 @@ photo.194.author: rie_panda55
 photo.194.commitdate: 2020/9/21
 photo.194.link: https://www.instagram.com/rie_panda55/
 photo.194.tags: home, laying down, portrait
-photo.195: https://www.instagram.com/p/CGlwYhVhwUS/media/?size=m
-photo.195.author: wumpwoast
-photo.195.link: https://www.instagram.com/wumpwoast/
-photo.195.tags: portrait, whiskers
-photo.196: https://www.instagram.com/p/CGuQq1Uh5mP/media/?size=m
-photo.196.author: ssc6105
-photo.196.link: https://www.instagram.com/ssc6105/
-photo.196.tags: door, paws, whiskers
-photo.197: https://www.instagram.com/p/CGdXvK0hZR6/media/?size=m
+photo.195: https://www.instagram.com/p/CGdXvK0hZR6/media/?size=m
+photo.195.author: ssc6105
+photo.195.commitdate: 2020/10/25
+photo.195.link: https://www.instagram.com/ssc6105/
+photo.195.tags: keeper, paws, standing, tail
+photo.196: https://www.instagram.com/p/CGlwYhVhwUS/media/?size=m
+photo.196.author: wumpwoast
+photo.196.commitdate: 2020/10/25
+photo.196.link: https://www.instagram.com/wumpwoast/
+photo.196.tags: portrait, whiskers
+photo.197: https://www.instagram.com/p/CGme7nqh8q9/media/?size=m
 photo.197.author: ssc6105
+photo.197.commitdate: 2020/10/25
 photo.197.link: https://www.instagram.com/ssc6105/
-photo.197.tags: keeper, paws, standing, tail
-photo.198: https://www.instagram.com/p/CGme7nqh8q9/media/?size=m
+photo.197.tags: keeper, paws, portrait
+photo.198: https://www.instagram.com/p/CGuQq1Uh5mP/media/?size=m
 photo.198.author: ssc6105
+photo.198.commitdate: 2020/10/25
 photo.198.link: https://www.instagram.com/ssc6105/
-photo.198.tags: keeper, paws, portrait
+photo.198.tags: door, paws, whiskers
 species: 2
 studbook.id: 1774
 video.1: https://youtu.be/f-hoQdNnqA0

--- a/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
+++ b/pandas/japan/0190_hakkeijima-sea-paradise/0023_kokin.txt
@@ -34,7 +34,7 @@ photo.4.author: minatomirai215
 photo.4.commitdate: 2020/6/27
 photo.4.link: https://www.instagram.com/minatomirai215/
 photo.4.tags: baby, close-up, whiskers
-photo.5: https://www.instagram.com/p/BdRtMHChNGn/media/?size=m
+photo.5: ig://BdRtMHChNGn/m
 photo.5.author: mifko55
 photo.5.commitdate: 2020/4/30
 photo.5.link: https://www.instagram.com/mifko55/
@@ -972,22 +972,22 @@ photo.194.author: rie_panda55
 photo.194.commitdate: 2020/9/21
 photo.194.link: https://www.instagram.com/rie_panda55/
 photo.194.tags: home, laying down, portrait
-photo.195: https://www.instagram.com/p/CGdXvK0hZR6/media/?size=m
+photo.195: ig://CGdXvK0hZR6/m
 photo.195.author: ssc6105
 photo.195.commitdate: 2020/10/25
 photo.195.link: https://www.instagram.com/ssc6105/
 photo.195.tags: keeper, paws, standing, tail
-photo.196: https://www.instagram.com/p/CGlwYhVhwUS/media/?size=m
+photo.196: ig://CGlwYhVhwUS/m
 photo.196.author: wumpwoast
 photo.196.commitdate: 2020/10/25
 photo.196.link: https://www.instagram.com/wumpwoast/
 photo.196.tags: portrait, whiskers
-photo.197: https://www.instagram.com/p/CGme7nqh8q9/media/?size=m
+photo.197: ig://CGme7nqh8q9/m
 photo.197.author: ssc6105
 photo.197.commitdate: 2020/10/25
 photo.197.link: https://www.instagram.com/ssc6105/
 photo.197.tags: keeper, paws, portrait
-photo.198: https://www.instagram.com/p/CGuQq1Uh5mP/media/?size=m
+photo.198: ig://CGuQq1Uh5mP/m
 photo.198.author: ssc6105
 photo.198.commitdate: 2020/10/25
 photo.198.link: https://www.instagram.com/ssc6105/


### PR DESCRIPTION
This is the first photobump for redpandafinder since the move away from [IG's old image links](https://github.com/wwoast/redpanda-lineage/pull/247) in the database. I tested one of the old links this morning with `wget` and they definitely don't work anymore!

So in the new world, every time an IG link is added to redpandafinder, it needs an extra step where it's converted into a special _ig://<shortcode>/<imagesize>_ URL. This tells RPF JS to use the IG oEmbed API instead of just treating it like a normal `src` attribute to an `<img>` tag.

One interesting facet of this is that I can't do pixel identification of pandas in group photos anymore, unless I have something that can fetch from the oEmbed API. I'll need to write such a tool here shortly.