### PR TITLE
Live replace

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -527,6 +527,12 @@ img.preload {
     display: none;
 }
 
+img.aboutFocus.replace,
+img.twinFocus.replace {
+    /* JS needs to replace the src before displaying these */
+    display: none;
+}
+
 div.pandaDossier, div.zooDossier, div.profileDossier {
     display: table-cell;
     vertical-align: top;

--- a/css/panda.css
+++ b/css/panda.css
@@ -370,7 +370,7 @@ div#contentFrame.mothersDay, div#contentFrame.birthdayPandas, div.mediaFrame {
 }
 
 /* Class to add to hidden sections on about/links page */
-div.hidden {
+div.hidden, img.hidden {
     display: none;
 }
 

--- a/fragments/cn/about.html
+++ b/fragments/cn/about.html
@@ -60,29 +60,29 @@
   <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
   <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
   </ul>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
   <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
   <ul>
   <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
   <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
   </ul>
-  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
   <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
   <ul>
   <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
   <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
   <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
   </ul>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
   <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
   <ul>
   <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
   <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
   <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
   </ul>
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
   <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
   <ul>
   <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
   <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
   <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
   <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
   <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
   <h2>Red Panda Lineage Data</h2>
   <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/cn/about.html
+++ b/fragments/cn/about.html
@@ -60,29 +60,29 @@
   <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
   <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
   </ul>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
   <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
   <ul>
   <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
   <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
   </ul>
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
   <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
   <ul>
   <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
   <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
   <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
   </ul>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
   <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
   <ul>
   <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
   <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
   <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
   </ul>
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
   <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
   <ul>
   <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
   <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
   <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
   <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
   <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
   <h2>Red Panda Lineage Data</h2>
   <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/cn/about.html
+++ b/fragments/cn/about.html
@@ -1,113 +1,114 @@
 <div id="hiddenContentFrame" class="about">
-<div class="shrinker">
-
-<div id="aboutPageMenu" class="sectionMenu">
-  <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
-    Usage Guide
-  </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
-    About Red Pandas
-  </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
-    About This Site
-  </div></button>
-</div>
+  <div class="shrinker">
   
-<div class="hidden section" id="usageGuide">
-<div class="pandaAbout onlyDesktop">
-<h2>How To Use This Site (PC)</h2>
-<ul>
-<li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
-<li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
-<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
-<li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
-<li>Click the upper-left corner of a panda photo to see more photos.</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout onlyMobile">
-<h2>How To Use This Site (Mobile)</h2>
-<ul>
-<li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
-<li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
-<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
-<li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>
-<li>Swipe left or right on a panda photo to see more photos.</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout">
-<h2>Search Tips</h2>
-<ul>
-<li>You can search for zoos by name or location! Zoo searches will show all red pandas currently living at a zoo.</li>
-<li>You can search photos by descriptive tag! Try one of these:</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout aboutTags"></div><!-- pandaAbout, with tags filled in -->
-</div><!-- usageGuide -->
-
-<div class="hidden section" id="aboutRedPandas">
-<div class="pandaAbout">
-<h2>About Red Pandas</h2>
-<h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
-<p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-<p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
-<p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-<p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
-<p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-
-<h2>Surprising Red Panda Facts</h2>
-<ul>
-<li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
-<li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
-</ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
-<h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
-<ul>
-<li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
-<li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
-</ul>
-<img class="twinFocus" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
-<h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
-<ul>
-<li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
-<li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
-<li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
-</ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/BQkZPmwhZIu/media/?size=l" alt="Marumi and Gin, fun with mom" />
-<h5 class="caption">Marumi the Mom-terrorizer! <a href="https://www.instagram.com/sina_dw/">(📷&nbsp;sina_dw)</a></h5>
-<ul>
-<li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
-<li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
-<li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
-</ul>
-<img class="twinFocus" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
-<h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
-<ul>
-<li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
-</ul>
-</div><!-- pandaAbout -->
-</div><!-- aboutRedPandas -->
-
-<div class="hidden section" id="aboutThisSite">
-<div class="pandaAbout">
-<h2>About This Site</h2>
-<p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
-<p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
-<p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-<img class="aboutFocus" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
-<h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
-<h2>Red Panda Lineage Data</h2>
-<p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>
-<h2>Contributions</h2>
-<p>If you'd like to submit new data or fixes to existing Red Panda Lineage data, we really appreciate the help! Just fill out one of the forms below:</p>
-<ul>
-<li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Lineage Request</a></li>
-</ul>
-<p>If you have a technical software-development background, you are also more than welcome to directly contribute to the dataset! We'll review any PRs or issues submitted through <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
-</div><!-- pandaAbout -->
-</div><!-- aboutThisSite -->
-
-</div><!-- shrinker -->
-</div><!-- contentFrame -->
+  <div id="aboutPageMenu" class="sectionMenu">
+    <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
+      Usage Guide
+    </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
+      About Red Pandas
+    </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
+      About This Site
+    </div></button>
+  </div>
+    
+  <div class="hidden section" id="usageGuide">
+  <div class="pandaAbout onlyDesktop">
+  <h2>How To Use This Site (PC)</h2>
+  <ul>
+  <li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
+  <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
+  <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
+  <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
+  <li>Click the upper-left corner of a panda photo to see more photos.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout onlyMobile">
+  <h2>How To Use This Site (Mobile)</h2>
+  <ul>
+  <li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
+  <li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
+  <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
+  <li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>
+  <li>Swipe left or right on a panda photo to see more photos.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout">
+  <h2>Search Tips</h2>
+  <ul>
+  <li>You can search for zoos by name or location! Zoo searches will show all red pandas currently living at a zoo.</li>
+  <li>You can search photos by descriptive tag! Try one of these:</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout aboutTags"></div><!-- pandaAbout, with tags filled in -->
+  </div><!-- usageGuide -->
+  
+  <div class="hidden section" id="aboutRedPandas">
+  <div class="pandaAbout">
+  <h2>About Red Pandas</h2>
+  <h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
+  <p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  <p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
+  <p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  <p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
+  <p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  
+  <h2>Surprising Red Panda Facts</h2>
+  <ul>
+  <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
+  <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
+  </ul>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
+  <ul>
+  <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
+  <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
+  </ul>
+  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
+  <ul>
+  <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
+  <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
+  <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
+  </ul>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
+  <ul>
+  <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
+  <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
+  <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
+  </ul>
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
+  <ul>
+  <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  </div><!-- aboutRedPandas -->
+  
+  <div class="hidden section" id="aboutThisSite">
+  <div class="pandaAbout">
+  <h2>About This Site</h2>
+  <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
+  <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
+  <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
+  <h2>Red Panda Lineage Data</h2>
+  <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>
+  <h2>Contributions</h2>
+  <p>If you'd like to submit new data or fixes to existing Red Panda Lineage data, we really appreciate the help! Just fill out one of the forms below:</p>
+  <ul>
+  <li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Lineage Request</a></li>
+  </ul>
+  <p>If you have a technical software-development background, you are also more than welcome to directly contribute to the dataset! We'll review any PRs or issues submitted through <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
+  </div><!-- pandaAbout -->
+  </div><!-- aboutThisSite -->
+  
+  </div><!-- shrinker -->
+  </div><!-- contentFrame -->
+  

--- a/fragments/en/about.html
+++ b/fragments/en/about.html
@@ -60,29 +60,29 @@
 <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
 <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
 </ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
 <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
 <ul>
 <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
 <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
 </ul>
-<img class="twinFocus" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
 <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
 <ul>
 <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
 <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
 <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
 </ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
 <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
 <ul>
 <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
 <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
 <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
 </ul>
-<img class="twinFocus" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
 <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
 <ul>
 <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
 <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
 <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
 <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-<img class="aboutFocus" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
 <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
 <h2>Red Panda Lineage Data</h2>
 <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/en/about.html
+++ b/fragments/en/about.html
@@ -60,29 +60,29 @@
 <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
 <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
 </ul>
-<img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
 <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
 <ul>
 <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
 <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
 </ul>
-<img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-<img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+<img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
 <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
 <ul>
 <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
 <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
 <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
 </ul>
-<img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
 <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
 <ul>
 <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
 <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
 <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
 </ul>
-<img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-<img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
 <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
 <ul>
 <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
 <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
 <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
 <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-<img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
 <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
 <h2>Red Panda Lineage Data</h2>
 <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/en/about.html
+++ b/fragments/en/about.html
@@ -60,29 +60,29 @@
 <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
 <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
 </ul>
-<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
 <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
 <ul>
 <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
 <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
 </ul>
-<img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
 <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
 <ul>
 <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
 <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
 <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
 </ul>
-<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
 <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
 <ul>
 <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
 <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
 <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
 </ul>
-<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-<img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
 <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
 <ul>
 <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
 <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
 <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
 <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
 <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
 <h2>Red Panda Lineage Data</h2>
 <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/jp/about.html
+++ b/fragments/jp/about.html
@@ -90,7 +90,7 @@ Red Panda Network はネパール、ブータン等で野生のレッサーパ�
 <p>また、将来的には動物園とも共同してレッサーパンダのサポートをしていきたいと考えています。
 SNS等で大好きなレッサーパンダを見ているとき、ユーザの皆さんも彼らを出来得る限り幸せにしてあげたいと思われるのではないでしょうか。</p>
 
-<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
 <h5 class="caption">ルル王女 💓 <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;takashi_8310iyo)</a></h5>
 
 <h2>レッサーパンダのデータについて</h2>

