### PR TITLE
Fixed death dates for yanyan, aqua, and miku

### DIFF
--- a/pandas/japan/0013_nishiyama/0112_yanyan.txt
+++ b/pandas/japan/0013_nishiyama/0112_yanyan.txt
@@ -4,7 +4,7 @@ birthday: 2010/6/24
 birthplace: 13
 children: 115, 116, 52, 119, 121
 commitdate: 2018/6/25
-death: 2020/1/23
+death: 2021/1/23
 en.name: Yan-Yan
 en.nicknames: none
 en.othernames: Jan-Jan, Yanyan

--- a/pandas/japan/0031_ishikawa/0179_aqua.txt
+++ b/pandas/japan/0031_ishikawa/0179_aqua.txt
@@ -4,7 +4,7 @@ birthday: 2010/7/6
 birthplace: 1
 children: 181, 182, 183, 73
 commitdate: 2018/7/13
-death: 2020/1/24
+death: 2021/1/24
 en.name: Aqua
 en.nicknames: none
 en.othernames: Akua

--- a/pandas/japan/0074_osaki-park-childrens-zoo/0339_miku.txt
+++ b/pandas/japan/0074_osaki-park-childrens-zoo/0339_miku.txt
@@ -4,7 +4,7 @@ birthday: 1999/7/21
 birthplace: 42
 children: none
 commitdate: 2018/9/22
-death: 2020/1/22
+death: 2021/1/22
 en.name: Miku
 en.nicknames: none
 en.othernames: none


### PR DESCRIPTION
Fixed death year for yanyan, aqua, and miku from 2020 to 2021.