--- a/fragments/jp/about.html
+++ b/fragments/jp/about.html
@@ -90,7 +90,7 @@ Red Panda Network はネパール、ブータン等で野生のレッサーパ�
 <p>また、将来的には動物園とも共同してレッサーパンダのサポートをしていきたいと考えています。
 SNS等で大好きなレッサーパンダを見ているとき、ユーザの皆さんも彼らを出来得る限り幸せにしてあげたいと思われるのではないでしょうか。</p>
 
-<img class="aboutFocus replace" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
+<img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
 <h5 class="caption">ルル王女 💓 <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;takashi_8310iyo)</a></h5>
 
 <h2>レッサーパンダのデータについて</h2>

--- a/fragments/jp/about.html
+++ b/fragments/jp/about.html
@@ -90,7 +90,7 @@ Red Panda Network はネパール、ブータン等で野生のレッサーパ�
 <p>また、将来的には動物園とも共同してレッサーパンダのサポートをしていきたいと考えています。
 SNS等で大好きなレッサーパンダを見ているとき、ユーザの皆さんも彼らを出来得る限り幸せにしてあげたいと思われるのではないでしょうか。</p>
 
-<img class="aboutFocus" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BZlXepKFkIE/media/?size=l" alt="ルル王女" />
 <h5 class="caption">ルル王女 💓 <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;takashi_8310iyo)</a></h5>
 
 <h2>レッサーパンダのデータについて</h2>

--- a/fragments/np/about.html
+++ b/fragments/np/about.html
@@ -60,29 +60,29 @@
   <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
   <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
   </ul>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
   <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
   <ul>
   <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
   <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
   </ul>
-  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
   <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
   <ul>
   <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
   <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
   <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
   </ul>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
   <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
   <ul>
   <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
   <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
   <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
   </ul>
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
   <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
   <ul>
   <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
   <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
   <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
   <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
   <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
   <h2>Red Panda Lineage Data</h2>
   <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/np/about.html
+++ b/fragments/np/about.html
@@ -60,29 +60,29 @@
   <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
   <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
   </ul>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
   <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
   <ul>
   <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
   <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
   </ul>
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
   <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
   <ul>
   <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
   <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
   <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
   </ul>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
   <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
   <ul>
   <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
   <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
   <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
   </ul>
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-  <img class="twinFocus replace hidden" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
   <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
   <ul>
   <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
@@ -96,7 +96,7 @@
   <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
   <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
   <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-  <img class="aboutFocus replace hidden" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
   <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
   <h2>Red Panda Lineage Data</h2>
   <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>

--- a/fragments/np/about.html
+++ b/fragments/np/about.html
@@ -1,113 +1,114 @@
 <div id="hiddenContentFrame" class="about">
-<div class="shrinker">
-
-<div id="aboutPageMenu" class="sectionMenu">
-  <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
-    Usage Guide
-  </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
-    About Red Pandas
-  </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
-    About This Site
-  </div></button>
-</div>
+  <div class="shrinker">
   
-<div class="hidden section" id="usageGuide">
-<div class="pandaAbout onlyDesktop">
-<h2>How To Use This Site (PC)</h2>
-<ul>
-<li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
-<li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
-<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
-<li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
-<li>Click the upper-left corner of a panda photo to see more photos.</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout onlyMobile">
-<h2>How To Use This Site (Mobile)</h2>
-<ul>
-<li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
-<li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
-<li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
-<li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>
-<li>Swipe left or right on a panda photo to see more photos.</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout">
-<h2>Search Tips</h2>
-<ul>
-<li>You can search for zoos by name or location! Zoo searches will show all red pandas currently living at a zoo.</li>
-<li>You can search photos by descriptive tag! Try one of these:</li>
-</ul>
-</div><!-- pandaAbout -->
-<div class="pandaAbout aboutTags"></div><!-- pandaAbout, with tags filled in -->
-</div><!-- usageGuide -->
-
-<div class="hidden section" id="aboutRedPandas">
-<div class="pandaAbout">
-<h2>About Red Pandas</h2>
-<h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
-<p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-<p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
-<p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-<p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
-<p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
-<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
-
-<h2>Surprising Red Panda Facts</h2>
-<ul>
-<li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
-<li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
-</ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
-<h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
-<ul>
-<li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
-<li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
-</ul>
-<img class="twinFocus" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
-<h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
-<ul>
-<li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
-<li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
-<li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
-</ul>
-<img class="aboutFocus" src="https://www.instagram.com/p/BQkZPmwhZIu/media/?size=l" alt="Marumi and Gin, fun with mom" />
-<h5 class="caption">Marumi the Mom-terrorizer! <a href="https://www.instagram.com/sina_dw/">(📷&nbsp;sina_dw)</a></h5>
-<ul>
-<li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
-<li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
-<li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
-</ul>
-<img class="twinFocus" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
-<img class="twinFocus" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
-<h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
-<ul>
-<li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
-</ul>
-</div><!-- pandaAbout -->
-</div><!-- aboutRedPandas -->
-
-<div class="hidden section" id="aboutThisSite">
-<div class="pandaAbout">
-<h2>About This Site</h2>
-<p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
-<p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
-<p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
-<img class="aboutFocus" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
-<h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
-<h2>Red Panda Lineage Data</h2>
-<p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>
-<h2>Contributions</h2>
-<p>If you'd like to submit new data or fixes to existing Red Panda Lineage data, we really appreciate the help! Just fill out one of the forms below:</p>
-<ul>
-<li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Lineage Request</a></li>
-</ul>
-<p>If you have a technical software-development background, you are also more than welcome to directly contribute to the dataset! We'll review any PRs or issues submitted through <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
-</div><!-- pandaAbout -->
-</div><!-- aboutThisSite -->
-
-</div><!-- shrinker -->
-</div><!-- contentFrame -->
+  <div id="aboutPageMenu" class="sectionMenu">
+    <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
+      Usage Guide
+    </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
+      About Red Pandas
+    </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
+      About This Site
+    </div></button>
+  </div>
+    
+  <div class="hidden section" id="usageGuide">
+  <div class="pandaAbout onlyDesktop">
+  <h2>How To Use This Site (PC)</h2>
+  <ul>
+  <li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
+  <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
+  <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
+  <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
+  <li>Click the upper-left corner of a panda photo to see more photos.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout onlyMobile">
+  <h2>How To Use This Site (Mobile)</h2>
+  <ul>
+  <li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
+  <li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
+  <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
+  <li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>
+  <li>Swipe left or right on a panda photo to see more photos.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout">
+  <h2>Search Tips</h2>
+  <ul>
+  <li>You can search for zoos by name or location! Zoo searches will show all red pandas currently living at a zoo.</li>
+  <li>You can search photos by descriptive tag! Try one of these:</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  <div class="pandaAbout aboutTags"></div><!-- pandaAbout, with tags filled in -->
+  </div><!-- usageGuide -->
+  
+  <div class="hidden section" id="aboutRedPandas">
+  <div class="pandaAbout">
+  <h2>About Red Pandas</h2>
+  <h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
+  <p>Red Pandas are beautiful, rare, and precious. Each one in captivity should be appreciated, and I hope the photos and family tree here help spread my love for these animals. There are so few left, in the rainforests and rainshadows around the Himalayas, and the world would be so much smaller without them.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  <p>When visiting a Red Panda at the zoo, I recommend finding out what the animal's feeding times are. Many pandas seem a little lazy outside of their feeding schedule, to put it kindly! The truth is their metabolism is very low, and combined with bamboo being such a low-nutrient staple food, they are very miserly in spending their energy budget. On the other hand, captive pandas tend to fawn over apples and grapes, and when a red panda gets a tasty snack, all bets on behavior are off!</p>
+  <p>Other good times to visit red pandas at zoos are during the early winter, when red panda cubs start exploring out of the den more regularly, and during the mating season in February, where they squeak and wrestle and burn energy pursuing conjugal mayhem.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  <p>Outside these very specific and atypical periods, red pandas remain very fascinating and wonderful to visit. They are the kind of animal that watches back, especially when you are distracted, or if you've failed to see them first. They move with the quietest, gentlest grace through the trees, preferring to be safely above us at nearly all times. You can trace a red panda's movements with unfailing focus, and still they will escape your view, sometimes hiding quietly in plain sight. And when they're not busy eating a third of their body weight every day or sleeping over a dozen hours a day, red pandas can groom for hours at a time.</p>
+  <p>So perhaps most importantly, when you visit a red panda, and you have their attention, don't take it for granted. They don't offer it easily or readily, being very shy and involved in their own panda affairs of doing what seems to us like not a whole lot. They just need space, fresh bamboo, and love &mdash; not the direct love that humans need from each other, but the love that comes from giving a piece of your heart away without even considering whether you'll see it again.</p>
+  <div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+  
+  <h2>Surprising Red Panda Facts</h2>
+  <ul>
+  <li>Red pandas are adorably fuzzy, but their coats are coarse and rough to the touch.</li>
+  <li>Most pandas can stand on two legs, and a few are known to walk this way for limited distances.</li>
+  </ul>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" alt="Eita, Futa's standing son" />
+  <h5 class="caption">Stand proudly, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
+  <ul>
+  <li>In addition to marking their territories using scent glands on their butts, hands and feet, red pandas are known for tasting the air, typically by holding their surprisingly long tongues out of their mouths in a slightly rigid hook, or occasionally by opening their mouths very wide.</li>
+  <li>Though known for eating bamboo leaves and young shoots, they've been seen digging up and eating soft bamboo roots and stalks in captivity.</li>
+  </ul>
+  <img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" alt="Marimo and a bamboo root" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" alt="Jazz and Melody, apple twins" />
+  <h5 class="caption">Marimo and a bamboo root (left,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), and the apple twins Melody and Jazz (right,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
+  <ul>
+  <li>Using their semi-retractable claws and a false thumb that acts like a fixed sixth finger, red pandas will often hold and eat food in their hands, even while standing. Aside from their excited chewing speed, red pandas eat apple slices the same way people do!</li>
+  <li>Red pandas have a characteristic smile, with their mouth open and tongue in place, and they appear to do this when their bodies are too warm.</li>
+  <li>Nearly all red pandas are born in late June to late July, though in the southern hemisphere their mating and breeding schedule shifts by six months to match the seasons.</li>
+  </ul>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" alt="Gin hops over Marumi" />
+  <h5 class="caption">Gin hops over her daughter Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
+  <ul>
+  <li>Red panda moms get to choose between raising extremely playful twins or triplets, or having a single baby that will invariably discover that mom's tail is the coolest thing to chase ever!</li>
+  <li>Unless they are raised with a sibling, red pandas tend to be highly solitary and territorial, needing plenty of their own space to be comfortable.</li>
+  <li>Each red panda has a recognizable coat coloring, facial mask, tail pattern, and ear shape, but these facets (particularly the mask and tail) tend to evolve as they get older. The most obvious change is progressing into adulthood, where initially flat faces tend to broaden out as the panda loses its fuzzy "baby coat".</li>
+  </ul>
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" alt="Fulgens" />
+  <img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" alt="Styani" />
+  <h5 class="caption"><i>Fulgens</i> (left,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>), and <i>Styani</i> (right,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
+  <ul>
+  <li>There are two subspecies of red panda, one from Sichuan Province in China / East of the Himalayas (<i>Ailurus fulgens styani</i>), and one in Nepal, Bhutan, and Darjeeling, south of the Himalayas (<i>Ailurus fulgens fulgens</i>). The latter are smaller, with white-blushed faces and tend to have a particular tilted almond shape to their eyes. Japan's captive population is almost entirely <i>styani</i> while America and Europe tend to have <i>fulgens</i>.</li>
+  </ul>
+  </div><!-- pandaAbout -->
+  </div><!-- aboutRedPandas -->
+  
+  <div class="hidden section" id="aboutThisSite">
+  <div class="pandaAbout">
+  <h2>About This Site</h2>
+  <p>On the surface, redpandafinder dot com (localized domains coming soon) is for people who love red pandas and enjoy visiting them at zoos. It's designed to be a quick reference, a family tree with photos, and a way to share pandas you love with your friends.</p>
+  <p>Like a zoo itself, this site hopes that being closer to the animals will change people's hearts. We encourage everyone visiting this site to donate to <a href="https://redpandanetwork.org">Red Panda Network</a>, who does crucial conservation efforts for wild red pandas in Nepal and Bhutan.</p>
+  <p>Eventually, this site also wants to support red pandas in cooperation with specific zoos. When you see your favorite red pandas on Instagram every day, you want to give them the best lives they can have.</p>
+  <img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" alt="Jazz and Melody, the apple goblins" />
+  <h5 class="caption">Jazz and Melody, the singing apple-duo! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
+  <h2>Red Panda Lineage Data</h2>
+  <p>The Red Panda Lineage dataset searchable on this site is sourced from red panda fans in Japan and worldwide, and is supplemented and checked against studbook information compiled by Angela Glatston at Rotterdam Zoo in The Netherlands. The dataset is stored on <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> and is updated several times a week.</p>
+  <h2>Contributions</h2>
+  <p>If you'd like to submit new data or fixes to existing Red Panda Lineage data, we really appreciate the help! Just fill out one of the forms below:</p>
+  <ul>
+  <li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Lineage Request</a></li>
+  </ul>
+  <p>If you have a technical software-development background, you are also more than welcome to directly contribute to the dataset! We'll review any PRs or issues submitted through <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
+  </div><!-- pandaAbout -->
+  </div><!-- aboutThisSite -->
+  
+  </div><!-- shrinker -->
+  </div><!-- contentFrame -->
+  

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1202,6 +1202,7 @@ Gallery.url.instagram = function(image, input_uri) {
   window.addEventListener(ig_locator, function() {
     // Second-stage. Fetch the image using the thumbnail_url
     image.src = Gallery.url.paths[ig_locator];
+    img.classList.remove("replace");  /* For about page images */
   });
   if (ig_locator in Gallery.url.paths) {
     // Do we already have the image details?

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1202,7 +1202,6 @@ Gallery.url.instagram = function(image, input_uri) {
   window.addEventListener(ig_locator, function() {
     // Second-stage. Fetch the image using the thumbnail_url
     image.src = Gallery.url.paths[ig_locator];
-    image.classList.remove("hidden");   // If image was hidden, show it now
   });
   if (ig_locator in Gallery.url.paths) {
     // Do we already have the image details?

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1202,6 +1202,7 @@ Gallery.url.instagram = function(image, input_uri) {
   window.addEventListener(ig_locator, function() {
     // Second-stage. Fetch the image using the thumbnail_url
     image.src = Gallery.url.paths[ig_locator];
+    image.classList.remove("hidden");   // If image was hidden, show it now
   });
   if (ig_locator in Gallery.url.paths) {
     // Do we already have the image details?

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1202,7 +1202,7 @@ Gallery.url.instagram = function(image, input_uri) {
   window.addEventListener(ig_locator, function() {
     // Second-stage. Fetch the image using the thumbnail_url
     image.src = Gallery.url.paths[ig_locator];
-    img.classList.remove("replace");  /* For about page images */
+    image.classList.remove("replace");  /* For about page images */
   });
   if (ig_locator in Gallery.url.paths) {
     // Do we already have the image details?

--- a/js/page.js
+++ b/js/page.js
@@ -155,6 +155,7 @@ Page.about.sections.show = function(section_id) {
       var size = img.src.split("/")[6].split("=")[1];
       var ig_url = "ig://" + shortcode + "/" + size;
       Gallery.url.process(img, ig_url);
+      img.classList.remove("replace");
     }
   }
 }

--- a/js/page.js
+++ b/js/page.js
@@ -149,7 +149,7 @@ Page.about.sections.show = function(section_id) {
   desired_button.classList.add("selected");
   // Find all image links on instagram, and replace their URIs with fetches
   var replace_images = document.getElementsByClassName("replace");
-  for (let img of replace_images) {
+  for (var img of replace_images) {
     if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
       var shortcode = img.src.split("/")[4];
       var size = img.src.split("/")[6].split("=")[1];

--- a/js/page.js
+++ b/js/page.js
@@ -22,6 +22,18 @@ Page.about.fetch = function() {
     window.dispatchEvent(Page.about.loaded);   // Report the data has loaded
   }
 }
+Page.about.fetchImages = function() {
+  // Find all image links on instagram, and replace their URIs with fetches
+  var replace_images = document.getElementsByClassName("replace");
+  for (var img of replace_images) {
+    if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
+      var shortcode = img.src.split("/")[4];
+      var size = img.src.split("/")[6].split("=")[1];
+      var ig_url = "ig://" + shortcode + "/" + size;
+      Gallery.url.process(img, ig_url);
+    }
+  }
+}
 Page.about.hashchange = function() {
   // The about page hashchange results in needing to draw or fetch the
   // about page and initialize its menus, or at the very least, scroll
@@ -79,16 +91,6 @@ Page.about.render = function() {
   if (history.scrollRestoration) {
     history.scrollRestoration = 'auto';
   }
-  // Find all image links on instagram, and replace their URIs with fetches
-  var replace_images = document.getElementsByClassName("replace");
-  for (var img of replace_images) {
-    if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
-      var shortcode = img.src.split("/")[4];
-      var size = img.src.split("/")[6].split("=")[1];
-      var ig_url = "ig://" + shortcode + "/" + size;
-      Gallery.url.process(img, ig_url);
-    }
-  }  
 }
 Page.about.routing = function() {
   // When someone clicks the about button, either show the about page,
@@ -157,6 +159,8 @@ Page.about.sections.show = function(section_id) {
   // Remove the hidden class on the desired section, and "select" its button
   desired.classList.remove("hidden");
   desired_button.classList.add("selected");
+  // Fetch images from IG if necessary
+  Page.about.fetchImages();
 }
 Page.about.tags = function() {
   // Take all available tags for this language, and draw an unordered list.

--- a/js/page.js
+++ b/js/page.js
@@ -147,6 +147,16 @@ Page.about.sections.show = function(section_id) {
   // Remove the hidden class on the desired section, and "select" its button
   desired.classList.remove("hidden");
   desired_button.classList.add("selected");
+  // Find all image links on instagram, and replace their URIs with fetches
+  var replace_images = document.getElementsByClassName("replace");
+  for (let img of replace_images) {
+    if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
+      var shortcode = img.src.split("/")[4];
+      var size = img.src.split("/")[6].split("=")[1];
+      var ig_url = "ig://" + shortcode + "/" + size;
+      Gallery.url.process(img, ig_url);
+    }
+  }
 }
 Page.about.tags = function() {
   // Take all available tags for this language, and draw an unordered list.

--- a/js/page.js
+++ b/js/page.js
@@ -79,6 +79,17 @@ Page.about.render = function() {
   if (history.scrollRestoration) {
     history.scrollRestoration = 'auto';
   }
+  // Find all image links on instagram, and replace their URIs with fetches
+  var replace_images = document.getElementsByClassName("replace");
+  for (var img of replace_images) {
+    if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
+      var shortcode = img.src.split("/")[4];
+      var size = img.src.split("/")[6].split("=")[1];
+      var ig_url = "ig://" + shortcode + "/" + size;
+      Gallery.url.process(img, ig_url);
+      img.classList.remove("replace");
+    }
+  }  
 }
 Page.about.routing = function() {
   // When someone clicks the about button, either show the about page,
@@ -147,17 +158,6 @@ Page.about.sections.show = function(section_id) {
   // Remove the hidden class on the desired section, and "select" its button
   desired.classList.remove("hidden");
   desired_button.classList.add("selected");
-  // Find all image links on instagram, and replace their URIs with fetches
-  var replace_images = document.getElementsByClassName("replace");
-  for (var img of replace_images) {
-    if (img.src.indexOf("https://www.instagram.com/p/") == 0) {
-      var shortcode = img.src.split("/")[4];
-      var size = img.src.split("/")[6].split("=")[1];
-      var ig_url = "ig://" + shortcode + "/" + size;
-      Gallery.url.process(img, ig_url);
-      img.classList.remove("replace");
-    }
-  }
 }
 Page.about.tags = function() {
   // Take all available tags for this language, and draw an unordered list.

--- a/js/page.js
+++ b/js/page.js
@@ -87,7 +87,6 @@ Page.about.render = function() {
       var size = img.src.split("/")[6].split("=")[1];
       var ig_url = "ig://" + shortcode + "/" + size;
       Gallery.url.process(img, ig_url);
-      img.classList.remove("replace");
     }
   }  
 }


### PR DESCRIPTION
The images on the #about page weren't loading since they still used the old IG redirect uris. I added a hook function on #about section change that plugs in the `Gallery.url.process` callbacks to load IG images as necessary.