### PR TITLE
Portuguese translation: 1st version

### DIFF
--- a/fragments/pt/about.html
+++ b/fragments/pt/about.html
@@ -1,0 +1,118 @@
+<div id="hiddenContentFrame" class="about">
+<div class="shrinker">
+
+<div id="aboutPageMenu" class="sectionMenu">
+  <button id="usageGuide_button" class="sectionButton three"><div class="sectionMenuItem">
+    Guia de uso
+  </div></button><button id="aboutRedPandas_button" class="sectionButton three"><div class="sectionMenuItem">
+    Sobre os pandas-vermelhos
+  </div></button><button id="aboutThisSite_button" class="sectionButton three"><div class="sectionMenuItem">
+    Sobre o site
+  </div></button>
+</div>
+  
+<div class="hidden section" id="usageGuide">
+<div class="pandaAbout onlyDesktop">
+<h2>Como usar o site (PC)</h2>
+<ul>
+<li>Clique em 🇧🇷 para mudar o idioma. Seis idiomas estão disponíveis.</li>
+<li>Para ver um novo panda-vermelho, basta clicar no ícone 🎲 <i>(Aleatório)</i>.</li>
+<li>Quando souber o nome de um panda, use a barra branca <i>Pesquisar</i> para encontrá-lo novamente. Basta clicar na barra <i>Pesquisar</i>, digitar um nome e pressionar <i>Enter</i>.</li>
+<li>Quando tiver encontrado um panda, você pode saber mais sobre sua família clicando na barra verde com o nome dele ou nos nomes da família do panda.</li>
+<li>Clique no canto superior esquerdo da foto de um panda para ver mais fotos.</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout onlyMobile">
+<h2>Como usar o site (Móvel)</h2>
+<ul>
+<li>Toque em 🇧🇷 para mudar o idioma. Seis idiomas estão disponíveis.</li>
+<li>Para ver um novo panda-vermelho, basta tocar  no ícone 🎲 <i>(Aleatório)</i> icon.</li>
+<li>Quando souber o nome de um panda, use a barra branca <i>Pesquisar</i> para encontrá-lo novamente. Basta tocar na barra <i>Pesquisar</i>, inserir um nome e tocar o botão <i>Pesquisar</i> do seu teclado.</li>
+<li>Quando tiver encontrado um panda, você pode saber mais sobre sua família clicando na barra verde com o nome dele ou nos nomes da família do panda.</li>
+<li>Deslize para a esquerda ou a direita sobre a foto de um panda para ver mais fotos.</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout">
+<h2>Dicas de pesquisa</h2>
+<ul>
+<li>Você pode procurar zoológicos pelo nome ou localização! Pesquisas por zoológicos mostrarão todos os pandas-vermelhos vivendo atualmente num zoológico.</li>
+<li>Você pode procurar fotos por etiqueta descritiva! Experimente uma destas:</li>
+</ul>
+</div><!-- pandaAbout -->
+<div class="pandaAbout aboutTags"></div><!-- pandaAbout, with tags filled in -->
+</div><!-- usageGuide -->
+
+<div class="hidden section" id="aboutRedPandas">
+<div class="pandaAbout">
+<h2>Sobre os pandas-vermelhos</h2>
+<h4><a href="https://www.instagram.com/wumpwoast/">✍️ a_ka_pan</a></h4>
+<p>"Carisma de um cãozinho e beleza de um gatinho": essa foi a impressão que eu tive quando comecei a me apaixonar pelos pandas-vermelhos. Um olhar mais profundo, porém, revela que eles são peculiares e especiais. Seus parentes mais próximos, os guaxinins, furões e cangambás, não são tão próximos assim, muito menos são próximos os cães, gatos, raposas ou mesmo pandas-gigantes. Pandas-vermelhos são pandas-vermelhos, com sua própria fofura e encanto.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/bn9PVbfRK0g" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div> 
+<p>Após quase um ano aprendendo por conta própria sobre pandas-vermelhos, realizei o sonho de ver um com os próprios olhos, quando viajei do Brasil para Portugal. Meu país não tem pandas-vermelhos e, por ser de clima tropical, talvez nunca tenha. Cheguei ao Jardim Zoológico de Lisboa no meio da tarde, por isso, só pude ver um panda dormindo numa árvore. Eu já sabia que eram animais crepusculares, mais ativos ao nascer e ao pôr do sol, por isso, dei uma volta pelo zoo para revê-los no entardecer. Deu certo! Lá estava o panda maior comendo uma banana, descendo em seguida até o laguinho para beber água e, por fim, subindo na árvore para descansar de novo. "Zerei a vida", pensei.</p>
+<p>Dica linguística: em português, a espécie se chama <i>panda-vermelho</i>, com hífen. <i>Panda vermelho</i>, sem hífen, seria um panda-gigante pintado de vermelho. Num contexto em que se trata apenas de pandas-vermelhos, tudo bem chamá-los só de pandas: no Ocidente, eles foram os primeiros a serem chamados assim, ou seja, o panda-gigante é chamado de panda por causa do panda-vermelho. Os primeiros a estudarem a espécie a chamaram de <i>wah</i>, nome na língua limbu, derivado de um dos sons que o panda-vermelho faz: wah! 
+
+<h4><a href="https://www.instagram.com/wumpwoast/">✍️ wumpwoast</a></h4>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/1hlM3IYMs1o" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>Ao visitar um panda-vermelho no zoológico, recomendo descobrir quais são os horários de alimentação do animal. Muitos pandas parecem um pouco preguiçosos fora de seu horário de alimentação, para dizer o mínimo! A verdade é que seu metabolismo é muito baixo e, combinado com o bambu ser um alimento básico de poucos nutrientes, eles são muito econômicos ao gastar sua reserva de energia. Por outro lado, pandas em cativeiro adoram maçãs e uvas, e quando um panda-vermelho ganha um lanche gostoso, qualquer palpite sobre seu comportamento é incerto!</p>
+<p>Outro bom momento para visitar pandas-vermelhos em zoológicos é durante o início do inverno, quando filhotes começam a explorar fora da toca mais regularmente, e durante a temporada de acasalamento em fevereiro, quando eles chiam, brigam e gastam energia em busca do caos conjugal.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/ASP_YmgIvnc" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+<p>Fora desses períodos muito específicos e atípicos, pandas-vermelhos continuam a ser muito fascinantes e maravilhosos de se visitar. São o tipo de animal que olham de volta, especialmente quando você estiver distraído ou se você não o tiver visto primeiro. Movem-se com a mais silenciosa e delicada graça pelas árvores, preferindo estar em segurança acima de nós quase todo o tempo. Você pode seguir com foco infalível os movimentos de um panda-vermelho, e ele ainda escapará da sua vista, às vezes se escondendo silenciosamente à vista de todos. E quando não estiverem ocupados comendo um terço de seu peso corporal todo dia ou dormindo mais de doze horas por dia, pandas-vermelhos podem se limpar por horas a cada vez.</p>
+<p>Então, talvez o mais importante, quando visitar um panda-vermelho e tiver a atenção dele, não a tome como garantida. Eles não a oferecem fácil ou rapidamente, sendo muito tímidos e envolvidos em seus próprios assuntos de panda fazendo o que parece não ser grande coisa para nós. Eles só precisam de espaço, bambu fresco e amor &mdash; não o amor direto que humanos precisam uns dos outros, mas o amor que vem de entregar um pedaço do seu coração sem nem sequer considerar se o verá de novo.</p>
+<div class="youtube"><iframe width="658" height="370" src="https://www.youtube.com/embed/eBXvRaP_ODo" frameborder="0" allow="encrypted-media" allowfullscreen></iframe></div>
+
+<h2>Fatos supreeendentes sobre os pandas-vermelhos</h2>
+<ul>
+<li>Pandas-vermelhos são felpudinhos, mas sua pelagem é grosseira e áspera ao tato.</li>
+<li>A maioria dos pandas pode se erguer sobre duas pernas, e alguns são conhecidos por andar assim por curtas distâncias.</li>
+</ul>
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BjN6DqcH2OH/media/?size=l" loading="lazy" alt="Eita, filho de Futa" />
+<h5 class="caption"Erga-se com orgulho, Eita-kun. <a href="https://www.instagram.com/cattail.sapporo/">(📷&nbsp;cattail.sapporo)</a></h5>
+<ul>
+<li>Além de marcarem seus territórios usando glândulas odoríferas em seus bumbuns, mãos e pés, pandas-vermelhos são conhecidos por sentirem o gosto do ar, tipicamente por colocarem suas línguas surpreendentemente longas para fora de suas bocas como um gancho levemente rígido, ou eventualmente por abrirem bem largo suas bocas.</li>
+<li>Apesar de serem conhecidos por comerem folhas e brotos novos de bambu, eles são vistos em cativeiro escavando e comendo raízes e caules macios de bambu.</li>
+</ul>
+<img class="twinFocus replace" src="https://www.instagram.com/p/BhxLb_dFYux/media/?size=m" loading="lazy" alt="Marimo e uma raiz de bambu" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bm5w2mylDpI/media/?size=m" loading="lazy" alt="Jazz e Melody, Gêmeos da Maçã" />
+<h5 class="caption">Marimo e uma raiz de bambu (à esquerda,&nbsp;<a href="https://www.instagram.com/yossi929">📷&nbsp;yossi929</a>), e os Gêmeos da Maçã Melody e Jazz (à direita,&nbsp;<a href="https://www.instagram.com/nakacchi_desu">📷&nbsp;nakacchi_desu</a>)</h5>
+<ul>
+<li>Usando suas garras semirretráteis e um falso polegar que atua como um sexto dedo fixo, pandas-vermelhos costumam segurar e comer comida com as mãos, mesmo enquanto estão de pé. Além de sua entusiasmada velocidade de mastigação, pandas-vermelhos comem fatias de maçã que nem gente!</li>
+<li>Pandas-vermelhos têm um sorriso característico, com sua boca aberta e a língua no lugar, e aparentemente fazem isso quando seus corpos estão quentes demais.</li>
+<li>Quase todos os pandas-vermelhos nascem entre o fim de junho e o fim de julho, embora no hemisfério Sul seu período de acasalamento e reprodução se alterem em seis meses para se adequarem às estações do ano.</li>
+</ul>
+<img class="aboutFocus replace" src="https://www.instagram.com/p/B1LrNuDBTJP/media/?size=l" loading="lazy" alt="Gin salta sobre Marumi" />
+<h5 class="caption">Gin saltando sobre sua filha Marumi! <a href="https://www.instagram.com/tama67photo/">(📷&nbsp;tama67photo)</a></h5>
+<ul>
+<li>Mamães pandas-vermelhas podem escolher entre criar gêmeos ou trigêmeos extremamente bricalhões ou terem um único bebê que, invariavelmente, descobrirá que a cauda da mamãe é a coisa mais legal do mundo de se perseguir!</li>
+<li>A menos que tenham crescido com um irmão, pandas-vermelhos tendem a ser muito solitários e territorialistas, precisando de muito espaço próprio para se sentirem confortáveis.</li>
+<li>Cada panda-vermelho tem coloração de pelagem, máscara facial, padrão de cauda e formato de orelha reconhecíveis, mas tais facetas (em particular a máscara e a cauda) tendem a evoluir à medida que envelhecem. A mudança mais óbvia é progredir para a idade adulta, quando as faces incialmente achatadas tendem a se alargar conforme o panda perde sua felpuda "pelagem de bebê".</li>
+</ul>
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bl1XeV_loeD/media/?size=m" loading="lazy" alt="Ailurus fulgens fulgens" />
+<img class="twinFocus replace" src="https://www.instagram.com/p/Bjb9yntlwMv/media/?size=m" loading="lazy" alt="Ailurus fulgens styani" />
+<h5 class="caption"><i>Ailurus fulgens fulgens</i> (à esquerda,&nbsp;<a href="https://www.instagram.com/miis_98">📷&nbsp;miis_98</a>) e <i>Ailurus fulgens styani</i> (à direita,&nbsp;<a href="https://www.instagram.com/yossi929/">📷&nbsp;yossi929</a>).</h5>
+<ul>
+<li>Há duas subespécies de panda-vermelho, uma da província de Sichuan na China, a leste do Himalaia (<i>Ailurus fulgens styani</i>), e uma no Nepal, Butão e Darjeeling (Índia), ao sul do Himalaia (<i>Ailurus fulgens fulgens</i>). Esta última é menor, com faces esbranquiçadas e tendem a ter olhos com uma particular forma de amêndoa inclinada. A população em cativeiro do Japão é quase inteira de <i>A. f. styani</i> enquanto os Estados Unidos e na Europa tendem a ter <i>A. f. fulgens</i>.</li>
+</ul>
+</div><!-- pandaAbout -->
+</div><!-- aboutRedPandas -->
+
+<div class="hidden section" id="aboutThisSite">
+<div class="pandaAbout">
+<h2>Sobre este site</h2>
+<p>Na superfície, o redpandafinder.com é para pessoas que amam pandas-vermelhos e gostam de visitá-los em zoológicos. É projetado para ser uma referência rápida, uma árvore genealógica com fotos e um jeito de compartilhar os pandas que você ama com seus amigos.</p>
+<p>Como um zoológico em si, este site espera que estar mais perto dos animais mude os corações das pessoas. Incentivamos todos que visitem este site a fazerem doações para a <a href="https://redpandanetwork.org">Red Panda Network</a>, que faz esforços de conservação cruciais para pandas-vermelhos selvagens no Nepal e no Butão.</p>
+<p>Por fim, este site também quer dar suporte a pandas-vermelhos em cooperação com zoológicos específicos. Quando você vir seus pandas-vermelhos favoritos no Instagram todo dia, você quer lhes dar a melhor vida que puderem ter.</p>
+<img class="aboutFocus replace" src="https://www.instagram.com/p/BojHOlxAKjh/media/?size=l" loading="lazy" alt="Jazz e Melody, o Dueto da Maçã" />
+<h5 class="caption">Jazz e Melody, o Dueto da Maçã! <a href="https://www.instagram.com/falcon_tenor">(📷&nbsp;falcon_tenor)</a></h5>
+<h2>Dados da Red Panda Lineage</h2>
+<p>O conjunto de dados pesquisável da Red Panda Lineage (Linhagem de Pandas-Vermelhos) neste site é obtido por fãs de pandas-vermelhos pelo mundo, e é suplementado e verificado com informações do livro genealógico compiladas por Angela Glatston do Rotterdam Zoo nos Países Baixos. O conjunto de dados está armazenado no <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a> e é atualizado várias vezes por semana.</p>
+<h2>Contribuições</h2>
+<p>Se quiser submeter novos dados ou correções a dados existentes na LRed Panda Lineage, agradecemos muito a ajuda! Basta preencher o formulário abaixo:</p>
+<ul>
+<li><a href="https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0">Solicitação de linhagem</a></li>
+</ul>
+<p>Se tiver experiência técnica em desenvolvimento de software, você também é mais que bem-vindo a contribuir diretamente para o conjunto de dados! Revisaremos quaisquer PRs ou questões submetidas através do <a href="https://github.com/wwoast/redpanda-lineage">GitHub</a>.</p>
+</div><!-- pandaAbout -->
+</div><!-- aboutThisSite -->
+
+</div><!-- shrinker -->
+</div><!-- contentFrame -->

--- a/js/language.js
+++ b/js/language.js
@@ -39,7 +39,8 @@ Language.L.bias = {
   "en": [],
   "es": ["latin"],
   "jp": ["latin"],
-  "np": ["latin"]
+  "np": ["latin"],
+  "pt": ["latin"]
 }
 
 // Types of alphabets, so we can fall back to an alphabet that someone
@@ -49,7 +50,7 @@ Language.L.bias = {
 Language.alphabets = {
   "cjk": ["cn", "jp", "kr"],
   "cyrillic": ["ru"],
-  "latin": ["de", "dk", "en", "es", "fr", "nl", "pl", "se"],
+  "latin": ["de", "dk", "en", "es", "fr", "nl", "pl", "pt", "se"],
 }
 
 
@@ -238,6 +239,7 @@ Language.L.flags = {
        "Austria": "🇦🇹",
        "Belgium": "🇧🇪",
         "Bhutan": "🇧🇹",
+		"Brazil": "🇧🇷",
         "Canada": "🇨🇦",
          "Chile": "🇨🇱",
          "China": "🇨🇳",
@@ -259,6 +261,7 @@ Language.L.flags = {
    "Netherlands": "🇳🇱",
    "New Zealand": "🇳🇿",
         "Poland": "🇵🇱",
+	  "Portugal": "🇵🇹",
         "Russia": "🇷🇺",
      "Singapore": "🇸🇬",
       "Slovakia": "🇸🇰",
@@ -277,35 +280,40 @@ Language.L.gui = {
     "en": "About",
     "es": "Acerca\xa0de",
     "jp": "概要",
-    "np": "बारेमा"
+    "np": "बारेमा",
+	"pt": "Sobre"
   },
   "autumn": {
     "cn": "秋",
     "en": "Autumn",
     "es": "Otoño",
     "jp": "秋",
-    "np": "शरद तु"
+    "np": "शरद तु",
+	"pt": "Outono"
   },
   "babies": {
     "cn": "婴儿",
     "en": "Babies",
     "es": "Bebés",
     "jp": "乳幼児",
-    "np": "बच्चाहरु"
+    "np": "बच्चाहरु",
+	"pt": "Bebês"
   },
   "children": {
     "cn": Pandas.def.relations.children["cn"],
     "en": "Children",   // Capitalization
     "es": "Niños",
     "jp": Pandas.def.relations.children["jp"],
-    "np": "बच्चाहरु"
+    "np": "बच्चाहरु",
+	"pt": "Filhos(as)"
   },
   "contribute": {
     "cn": "上传照片",
     "en": "Submit a Photo",
     "es": "Enviar una foto",
     "jp": "写真を提出する",
-    "np": "फोटो पेश गर्नुहोस्"
+    "np": "फोटो पेश गर्नुहोस्",
+	"pt": "Enviar uma foto"
   },
   "contribute_link": {
     "en": "https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0",
@@ -316,56 +324,64 @@ Language.L.gui = {
     "en": "Copied",
     "es": "Copiado",
     "jp": "写す",
-    "np": "अनुकरण गनु"
+    "np": "अनुकरण गनु",
+	"pt": "Copiado"
   },
   "fall": {
     "cn": "秋",   // Convenience duplicate of autumn
     "en": "Autumn",
     "es": "Otoño",
     "jp": "秋",
-    "np": "शरद तु"
+    "np": "शरद तु",
+	"pt": "Outono"
   },
   "family": {
     "cn": "家族",
     "en": "Family",
     "es": "Familia",
     "jp": "ファミリ",
-    "np": "परिवार"
+    "np": "परिवार",
+	"pt": "Família"
   },
   "father": {
     "cn": "父亲",
     "en": "Father",
     "es": "Padre",
     "jp": "父",
-    "np": "बुबा"
+    "np": "बुबा",
+	"pt": "Pai"
   },
   "flag": {
     "cn": Language.L.flags["China"],
     "en": Language.L.flags["USA"],
     "es": Language.L.flags["Spain"],
     "jp": Language.L.flags["Japan"],
-    "np": Language.L.flags["Nepal"]
+    "np": Language.L.flags["Nepal"],
+	"pt": Language.L.flags["Brazil"]
   },
   "footerLink_rpf": {
     "cn": "小熊猫族谱项目",
     "en": "Red Panda Lineage",
     "es": "Red Panda Lineage",
     "jp": "Red Panda Lineage",
-    "np": "Red Panda Lineage"
+    "np": "Red Panda Lineage",
+    "pt": "Red Panda Lineage"
   },
   "footerLink_rpn": {
     "cn": "Red Panda Network",
     "en": "Red Panda Network",
     "es": "Red Panda Network",
     "jp": "Red Panda Network",
-    "np": "Red Panda Network"
+    "np": "Red Panda Network",
+    "pt": "Red Panda Network"
   },
   "home": {
     "cn": "主页",
     "en": "Home",
     "es": "Home",
     "jp": "ホーム",
-    "np": "होमपेज"
+    "np": "होमपेज",
+	"pt:" "Início"
   },
   "instagramLinks_body": {
     "cn": "",
@@ -373,21 +389,25 @@ Language.L.gui = {
           "know, this site would not exist. Thank you so much!",
     "es": "",
     "jp": "",
-    "np": ""
+    "np": "",
+    "pt": "Sem todos os dedicados e adoráveis fãs de pandas-vermelhos do " +
+          "Instagram que conheço, este site não existiria. Agradeço muito!"
   },
   "instagramLinks_button": {
     "cn": "IG",
     "en": "Instagram",
     "es": "Instagram",
     "jp": "インスタグラム",
-    "np": "Instagram"
+    "np": "Instagram",
+    "pt": "Instagram"
   },
   "instagramLinks_header": {
     "cn": "Instagram 小熊猫",
     "en": "Red Pandas on Instagram",
     "es": "Pandas rojos en Instagram",
     "jp": "Instagram レッサーパンダ",
-    "np": "Instagram निगल्य पोन्या"
+    "np": "Instagram निगल्य पोन्या",
+	"pt": "Pandas-vermelhos no Instagram"
   },
   "language": {
     "cn": {
@@ -398,6 +418,7 @@ Language.L.gui = {
       "kr": "朝鮮语",
       "np": "尼泊尔语",
       "pl": "波兰语",
+	  "pt": "葡萄牙语",
       "ru": "俄语",
       "se": "瑞典"
     },
@@ -409,6 +430,7 @@ Language.L.gui = {
       "kr": "Korean",
       "np": "Nepalese",
       "pl": "Polish",
+	  "pt": "Portuguese",
       "ru": "Russian",
       "se": "Swedish"
     },
@@ -420,6 +442,7 @@ Language.L.gui = {
       "kr": "Coreano",
       "np": "Nepalés",
       "pl": "Polaco",
+	  "pt": "Portugués",
       "ru": "Ruso",
       "se": "Sueco"
     },
@@ -431,6 +454,7 @@ Language.L.gui = {
       "kr": "韓国語",
       "np": "ネパール語",
       "pl": "ポーランド語",
+	  "pt": "ポルトガル語",
       "ru": "ロシア語",
       "se": "スウェーデン"
     },
@@ -442,8 +466,21 @@ Language.L.gui = {
       "kr": "कोरियन",
       "np": "नेपाली",
       "pl": "पोलिश",
+	  "pt": "पोर्तुगाली",
       "ru": "रसियन",
       "se": "स्वीडिश"
+    },
+    "pt": {
+      "cn": "Chinês",
+      "en": "Inglês",
+      "es": "Espanhol",
+      "jp": "Japonês",
+      "kr": "Coreano",
+      "np": "Nepalês",
+      "pl": "Polonês",
+	  "pt": "Português",
+      "ru": "Russo",
+      "se": "Sueco"
     },
     "ru": {
       "cn": "китайский",
@@ -452,7 +489,8 @@ Language.L.gui = {
       "jp": "японский",
       "kr": "корейский",
       "np": "непальский",
-      "pl": "Польский",
+      "pl": "польский",
+	  "pt": "португа́льский",
       "ru": "русский",
       "se": "шведский"
     },
@@ -464,6 +502,7 @@ Language.L.gui = {
       "kr": "Koreanska",
       "np": "Nepali",
       "pl": "Polska",
+	  "pt": "Portugisiska",
       "ru": "Ryska",
       "se": "Svenska"
     }
@@ -473,224 +512,256 @@ Language.L.gui = {
     "en": "Loading...",
     "es": "Cargando",
     "jp": "ローディング",
-    "np": "लोड"
+    "np": "लोड",
+	"pt": "Carregando..."
   },
   "litter": {
     "cn": Pandas.def.relations.litter["cn"],
     "en": "Litter",   // Capitalization
     "es": "Camada",
     "jp": Pandas.def.relations.litter["jp"],
-    "np": "रोटी"
+    "np": "रोटी",
+	"pt": "Ninhada"
   },
   "links": {
     "cn": "链接",
     "en": "Links",
     "es": "Enlaces",
     "jp": "リンク",
-    "np": "लिंक"
+    "np": "लिंक",
+	"pt": "Links"
   },
   "me": {
     "cn": "我",
     "en": "Me",
     "es": "Me",
     "jp": "私",
-    "np": "म"
+    "np": "म",
+	"pt": "Eu"
   },
   "media": {
     "cn": "媒体",
     "en": "Media",
     "es": "Imagenes",
     "jp": "メディア",
-    "np": "मिडिया"
+    "np": "मिडिया",
+	"pt": "Imagens"
   },
   "mother": {
     "cn": "母亲",
     "en": "Mother",
     "es": "Madre",
     "jp": "母",
-    "np": "आमा"
+    "np": "आमा",
+	"pt": "Mãe"
   },
   "nicknames": {
     "cn": "昵称",
     "en": "Nicknames",
     "es": "Apodos",
     "jp": "ニックネーム",
-    "np": "उपनामहरू"
+    "np": "उपनामहरू",
+	"pt": "Apelidos"
   },
   "othernames": {
     "cn": "其他名称",
     "en": "Other Names",
     "es": "Otros nombres",
     "jp": "他の名前",
-    "np": "अरु नामहरु"
+    "np": "अरु नामहरु",
+	"pt": "Outros nomes"
   },
   "paging": {
     "cn": "更多",
     "en": "More",
     "es": "Ver Más",
     "jp": "もっと",
-    "np": "अधिक"
+    "np": "अधिक",
+	"pt": "Mais"
   },
   "parents": {
     "cn": Pandas.def.relations.parents["cn"],
     "en": "Parents",   // Capitalization
     "es": "Padres",
     "jp": Pandas.def.relations.parents["jp"],
-    "np": "अभिभावक"
+    "np": "अभिभावक",
+	"pt": "Pais"
   },
   "profile": {
     "cn": "档案",
     "en": "Profile",
     "es": "Perfil",
     "jp": "プロフィール",
-    "np": "प्रोफाइल"
+    "np": "प्रोफाइल",
+	"pt": "Perfil"
   },
   "quadruplet": {
     "cn": "四胞胎",
     "en": "Quadruplet",
     "es": "Cuatrillizo",
     "jp": "四つ子",
-    "np": "प्रोफाइल"
+    "np": "प्रोफाइल",
+	"pt": "Quadrigêmeos"
   },
   "random": {
     "cn": "随机",
     "en": "Random",
     "es": "Aleatorio",
     "jp": "適当",
-    "np": "अनियमित"
+    "np": "अनियमित",
+	"pt": "Aleatório"
   },
   "redPandaCommunity_body": {
     "cn": "",
     "en": "",
     "es": "",
     "jp": "",
-    "np": ""
+    "np": "",
+	"pt": ""
   },
   "redPandaCommunity_button": {
     "cn": "社区",
     "en": "Community",
     "es": "Comunidad",
     "jp": "共同体",
-    "np": "समुदाय"
+    "np": "समुदाय",
+	"pt": "Comunidade"
   },
   "redPandaCommunity_header": {
     "cn": "小熊猫社区",
     "en": "Red Panda Community",
     "es": "Comunidad del Panda Rojo",
     "jp": "レッサーパンダの共同体",
-    "np": "निगल्य पोन्या समुदाय"
+    "np": "निगल्य पोन्या समुदाय",
+	"pt": "Comunidade do Panda-Vermelho"
   },
   "refresh": {
     "cn": "刷新",
     "en": "Refresh",
     "es": "Refrescar",
     "jp": "リロード",
-    "np": "ताजा गर्नु"
+    "np": "ताजा गर्नु",
+	"pt": "Atualizar"
   },
   "search": {
     "cn": "搜索...",
     "en": "Search...",
     "es": "Buscar...",
     "jp": "サーチ...",
-    "np": "खोज्नु"
+    "np": "खोज्नु",
+	"pt": "Pesquisar..."
   },
   "seen_date": {
     "cn": "目击日期 <INSERTDATE>",
     "en": "Seen <INSERTDATE>",
     "es": "Visto <INSERTDATE>",
     "jp": "TOWRITE <INSERTDATE>",
-    "np": "TOWRITE <INSERTDATE>"
+    "np": "TOWRITE <INSERTDATE>",
+	"pt": "Visto em <INSERTDATE>"
   },
   "siblings": {
     "cn": Pandas.def.relations.siblings["cn"],
     "en": "Siblings",   // Capitalization,
     "es": "Hermanos",
     "jp": Pandas.def.relations.siblings["jp"],
-    "np": "भाइबहिनीहरू"
+    "np": "भाइबहिनीहरू",
+	"pt": "Irmã(o)s"
   },
   "since_date": {
     "cn": "自 <INSERTDATE>",
     "en": "Since <INSERTDATE>",
     "es": "Ya que <INSERTDATE>",
     "jp": "<INSERTDATE>から",
-    "np": "<INSERTDATE>देखि"
+    "np": "<INSERTDATE>देखि",
+	"pt": "Desde <INSERTDATE>"
   },
   "specialThanksLinks_body": {
     "cn": "",
     "en": "",
     "es": "",
     "jp": "",
-    "np": ""
+    "np": "",
+	"pt": ""
   },
   "specialThanksLinks_button": {
     "cn": "鸣谢",
     "en": "Special Thanks",
     "es": "Agradecimientos",
     "jp": "感佩",
-    "np": "विशेष धन्यवाद"
+    "np": "विशेष धन्यवाद",
+	"pt": "Agradecimentos Especiais"
   },
   "specialThanksLinks_header": {
     "cn": "鸣谢",
     "en": "Special Thanks",
-    "es": "Agradecimientos Especial",
+    "es": "Agradecimientos Especiales",
     "jp": "感佩",
-    "np": "विशेष धन्यवाद"
+    "np": "विशेष धन्यवाद",
+	"pt": "Agradecimentos Especiais"
   },
   "spring": {
     "cn": "春",
     "en": "Spring",
     "es": "Primavera",
     "jp": "春",
-    "np": "वसन्त"
+    "np": "वसन्त",
+	"pt": "Primavera"
   },
   "summer": {
     "cn": "夏",
     "en": "Summer",
     "es": "Verano",
     "jp": "夏",
-    "np": "गर्मी"
+    "np": "गर्मी",
+	"pt": "Verão"
   },
   "title": {
     "cn": "查找小熊猫",
     "en": "Red Panda Finder",
     "es": "Buscador de Panda Rojo",
     "jp": "レッサーパンダのファインダー",
-    "np": "निगल्या पोनिया मित्र"
+    "np": "निगल्या पोनिया मित्र",
+	"pt": "Buscador de Pandas-Vermelhos"
   },
   "top": {
     "cn": "顶部",
     "en": "Top",
     "es": "Arriba",
     "jp": "上",
-    "np": "माथि"
+    "np": "माथि",
+	"pt": "Para cima"
   },
   "tree": {
     "cn": "树",
     "en": "Tree",
     "es": "Árbol",
     "jp": "木",
-    "np": "रूख"
+    "np": "रूख",
+	"pt": "Árvore"
   },
   "twin": {
     "cn": "双胞胎",
     "en": "Twin",
     "es": "Mellizo",
     "jp": "双子",
-    "np": "जुम्ल्याहा"
+    "np": "जुम्ल्याहा",
+	"pt": "Gêmeo"
   },
   "triplet": {
     "cn": "三胞胎",
     "en": "Triplet",
     "es": "Trillizo",
     "jp": "三つ子",
-    "np": "तीनवटा"
+    "np": "तीनवटा",
+	"pt": "Trigêmeo"
   },
   "winter": {
     "cn": "冬",
     "en": "Winter",
     "es": "Invierno",
     "jp": "冬",
-    "np": "जाडो"
+    "np": "जाडो",
+	"pt": "Inverno"
   },
   "zooLinks_body": {
     "cn": "",
@@ -705,14 +776,16 @@ Language.L.gui = {
     "en": "Zoos",
     "es": "Zoológicos",
     "jp": "動物園",
-    "np": "चिडियाखाना"
+    "np": "चिडियाखाना",
+	"pt": "Zoológicos"
   },
   "zooLinks_header": {
     "cn": "小熊猫动物园",
     "en": "Major Red Panda Zoos",
     "es": "Principales Zoológicos de Pandas Rojos",
     "jp": "レッサーパンダの動物園",
-    "np": "प्रमुख चिडियाखाना"
+    "np": "प्रमुख चिडियाखाना",
+	"pt": "Principais zoológicos com pandas-vermelhos".
   }
 }
 
@@ -722,14 +795,16 @@ Language.L.messages = {
     "en": " & ",
     "es": " y ",
     "jp": "と",
-    "np": " र "
+    "np": " र ",
+	"pt": "e"
   },
   "and_words": {
     "cn": "和",
     "en": " and ",
     "es": " y ",
     "jp": "と",
-    "np": " र "
+    "np": " र ",
+	"pt": "e"
   },
   "arrived_from_zoo": {
     "cn": ["<INSERTDATE>",
@@ -747,6 +822,9 @@ Language.L.messages = {
            "から"],
     "np": ["<INSERTDATE>",
            " बाट ",
+           "<INSERTZOO>"],
+    "pt": ["<INSERTDATE>",
+           ", desde ",
            "<INSERTZOO>"]
   },
   "closed": {
@@ -765,14 +843,18 @@ Language.L.messages = {
     "np": [Language.L.emoji.closed + " ",
            "स्थायी रूपमा ",
            "<INSERTDATE>",
-           "बन्द भयो"]
+           "बन्द भयो"],
+    "pt": [Language.L.emoji.closed + " ", 
+           "Permanentemente fechado em ",
+           "<INSERTDATE>"]
   },
   "comma": {
     "cn": "及",
     "en": ", ",
     "es": ", ",
     "jp": "と",
-    "np": ", "
+    "np": ", ",
+    "pt": ", "
   },
   "credit": {
     "cn": [Language.L.emoji.gift + " ",
@@ -799,7 +881,12 @@ Language.L.messages = {
            "<INSERTUSER>",
            " ले ",
            "<INSERTNUMBER>",
-           " फोटो योगदान गरेको छ"]
+           " फोटो योगदान गरेको छ"],
+    "pt": [Language.L.emoji.gift + " ",
+           "<INSERTUSER>",
+           " contribuiu com ",
+           "<INSERTNUMBER>",
+           " fotos."]
   },
   "credit_animal_filter_single": {
     "cn": [Language.L.emoji.gift + " ",
@@ -836,7 +923,14 @@ Language.L.messages = {
            "<INSERTNUMBER>",
            " ",
            "<INSERTNAME>",
-           " फोटोहरु योगदान गरेको छ"]
+           " फोटोहरु योगदान गरेको छ"],
+    "pt": [Language.L.emoji.gift + " ",
+           "<INSERTUSER>",
+           " contribuiu com ",
+           "<INSERTNUMBER>",
+           " fotos de ",
+           "<INSERTNAME>",
+           "."]
   },
   "departed_to_zoo": {
     "cn": ["<INSERTDATE>",
@@ -855,14 +949,18 @@ Language.L.messages = {
     "np": ["<INSERTZOO>",
            " ",
            "<INSERTDATE>",
-           " मा"]
+           " मा"],
+    "pt": ["<INSERTZOO>",
+           " em ",
+           "<INSERTDATE>"]
   },
   "find_a_nearby_zoo": {
     "cn": [Language.L.emoji.globe_asia, " 寻找附近的动物园"],
     "en": [Language.L.emoji.globe_americas, " Find a zoo nearby!"],
     "es": [Language.L.emoji.globe_americas, " ¡Encuentra un zoológico cerca de ti!"],
     "jp": [Language.L.emoji.globe_asia, " 近くの動物園を見つける"],
-    "np": [Language.L.emoji.globe_asia, " नजिकै चिडियाखाना खोज्नुहोस्"]
+    "np": [Language.L.emoji.globe_asia, " नजिकै चिडियाखाना खोज्नुहोस्"],
+    "pt": [Language.L.emoji.globe_americas, " Encontre um zoológico próximo!"]
   },
   "footer": {
     "cn": ["如果你喜爱小熊猫，请支持小熊猫网络（",
@@ -899,7 +997,15 @@ Language.L.messages = {
            " साथै तपाईंको स्थानीय चिडियाखानालाई समर्थन गर्नुहोस्। ",
            "<INSERTLINK_RPF>",
            " प्रोजेक्टको वंश डाटा शिष्टाचार, तर मिडिया यसको सिर्जनाकर्ताहरूको सम्पत्ति रहन्छ।",
-           " लेआउट र डिजाइन प्रतिलिपि अधिकार २०२१ Justin Fairchild द्वारा।"]
+           " लेआउट र डिजाइन प्रतिलिपि अधिकार २०२१ Justin Fairchild द्वारा।"],
+    "pt": ["Se você ama pandas-vermelhos, por favor apoie a  ",
+           "<INSERTLINK_RPN>",
+           " bem como seus zoológicos locais. Dados de linhagem são uma cortesia do projeto",
+           "<INSERTLINK_RPF>",
+           ", mas as mídias linkadas seguem sendo propriedade de seus criadores. ",
+           "Layout e design ©" +
+           "\xa0" +
+           "2021 Justin Fairchild."]
   },
   "found_animal": {
     "cn": [Language.L.emoji.flower, " ",
@@ -926,7 +1032,12 @@ Language.L.messages = {
            Language.L.emoji.see_and_say, 
            " ",
            "<INSERTNAME>",
-           " has been found and is safe!"]
+           " has been found and is safe!"],
+    "pt": [Language.L.emoji.flower, " ",
+           Language.L.emoji.see_and_say, 
+           " ",
+           "<INSERTNAME>",
+           " foi encontrado(a) e está a salvo!"]
   },
   "goodbye": {
     "cn": ["后会有期, ",
@@ -973,6 +1084,15 @@ Language.L.messages = {
            "<INSERTBIRTH>",
            " — ",
            "<INSERTDEATH>",
+           ")"],
+    "pt": ["Adeus, ",
+           "<INSERTNAME>",
+           ". ",
+           Language.L.emoji.died,
+           " (",
+           "<INSERTBIRTH>",
+           " — ",
+           "<INSERTDEATH>",
            ")"]
   },
   "happy_birthday": {
@@ -1005,6 +1125,12 @@ Language.L.messages = {
            "<INSERTNAME>",
            "! (",
            "<INSERTNUMBER>",
+           ")"],
+    "pt": [Language.L.emoji.birthday,
+           " Feliz aniversário, ",
+           "<INSERTNAME>",
+           "! (",
+           "<INSERTNUMBER>",
            ")"]
   },
   "landing_mothersday": {
@@ -1012,14 +1138,16 @@ Language.L.messages = {
     "en": ["Happy Mother's Day!"],
     "es": ["¡Feliz Día de la Madre!"],
     "jp": ["母の日おめでとう"],
-    "np": ["खुसी आमाको दिन!"]
+    "np": ["खुसी आमाको दिन!"],
+	"pt": ["Feliz Dia das Mães!"]
   },
   "list_comma": {
     "cn": "、",
     "en": ", ",
     "es": ", ",
     "jp": "、",
-    "np": ", "
+    "np": ", ",
+    "pt": ", "
   },
   "lost_animal": {
     "cn": [Language.L.emoji.alert, " ",
@@ -1062,6 +1190,14 @@ Language.L.messages = {
            "<ZOONAME>",
            ": ",
            "<ZOOCONTACT>"],
+    "pt": [Language.L.emoji.alert, " ",
+           Language.L.emoji.see_and_say, 
+           " Se vir ",
+           "<INSERTNAME>",
+           ", contacte ",
+           "<ZOONAME>",
+           ": ",
+           "<ZOOCONTACT>"]
   },
   "lunch_time": {
     "cn": [Language.L.emoji.paws, " ",
@@ -1079,6 +1215,9 @@ Language.L.messages = {
     "np": [Language.L.emoji.paws, " ",
            "खाजाको लागि के हो?", " ",
            Language.L.emoji.greens],
+    "pt": [Language.L.emoji.paws, " ",
+           "O que tem para o almoço?", " ",
+           Language.L.emoji.greens]
   },
   "missing_you": {
     "cn": ["我们想你, ",
@@ -1125,7 +1264,16 @@ Language.L.messages = {
            "<INSERTBIRTH>",
            " — ",
            "<INSERTDEATH>",
-           ")"]    
+           ")"],
+    "pt": ["Saudades de você, ",
+           "<INSERTNAME>",
+           ". ",
+           Language.L.emoji.died,
+           " (",
+           "<INSERTBIRTH>",
+           " — ",
+           "<INSERTDEATH>",
+           ")"]
   },
   "nearby_zoos": {
     "cn": [Language.L.emoji.website,
@@ -1157,7 +1305,13 @@ Language.L.messages = {
            Language.L.emoji.home,
            " नजिकका चिडियाखानाहरू भेट्टाउँदै।",
            " यदि भौगोलिक स्थान असफल भयो भने,",
-           " आफ्नो शहरको लागि खोजी प्रयास गर्नुहोस्।"]
+           " आफ्नो शहरको लागि खोजी प्रयास गर्नुहोस्।"],
+    "pt": [Language.L.emoji.website,
+           " ",
+           Language.L.emoji.home,
+           " Procurando zoológicos próximos. ",
+           "Se a geolocalização falhar, ",
+           "tente pesquisar sua cidade."]
   },
   "new_photos": {
     "contributors": {
@@ -1178,7 +1332,11 @@ Language.L.messages = {
       "np": [Language.L.emoji.giftwrap,
              " ",
              "<INSERTCOUNT>",
-             " योगदानकर्ताहरू नयाँ"]
+             " योगदानकर्ताहरू नयाँ"],
+      "pt": [Language.L.emoji.giftwrap,
+             " ",
+             "<INSERTCOUNT>",
+             " novos contribuintes"]
     },
     "pandas": {
       "cn": [Language.L.emoji.profile,
@@ -1200,7 +1358,11 @@ Language.L.messages = {
       "np": [Language.L.emoji.profile,
              " ",
              "<INSERTCOUNT>",
-             " निगल्य पोन्या नयाँ"]
+             " निगल्य पोन्या नयाँ"],
+      "pt": [Language.L.emoji.profile,
+             " ",
+             "<INSERTCOUNT>",
+             " novos pandas-vermelhos"]
     },
     "photos": {
       "cn": ["<INSERTCOUNT>",
@@ -1212,14 +1374,17 @@ Language.L.messages = {
       "jp": ["<INSERTCOUNT>",
              "枚の新しい写真"],
       "np": ["<INSERTCOUNT>",
-             " छवि नयाँ"]
+             " छवि नयाँ"], 
+      "pt": ["<INSERTCOUNT>",
+             " novas fotos"]
     },
     "suffix": {
       "cn": ["本星期！"],
       "en": [" this week!"],
       "es": [" esta semana."],
       "jp": ["今週！"],
-      "np": ["यो हप्ता"]
+      "np": ["यो हप्ता"],
+      "pt": [" esta semana!"]
     },
     "zoos": {
       "cn": [Language.L.emoji.zoo,
@@ -1239,7 +1404,11 @@ Language.L.messages = {
       "np": [Language.L.emoji.zoo,
              " ",
              "<INSERTCOUNT>",
-             " नयाँ चिडियाखाना"]
+             " नयाँ चिडियाखाना"],
+      "pt": [Language.L.emoji.zoo,
+             " ",
+             "<INSERTCOUNT>",
+             " novos zoológicos"]
     }
   },
   "no_result": {
@@ -1247,28 +1416,32 @@ Language.L.messages = {
     "en": ["No Pandas Found"],
     "es": ["No Se Encontró Ningún Panda"],
     "jp": ["パンダが見つかりません"],
-    "np": ["कुनै निगल्य पोन्या फेला परेन"]
+    "np": ["कुनै निगल्य पोन्या फेला परेन"],
+    "pt": ["Nenhum panda encontrado"]
   },
   "no_group_media_result": {
     "cn": ["找不到合影"],
     "en": ["No Group Photos Found"],
     "es": ["No Se Encontraron Fotos de Grupos"],
     "jp": ["集合写真は見つかりませんでした"],
-    "np": ["कुनै निगल्य पोन्या समूह भेटिएन"]
+    "np": ["कुनै निगल्य पोन्या समूह भेटिएन"],
+    "pt": ["Nenhuma foto de grupo encontrada"]
   },
   "no_subject_tag_result": {
     "cn": ["没有关联照片"],
     "en": ["No Tagged Photos"],
     "es": ["Sin Fotos Etiquetadas"],
     "jp": ["このパンダのタグ付けされた写真はありません"],
-    "np": ["कुनै फोटोहरू ट्याग छैनन्"]
+    "np": ["कुनै फोटोहरू ट्याग छैनन्"],
+    "pt": ["Nenhuma foto etiquetada"]
   },
   "no_zoos_nearby": {
     "cn": ["附近没有动物园"],
     "en": ["No Zoos Nearby"],
     "es": ["No Hay Zoológicos Cerca"],
     "jp": ["近くに動物園はありません"],
-    "np": ["नजिकै कुनै चिडियाखाना छैन"]
+    "np": ["नजिकै कुनै चिडियाखाना छैन"],
+    "pt": ["Nenhum zoológico próximo"]
   },
   "overflow": {
     "cn": ["显示前",
@@ -1285,7 +1458,10 @@ Language.L.messages = {
            "を表示"],
     "np": [" ",
            "<INSERTLIMIT>",
-           " मात्र"]
+           " मात्र"],
+    "pt": [" Mostrando os primeiros ",
+           "<INSERTLIMIT>",
+           "."]
   },
   "profile_babies_children": {
     "cn": ["<INSERTNAME>",
@@ -1307,7 +1483,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " को ",
            "<INSERTBABIES>",
-           " बच्चाहरु छन्"]
+           " बच्चाहरु छन्"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTBABIES>",
+           " filhos(as)."]
   },
   "profile_babies_siblings": {
     "cn": ["<INSERTNAME>",
@@ -1329,7 +1509,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " ",
            "<INSERTBABIES>",
-           " बच्चाका भाई बहिनीहरू छन्"]
+           " बच्चाका भाई बहिनीहरू छन्"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTBABIES>",
+           " irmãos(ãs) bebês."]
   },
   "profile_brothers": {
     "cn": ["<INSERTNAME>",
@@ -1351,7 +1535,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " छ ",
            "<INSERTBROTHERS>",
-           " भाइहरु"]
+           " भाइहरु"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTBROTHERS>",
+           " irmãos."]
   },
   "profile_brothers_babies": {
     "cn": ["<INSERTNAME>",
@@ -1383,7 +1571,13 @@ Language.L.messages = {
            "<INSERTBROTHERS>",
            " भाइहरु र ",
            "<INSERTBABIES>",
-           " नवजात शिशुहरू"]
+           " नवजात शिशुहरू"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTBROTHERS>",
+           " irmãos e ",
+           "<INSERTBABIES>",
+           " irmãos(ãs) bebês."]
   },
   "profile_children": {
     "cn": ["<INSERTNAME>",
@@ -1425,7 +1619,15 @@ Language.L.messages = {
            "<INSERTDAUGHTERS>",
            " छोरीहरू र ",
            "<INSERTSONS>",
-           " छोराहरू!"]
+           " छोराहरू!"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTTOTAL>",
+           " filhos: ",
+           "<INSERTDAUGHTERS>",
+           " meninas e ",
+           "<INSERTSONS>",
+           " meninos!"]
   },
   "profile_children_babies": {
     "cn": ["<INSERTNAME>",
@@ -1477,7 +1679,17 @@ Language.L.messages = {
            "<INSERTSONS>",
            " छोराहरू र ",
            "<INSERTBABIES>",
-           " बच्चाहरु!"]
+           " बच्चाहरु!"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTTOTAL>",
+           " filhos: ",
+           "<INSERTDAUGHTERS>",
+           " meninas, ",
+           "<INSERTSONS>",
+           " meninos e ",
+           "<INSERTBABIES>",
+           " recém-nascidos(as)!"]
   },
   "profile_daughters": {
     "cn": ["<INSERTNAME>",
@@ -1499,7 +1711,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " छ ",
            "<INSERTDAUGHTERS>",
-           " छोरीहरू"]
+           " छोरीहरू"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTDAUGHTERS>",
+           " filhas."]
   },
   "profile_daughters_babies": {
     "cn": ["<INSERTNAME>",
@@ -1531,7 +1747,13 @@ Language.L.messages = {
            "<INSERTDAUGHTERS>",
            " छोरीहरू र ",
            "<INSERTBABIES>",
-           " बच्चाहरु"]
+           " बच्चाहरु"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTDAUGHTERS>",
+           " filhas e ",
+           "<INSERTBABIES>",
+           " recém-nascidos(as)!"]
   },
   "profile_family": {
     "cn": ["<INSERTNAME>",
@@ -1543,7 +1765,9 @@ Language.L.messages = {
     "jp": ["<INSERTNAME>",
            "の直近の家族"],
     "np": ["<INSERTNAME>",
-           "को निकट परिवार"]
+           "को निकट परिवार"],
+    "pt": ["Família inmediata de ",
+           "<INSERTNAME>"]
   },
   "profile_sisters": {
     "cn": ["<INSERTNAME>",
@@ -1565,7 +1789,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " छ ",
            "<INSERTSISTERS>",
-           " बहिनीहरू"]
+           " बहिनीहरू"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTSISTERS>",
+           " irmãs."]
   },
   "profile_sisters_babies": {
     "cn": ["<INSERTNAME>",
@@ -1597,7 +1825,13 @@ Language.L.messages = {
            "<INSERTSISTERS>",
            " बहिनीहरू र ",
            "<INSERTBABIES>",
-           " बच्चा भाई बहिनीहरू"]
+           " बच्चा भाई बहिनीहरू"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTSISTERS>",
+           " irmãs e ",
+           "<INSERTBABIES>",
+           " irmãos(ãs) bebês."]
   },
   "profile_siblings": {
     "cn": ["<INSERTNAME>",
@@ -1640,7 +1874,15 @@ Language.L.messages = {
            "<INSERTSISTERS>",
            " बहिनीहरू र ",
            "<INSERTBROTHERS>",
-           " भाइहरु"]
+           " भाइहरु"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTTOTAL>",
+           " irmãos: ",
+           "<INSERTSISTERS>",
+           " fêmeas e ",
+           "<INSERTBROTHERS>",
+           " machos!"]
   },
   "profile_siblings_babies": {
     "cn": ["<INSERTNAME>",
@@ -1693,7 +1935,17 @@ Language.L.messages = {
            "<INSERTBROTHERS>",
            " भाइहरु र ",
            "<INSERTBABIES>",
-           " बच्चाहरु!"]
+           " बच्चाहरु!"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTTOTAL>",
+           " irmãos: ",
+           "<INSERTSISTERS>",
+           " fêmeas, ",
+           "<INSERTBROTHERS>",
+           " machos e ",
+           "<INSERTBABIES>",
+           " irmãos(ãs) bebês!"]
   },
   "profile_sons": {
     "cn": ["<INSERTNAME>",
@@ -1715,7 +1967,11 @@ Language.L.messages = {
     "np": ["<INSERTNAME>",
            " छ ",
            "<INSERTSONS>",
-           " छोराहरू"]
+           " छोराहरू"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTSONS>",
+           " filhos."]
   },
   "profile_sons_babies": {
     "cn": ["<INSERTNAME>",
@@ -1747,7 +2003,13 @@ Language.L.messages = {
            "<INSERTSONS>",
            " छोराहरू र ",
            "<INSERTBABIES>",
-           " बच्चाहरु!"]
+           " बच्चाहरु!"],
+    "pt": ["<INSERTNAME>",
+           " tem ",
+           "<INSERTSONS>",
+           " filhos e ",
+           "<INSERTBABIES>",
+           " recém-nascidos(as)!"]
   },
   "profile_where": {
     "cn": ["<INSERTNAME>",
@@ -1761,7 +2023,10 @@ Language.L.messages = {
     "jp": ["<INSERTNAME>",
            "はどこに住んでいましたか？"],
     "np": ["<INSERTNAME>",
-           " कहाँ बस्यो?"]
+           " कहाँ बस्यो?"],
+    "pt": ["Onde ",
+           "<INSERTNAME>",
+           " já morou?"]
   },
   "remembering_you_together": {
     "cn": [Language.L.emoji.hearts, " ",
@@ -1783,7 +2048,11 @@ Language.L.messages = {
     "np": [Language.L.emoji.hearts, " ",
            "<INSERTNAMES>",
            ": हामी तिमीलाई कहिल्यै बिर्सिने छैनौं। ",
-           Language.L.emoji.paws]
+           Language.L.emoji.paws],
+    "pt": [Language.L.emoji.hearts, " ",
+           "<INSERTNAMES>",
+           ": Nunca esqueceremos de você. ",
+           " ", Language.L.emoji.paws]
   },
   "shovel_pandas": {
     "cn": [Language.L.emoji.dig, " ",
@@ -1800,6 +2069,9 @@ Language.L.messages = {
            Language.L.emoji.treasure],
     "np": [Language.L.emoji.dig, " ",
            "गाडिएको खजाना खोजी गर्दै", " ",
+           Language.L.emoji.treasure],
+    "pt": [Language.L.emoji.dig, " ",
+           "Procurando o tesouro enterrado!", " ",
            Language.L.emoji.treasure]
   },
   "tag_combo": {
@@ -1817,7 +2089,10 @@ Language.L.messages = {
            "写真。"],
     "np": ["कम्बो: ",
            "<INSERTNUM>",
-           " फोटोहरू"]
+           " फोटोहरू"],
+    "pt": [" combo: ",
+           "<INSERTNUM>",
+           " fotos."]
   },
   "tag_subject": {
     "cn": ["<INSERTNUM>",
@@ -1854,7 +2129,15 @@ Language.L.messages = {
            "<INSERTEMOJI>",
            " ",
            "<INSERTTAG>",
-           "।"]
+           "।"],
+    "pt": ["<INSERTNUM>",
+           " ",
+           "<INSERTNAME>",
+           " fotos etiquetadas com ",
+           "<INSERTEMOJI>",
+           " ",
+           "<INSERTTAG>",
+           "."]
   },
   "trick_or_treat": {
     "cn": [Language.L.emoji.pumpkin, " ",
@@ -1866,12 +2149,14 @@ Language.L.messages = {
     "es": [Language.L.emoji.pumpkin, " ",
            "¡Truco o trato!", " ",
            Language.L.emoji.pumpkin],
-    "jp": [Language.L.emoji.pumpkin, " " ,
+    "jp": [Language.L.emoji.pumpkin, " ",
            "不気味なカボチャ", " ",
            Language.L.emoji.pumpkin],
-    "np": [Language.L.emoji.pumpkin, " " ,
+    "np": [Language.L.emoji.pumpkin, " ",
            "डरलाग्दो कद्दु", " ",
-           Language.L.emoji.pumpkin]
+           Language.L.emoji.pumpkin],
+    "pt": [Language.L.emoji.pumpkin, " ",
+           "Gostosuras ou travessuras", " "
   },
   "zoo_details_babies": {
     "cn": [Language.L.emoji.baby,
@@ -1901,6 +2186,11 @@ Language.L.messages = {
            " ",
            "<INSERTBABIES>",
            " पछि बच्चा जन्मे ",
+           "<INSERTYEAR>"],
+    "pt": [Language.L.emoji.baby,
+           " ",
+           "<INSERTBABIES>",
+           " filhotes nascidos desde ",
            "<INSERTYEAR>"]
   },
   "zoo_details_departures": {
@@ -1924,7 +2214,11 @@ Language.L.messages = {
     "np": [Language.L.emoji.truck,
            " ",
            "<INSERTNUM>",
-           " भर्खरको प्रस्थान"]
+           " भर्खरको प्रस्थान"],
+    "pt": [Language.L.emoji.truck,
+           " ",
+           "<INSERTNUM>", 
+           " partidas recentes"]
   },
   "zoo_details_pandas_live_here": {
     "cn": [Language.L.emoji.panda,
@@ -1947,7 +2241,11 @@ Language.L.messages = {
     "np": [Language.L.emoji.panda,
            " ",
            "<INSERTNUM>",
-           " पांडा यहाँ बस्छन्"]
+           " पांडा यहाँ बस्छन्"],
+    "pt": [Language.L.emoji.panda,
+           " ",
+           "<INSERTNUM>",
+           " pandas-vermelhos moram aqui"]
   },
   "zoo_details_no_pandas_live_here": {
     "cn": [Language.L.emoji.panda,
@@ -1964,7 +2262,10 @@ Language.L.messages = {
            "パンダが見つかりません"],
     "np": [Language.L.emoji.panda,
            " ",
-           "कुनै निगल्य पोन्या फेला परेन"]
+           "कुनै निगल्य पोन्या फेला परेन"],
+    "pt": [Language.L.emoji.panda,
+           " ",
+           "Nenhum panda-vermelho atualmente aqui"]
   },
   "zoo_details_records": {
     "cn": [Language.L.emoji.recordbook,
@@ -1993,6 +2294,11 @@ Language.L.messages = {
            " ",
            "<INSERTNUM>",
            " रेचोर्ड्स इन द दताबसे सिन्के ",
+           "<INSERTYEAR>"],
+    "pt": [Language.L.emoji.recordbook,
+           " ",
+           "<INSERTNUM>",
+           " registrados na base de dados desde ",
            "<INSERTYEAR>"]
   },
   "zoo_header_new_arrivals": {
@@ -2010,7 +2316,10 @@ Language.L.messages = {
            "新着"],
     "np": [Language.L.emoji.fireworks,
            " ",
-           "नयाँ आगमन"]
+           "नयाँ आगमन"],
+    "pt": [Language.L.emoji.fireworks,
+           " ",
+           "Novas chegadas"]
   },
   "zoo_header_other_pandas": {
     "cn": [Language.L.emoji.panda,
@@ -2032,7 +2341,11 @@ Language.L.messages = {
     "np": [Language.L.emoji.panda,
            " ",
            "<INSERTZOO>",
-           " अन्य पोन्या"]
+           " अन्य पोन्या"],
+    "pt": [Language.L.emoji.panda,
+           " ",
+           "Outros pandas em ",
+           "<INSERTZOO>"]
   },
   "zoo_header_recently_departed": {
     "cn": [Language.L.emoji.truck,
@@ -2049,7 +2362,10 @@ Language.L.messages = {
            "最近出発しました"],
     "np": [Language.L.emoji.truck,
            " ",
-           "भर्खर प्रस्थान"]
+           "भर्खर प्रस्थान"],
+    "pt": [Language.L.emoji.truck,
+           " ",
+           "Partiram recentemente"]
   }
 }
 
@@ -2061,7 +2377,8 @@ Language.L.polyglots = {
     "en": ["baby", "babies", "Baby", "Aka-chan", "Akachan"],
     "es": ["bebé", "bebe", "bebés", "bebes"],
     "jp": ["赤", "赤ちゃん"],
-    "np": ["बच्चा"]
+    "np": ["बच्चा"],
+	"pt": ["bebê", "bebês", "bebé", "bebés"]
   }
 }
 
@@ -2079,7 +2396,8 @@ Language.L.tags = {
               "air taste"],
        "es": ["saboreando el aire"],
        "jp": ["舌ヒラヒラ"],
-       "np": ["हावा चाख्ने"]
+       "np": ["हावा चाख्ने"],
+	   "pt": ["degustando o ar", "gosto do ar"]
   },
   "apple time": {
        "cn": ["苹果时间", "苹果"],
@@ -2087,7 +2405,8 @@ Language.L.tags = {
        "en": ["apple time", "apple"],
        "es": ["hora de la manazana", "manzana"],
        "jp": ["りんごタイム", "りんご"],
-       "np": ["स्याउ समय", "स्याउ"]
+       "np": ["स्याउ समय", "स्याउ"],
+	   "pt": ["hora da maçã", "maçã"]
   },
   "autumn": {
        "cn": ["秋天"],
@@ -2095,7 +2414,8 @@ Language.L.tags = {
        "en": ["autumn", "fall"],
        "es": ["otoño"],
        "jp": ["秋"],
-       "np": ["शरद तु"]
+       "np": ["शरद तु"],
+	   "pt": ["outono"]
   },
   "bamboo": {
        "cn": ["竹子", "竹"],
@@ -2103,7 +2423,8 @@ Language.L.tags = {
        "en": ["bamboo"],
        "es": ["bambú", "bambu"],
        "jp": ["笹", "竹"],
-       "np": ["बाँस"]
+       "np": ["बाँस"],
+	   "pt": ["bambu"]
   },
   "bear worm": {
        "cn": ["蠕动"],
@@ -2111,7 +2432,8 @@ Language.L.tags = {
        "en": ["bear worm", "bear-worm"],
        "es": ["gusan-oso", "gusanoso"],
        "jp": ["のびのび"],
-       "np": ["कीरा भालु"]
+       "np": ["कीरा भालु"],
+	   "pt": ["relaxado"]
   },
   "bite": {
        "cn": ["咬", "吃"],
@@ -2119,7 +2441,8 @@ Language.L.tags = {
        "en": ["bite"],
        "es": ["morder"],
        "jp": ["一口"],
-       "np": ["काट्नु"]
+       "np": ["काट्नु"],
+	   "pt": ["mordida"]
   },
   "blink": {
        "cn": ["眨眼"],
@@ -2127,7 +2450,8 @@ Language.L.tags = {
        "en": ["blink", "blinking"],
        "es": ["parpadear", "parpadeo"],
        "jp": ["まばたき"],
-       "np": ["झिम्काइ"]
+       "np": ["झिम्काइ"],
+	   "pt": ["pestanejando", "pestanejo"]
   },
   "bridge": {
        "cn": ["吊桥", "桥"],
@@ -2135,7 +2459,8 @@ Language.L.tags = {
        "en": ["bridge"],
        "es": ["puente"],
        "jp": ["吊り橋・渡し木", "架け橋"],
-       "np": ["पुल"]
+       "np": ["पुल"],
+	   "pt": ["ponte"]
   },
   "brothers": {
        "cn": ["兄弟"],
@@ -2143,7 +2468,8 @@ Language.L.tags = {
        "en": ["brothers", "bros"],
        "es": ["hermanos"],
        "jp": ["男兄弟"],
-       "np": ["भाइहरु"]
+       "np": ["भाइहरु"],
+	   "pt": ["irmãos"]
   },
   "carry": {
        "cn": ["运", "拿"],
@@ -2151,7 +2477,8 @@ Language.L.tags = {
        "en": ["carry", "holding"],
        "es": ["llevando", "sosteniendo"],
        "jp": ["笹運び", "枝運び", "運ぶ"],
-       "np": ["बोक्नु", "समात्नु"]
+       "np": ["बोक्नु", "समात्नु"],
+	   "pt": ["carregando", "levando", "segurando"]
   },
   "cherry blossoms": {
        "cn": ["樱花"],
@@ -2159,7 +2486,8 @@ Language.L.tags = {
        "en": ["cherry blossoms", "cherry blossom"],
        "es": ["flor de cerezo", "flores de cerezo"],
        "jp": ["桜"],
-       "np": ["चेरी खिल"]
+       "np": ["चेरी खिल"],
+	   "pt": ["flor de cerejeira", "flores de cerejeira", "flor de cereja", "flores de cereja", "sakura"]
   },
   "climb": {
        "cn": ["爬"],
@@ -2167,7 +2495,8 @@ Language.L.tags = {
        "en": ["climb", "climbing"],
        "es": ["trepando", "escalando"],
        "jp": ["木登り", "登る"],
-       "np": ["चढाई"]
+       "np": ["चढाई"],
+	   "pt": ["escalando", "subindo"]
   },
   "couple": {
        "cn": ["夫妇", "情侣"],
@@ -2175,7 +2504,8 @@ Language.L.tags = {
        "en": ["couple", "partners"],
        "es": ["pareja"],
        "jp": ["カップル", "夫婦", "ふうふ"],
-       "np": ["जोडी"]
+       "np": ["जोडी"],
+	   "pt": ["casal", "par"]
   },
   "destruction": {
        "cn": ["破坏"],
@@ -2183,7 +2513,8 @@ Language.L.tags = {
        "en": ["chaos", "destruction", "mess"],
        "es": ["caos", "destrucción", "destruccion", "desorden"],
        "jp": ["破壊"],
-       "np": ["विनाश"]
+       "np": ["विनाश"],
+	   "pt": ["caos", "destruição", "bagunça"]
   },
   "dig": {
        "cn": ["挖"],
@@ -2191,7 +2522,8 @@ Language.L.tags = {
        "en": ["dig", "digging", "digs"],
        "es": ["cavando", "excavando"],
        "jp": ["穴掘り"],
-       "np": ["खन्नुहोस्"]
+       "np": ["खन्नुहोस्"],
+	   "pt": ["cavando", "escavando"]
   },
   "dish": {
        "cn": ["盘子"],
@@ -2199,7 +2531,8 @@ Language.L.tags = {
        "en": ["dish", "plate"],
        "es": ["plato"],
        "jp": ["ごはん"],
-       "np": ["थाल"]
+       "np": ["थाल"],
+	   "pt": ["prato"]
   },
   "door": {
        "cn": ["门"],
@@ -2207,7 +2540,8 @@ Language.L.tags = {
        "en": ["door"],
        "es": ["puerta"],
        "jp": ["扉", "戸"],
-       "np": ["ढोका"]
+       "np": ["ढोका"],
+	   "pt": ["porta"]
   },
   "ear": {
        "cn": ["耳"],
@@ -2215,7 +2549,8 @@ Language.L.tags = {
        "en": ["ear", "ears"],
        "es": ["oreja", "orejas"],
        "jp": ["耳"],
-       "np": ["कान"]
+       "np": ["कान"],
+	   "pt": ["orelha", "orelhas"]
   },
   "eye": {
        "cn": ["眼睛", "眼"],
@@ -2223,7 +2558,8 @@ Language.L.tags = {
        "en": ["eye", "eyes"],
        "es": ["ojo", "ojos"],
        "jp": ["目"],
-       "np": ["कान"]
+       "np": ["कान"],
+	   "pt": ["olho", "olhos"]
   },
   "flowers": {
        "cn": ["花"],
@@ -2231,7 +2567,8 @@ Language.L.tags = {
        "en": ["flower", "flowers"],
        "es": ["flor", "flores"],
        "jp": ["花"],
-       "np": ["फूल", "फूलहरू"]
+       "np": ["फूल", "फूलहरू"],
+	   "pt": ["flor", "flores"]
   },
   "grooming": {
        "cn": ["梳毛"],
@@ -2239,7 +2576,8 @@ Language.L.tags = {
        "en": ["groom", "grooming", "cleaning"],
        "es": ["limpiándose", "limpiandose", "lamiéndose", "lamiendose", "lavándose", "lavandose"],
        "jp": ["毛づくろい"],
-       "np": ["फूलहरू"]
+       "np": ["फूलहरू"],
+	   "pt": ["limpando-se""]
   },
   "grumpy": {
        "cn": ["牢骚满腹"],
@@ -2247,7 +2585,8 @@ Language.L.tags = {
        "en": ["grumpy", "grouchy"],
        "es": ["gruñona", "gruñón", "grunona", "grunon"],
        "jp": ["ご機嫌ナナメ"],
-       "np": ["नराम्रो"]
+       "np": ["नराम्रो"],
+	   "pt": ["rabugento", "mal-humorado"]
   },
   "hammock": {
        "cn": ["吊床"],
@@ -2255,7 +2594,8 @@ Language.L.tags = {
        "en": ["hammock"],
        "es": ["hamaca"],
        "jp": ["ハンモック"],
-       "np": ["ह्यामॉक"]
+       "np": ["ह्यामॉक"],
+	   "pt": ["rede de dormir"]
   },
   "home": {
        "cn": ["家"],
@@ -2263,7 +2603,8 @@ Language.L.tags = {
        "en": ["home"],
        "es": ["casa", "en casa"],
        "jp": ["お家"],
-       "np": ["घर"]
+       "np": ["घर"],
+	   "pt": ["casa", "lar"]
   },
   "in love": {
        "cn": ["热恋", "恋爱"],
@@ -2271,7 +2612,8 @@ Language.L.tags = {
        "en": ["in love", "love"],
        "es": ["enamorado"],
        "jp": ["恋"],
-       "np": ["मायामा"]
+       "np": ["मायामा"],
+	   "pt": ["amor", "apaixonado"]
   },
   "itchy": {
        "cn": ["挠痒", "抓痒"],
@@ -2279,7 +2621,8 @@ Language.L.tags = {
        "en": ["itchy", "scratchy"],
        "es": ["rascándose", "rascandose"],
        "jp": ["カイカイ", "かゆい"],
-       "np": ["खुजली"]
+       "np": ["खुजली"],
+	   "pt": ["coceira", "coçando"]
   },
   "jizo": {
        "cn": ["地藏菩萨"],
@@ -2287,7 +2630,8 @@ Language.L.tags = {
        "en": ["jizo", "jizo statue", "statue"],
        "es": ["estatua"],
        "jp": ["お地蔵さん"],
-       "np": ["मूर्ति"]
+       "np": ["मूर्ति"],
+	   "pt": ["posição de estátua"]
   },
   "keeper": {
        "cn": ["饲养员"],
@@ -2295,7 +2639,8 @@ Language.L.tags = {
        "en": ["keeper", "zookeeper"],
        "es": ["cuidador", "cuidadora"],
        "jp": ["飼育員"],
-       "np": ["चिडियाखाना"]
+       "np": ["चिडियाखाना"],
+	   "pt": ["cuidador", "cuidadora"]
   },
   "kiss": {
        "cn": ["接吻", "亲亲", "吻"],
@@ -2303,7 +2648,8 @@ Language.L.tags = {
        "en": ["kissing", "kiss"],
        "es": ["beso", "besos"],
        "jp": ["接吻", "せっぷん", "キス"],
-       "np": ["चुम्बन"]
+       "np": ["चुम्बन"],
+	   "pt": ["beijo", "beijos", "beijando"]
   },
   "laying down": {
        "cn": ["躺"],
@@ -2311,7 +2657,8 @@ Language.L.tags = {
        "en": ["lay down", "laying down"],
        "es": ["acostado", "recostado"],
        "jp": ["寝そべっている"],
-       "np": ["तल राख्नु"]
+       "np": ["तल राख्नु"],
+	   "pt": ["deitado", "deitando-se"]
   },
   "lips": {
        "cn": ["唇"],
@@ -2319,7 +2666,8 @@ Language.L.tags = {
        "en": ["lips"],
        "es": ["labios"],
        "jp": ["くちびる"],
-       "np": ["ओठ"]
+       "np": ["ओठ"],
+	   "pt": ["lábios"]
   },
   "long-tongue": {
        "cn": ["伸长舌头"],
@@ -2328,7 +2676,8 @@ Language.L.tags = {
        "en": ["long tongue", "long-tongue"],
        "es": ["sacando la lengua"],
        "jp": ["長い舌"],
-       "np": ["लामो जीभ"]
+       "np": ["लामो जीभ"],
+	   "pt": ["mostrando a língua"]
   },
   "lunch time": {
        "cn": ["午餐时间"],
@@ -2336,7 +2685,8 @@ Language.L.tags = {
        "en": ["lunch time", "lunch"],
        "es": ["hora de comer", "almuerzo"],
        "jp": ["ランチの時間"],
-       "np": ["खाजा समय", "भोजन"]
+       "np": ["खाजा समय", "भोजन"],
+	   "pt": ["hora do almoço", "almoço"]
   },
   "mofumofu": {
         "cn": ["软软"],
@@ -2344,7 +2694,8 @@ Language.L.tags = {
         "en": ["mofumofu", "fluffy", "punchy"],
         "es": ["rechoncho", "rechoncha", "esponjoso", "esponjosa"],
         "jp": ["モフモフ"],
-        "np": ["रमाईलो"]
+        "np": ["रमाईलो"],
+		"pt": ["felpudo", "fofo", "gorducho", "rechonchudo"]
   },
   "muzzle": {
         "cn": ["口鼻套"],
@@ -2352,7 +2703,8 @@ Language.L.tags = {
         "en": ["muzzle", "snout"],
         "es": ["hocico", "trompa"],
         "jp": ["マズル"],
-        "np": ["थूली", "थोरै"]
+        "np": ["थूली", "थोरै"],
+		"pt": ["focinho"]
   },
   "night": {
         "cn": ["夜", "晚上"],
@@ -2360,7 +2712,8 @@ Language.L.tags = {
         "en": ["night"],
         "es": ["noche"],
         "jp": ["夜"],
-        "np": ["रात"]
+        "np": ["रात"],
+		"pt": ["noite"]
   },
   "nose": {
         "cn": ["鼻子"],
@@ -2368,7 +2721,8 @@ Language.L.tags = {
         "en": ["nose", "snout"],
         "es": ["nariz", "hocico"],
         "jp": ["鼻"],
-        "np": ["नाक"]
+        "np": ["नाक"],
+		"pt": ["nariz"]
   },
   "old": {
         "cn": ["老人"],
@@ -2376,7 +2730,8 @@ Language.L.tags = {
         "en": ["old"],
         "es": ["viejo", "vieja"],
         "jp": ["シニアパンダさん", "年老いた"],
-        "np": ["पुरानो"]
+        "np": ["पुरानो"],
+		"pt": ["idoso", "idosa"]
   },
   "panda bowl": {
         "cn": ["碗"],
@@ -2385,7 +2740,8 @@ Language.L.tags = {
         "en": ["panda bowl", "bowl"],
         "es": ["bola de panda", "bola"],
         "jp": ["エサ鉢"],
-        "np": ["पोनिया कटोरा"]
+        "np": ["पोनिया कटोरा"],
+		"pt": ["tigela de panda", "tigela"]
   },
   "paws": {
         "cn": ["爪"],
@@ -2393,7 +2749,8 @@ Language.L.tags = {
         "en": ["paws", "feet"],
         "es": ["patas", "pies"],
         "jp": ["足"],
-        "np": ["पन्जा"]
+        "np": ["पन्जा"],
+		"pt": ["patas", "pés"]
   },
   "peek": {
         "cn": ["偷窥"],
@@ -2401,7 +2758,8 @@ Language.L.tags = {
         "en": ["peek", "peeking"],
         "es": ["ojeando", "mirando", "curioseando"],
         "jp": ["チラ見"],
-        "np": ["झिक्नु"]
+        "np": ["झिक्नु"],
+		"pt": ["espiando"]
   },
   "playing": {
         "cn": ["玩耍"],
@@ -2409,7 +2767,8 @@ Language.L.tags = {
         "en": ["playing", "play"],
         "es": ["jugando", "jugar"],
         "jp": ["拝み食い", "両手食い"],
-        "np": ["खेलिरहेको", "खेल्नु"]
+        "np": ["खेलिरहेको", "खेल्नु"],
+		"pt": ["brincando"]
   },
   "poop": {
         "cn": ["便便"],
@@ -2417,7 +2776,8 @@ Language.L.tags = {
         "en": ["poop"],
         "es": ["heces", "caca", "mierda"],
         "jp": [Language.L.emoji.poop],
-        "np": [Language.L.emoji.poop]
+        "np": [Language.L.emoji.poop],
+		"pt": ["cocô", "cocó", "caca"]
   },
   "pooping": {
         "cn": ["便便"],
@@ -2427,7 +2787,8 @@ Language.L.tags = {
         "es": ["defecando", "haciendo caca", "cagando"],
         "jp": ["💩している"],
         "np": [Language.L.emoji.panda +
-               Language.L.emoji.poop]
+               Language.L.emoji.poop],
+		"pt": ["fazendo cocô", "fazendo caca"]
   },
   "portrait": {
         "cn": ["肖像"],
@@ -2435,7 +2796,8 @@ Language.L.tags = {
         "en": ["portrait", "square"],
         "es": ["retrato", "cuadrada"],
         "jp": ["顔写真"],
-        "np": ["चित्र"]
+        "np": ["चित्र"],
+		"pt": ["retrato"]
   },
   "praying": {
         "cn": ["祈祷"],
@@ -2443,7 +2805,8 @@ Language.L.tags = {
         "en": ["praying", "pray"],
         "es": ["rezando", "orando"],
         "jp": ["お祈りしている"],
-        "np": ["प्रार्थना गर्दै", "प्रार्थना"]
+        "np": ["प्रार्थना गर्दै", "प्रार्थना"],
+		"pt": ["rezando", "orando", "mãos postas"]
   },
   "profile": {
         "cn": ["资料"],
@@ -2451,7 +2814,8 @@ Language.L.tags = {
         "en": ["profile"],
         "es": ["perfil"],
         "jp": ["プロフィール画像"],
-        "np": ["प्रोफाइल"]
+        "np": ["प्रोफाइल"],
+		"pt": ["perfil"]
   },
   "pull-up": {
         "cn": ["引体向上"],
@@ -2459,7 +2823,8 @@ Language.L.tags = {
         "en": ["pull-up", "pull-ups", "pullup"],
         "es": ["flexiones", "dominadas"],
         "jp": ["鉄棒", "懸垂"],
-        "np": ["तान्नु"]
+        "np": ["तान्नु"],
+		"pt": ["flexões"]
   },
   "pumpkin": {
         "cn": ["南瓜"],
@@ -2467,7 +2832,8 @@ Language.L.tags = {
         "en": ["pumpkin", "halloween"],
         "es": ["calabaza"],
         "jp": ["かぼちゃ", "南瓜"],
-        "np": ["कद्दू", "हेलोवीन"]
+        "np": ["कद्दू", "हेलोवीन"],
+		"pt": ["abóbora"]
   },
   "reiwa": {
         "cn": ["令和"],
@@ -2475,7 +2841,8 @@ Language.L.tags = {
         "en": ["reiwa"],
         "es": ["reiwa"],
         "jp": ["令和"],
-        "np": [Language.L.emoji.reiwa]
+        "np": [Language.L.emoji.reiwa],
+		"pt": ["reiwa"]
   },
   "scale": {
         "cn": ["测体重"],
@@ -2483,7 +2850,8 @@ Language.L.tags = {
         "en": ["scale", "weigh-in", "weight"],
         "es": ["balanza", "pesa"],
         "jp": ["体重計", "たいじゅうけい"],
-        "np": ["स्केल", "तौल"]
+        "np": ["स्केल", "तौल"],
+		"pt": ["balança", "peso"]
   },
   "shake": {
         "cn": ["摇晃"],
@@ -2491,7 +2859,8 @@ Language.L.tags = {
         "en": ["shake", "shaking"],
         "es": ["sacudiéndose", "sacudiendose"],
         "jp": ["ドリパン", "ブルブル", "ゆらゆら"],
-        "np": ["हल्लाउनु"]
+        "np": ["हल्लाउनु"],
+		"pt": ["sacudindo-se"]
   },
   "shedding": {
         "cn": ["换毛"],
@@ -2499,7 +2868,8 @@ Language.L.tags = {
         "en": ["shedding", "changing fur", "losing fur", "losing hair"],
         "es": ["mudando", "mudando el pelo", "cambiando el pelo"],
         "jp": ["換毛", "泣いている"],
-        "np": ["सुस्त"]
+        "np": ["सुस्त"],
+		"pt": ["mudando o pelo", "perdendo pelo"]
   },
   "shoots": {
         "cn": ["竹笋"],
@@ -2507,7 +2877,8 @@ Language.L.tags = {
         "en": ["shoots", "shoot"],
         "es": ["brotes"],
         "jp": ["竹の子", "たけのこ"],
-        "np": ["बाँस को टुप्पो"]
+        "np": ["बाँस को टुप्पो"],
+		"pt": ["brotos". "broto"]
   },
   "siblings": {
         "cn": ["同胞"],
@@ -2515,7 +2886,8 @@ Language.L.tags = {
         "en": ["siblings"],
         "es": ["hermanos"],
         "jp": ["兄弟", "きょうだい"],
-        "np": ["भाइबहिनीहरू"]
+        "np": ["भाइबहिनीहरू"],
+		"pt": ["irmãos(ãs)"]
   },
   "sisters": {
         "cn": ["姐妹"],
@@ -2523,7 +2895,8 @@ Language.L.tags = {
         "en": ["sisters"],
         "es": ["hermanas"],
         "jp": ["姉妹"],
-        "np": ["बहिनीहरू"]
+        "np": ["बहिनीहरू"],
+		"pt": ["irmãs"]
   },
   "sleeping": {
         "cn": ["睡觉"],
@@ -2531,7 +2904,8 @@ Language.L.tags = {
         "en": ["sleeping", "sleep", "asleep"],
         "es": ["durmiendo", "dormido", "dormida", "durmiéndose", "durmiendose", "dormir"],
         "jp": ["寝ている"],
-        "np": ["सुत्नु", "निद्रा"]
+        "np": ["सुत्नु", "निद्रा"],
+		"pt": ["dormindo"]
   },
   "slobber": {
         "cn": ["口水", "流口水"],
@@ -2539,7 +2913,8 @@ Language.L.tags = {
         "en": ["slobber", "slobbering"],
         "es": ["babeándo", "babeando", "baba"],
         "jp": ["よだれをたらしている"],
-        "np": ["स्लोबर"]
+        "np": ["स्लोबर"],
+		"pt": ["babando", "baba"]
   },
   "smile": {
         "cn": ["笑", "微笑"],
@@ -2547,7 +2922,8 @@ Language.L.tags = {
         "en": ["smile", "smiling"],
         "es": ["sonriéndo", "sonriendo", "sonreír", "sonreir", "sonriente", "sonrisa"],
         "jp": ["スマイル"],
-        "np": ["हाँसो"]
+        "np": ["हाँसो"],
+		"pt": ["sorrindo", "sorriso", "sorridente"]
   },
   "snow": {
         "cn": ["雪"],
@@ -2555,7 +2931,8 @@ Language.L.tags = {
         "en": ["snow"],
         "es": ["nieve"],
         "jp": ["雪"],
-        "np": ["हिउँ"]
+        "np": ["हिउँ"],
+		"pt": ["neve"]
   },
   "spider": {
         "cn": ["蜘蛛"],
@@ -2563,7 +2940,8 @@ Language.L.tags = {
         "en": ["spider", "spider-bear", "spider bear"],
         "es": ["araña", "arana"],
         "jp": ["スパイダー"],
-        "np": ["माकुरो", "माकुरो भालु"]
+        "np": ["माकुरो", "माकुरो भालु"],
+		"pt": ["panda-aranha", "aranha"]
   },
   "standing": {
         "cn": ["站立"],
@@ -2571,7 +2949,8 @@ Language.L.tags = {
         "en": ["standing", "stand"],
         "es": ["de pie", "parado"],
         "jp": ["立っている"],
-        "np": ["खडा"]
+        "np": ["खडा"],
+		"pt": ["de pé", "em pé"]
   },
   "stretching": {
         "cn": ["拉伸"],
@@ -2579,7 +2958,8 @@ Language.L.tags = {
         "en": ["stretching", "stretch"],
         "es": ["estirándose", "estirandose"],
         "jp": ["ストレッチしている"],
-        "np": ["तन्नु", "तान्न"]
+        "np": ["तन्नु", "तान्न"],
+		"pt": ["espreguiçando-se"]
   },
   "surprise": {
         "cn": ["惊喜"],
@@ -2587,7 +2967,8 @@ Language.L.tags = {
         "en": ["surprise", "surprised"],
         "es": ["sorpresa", "sorprendido", "sorprendida"],
         "jp": ["びっくり"],
-        "np": ["अचम्म"]
+        "np": ["अचम्म"],
+		"pt": ["surpreso", "surpresa", "surpreendido"]
   },
   "tail": {
         "cn": ["尾巴"],
@@ -2595,7 +2976,8 @@ Language.L.tags = {
         "en": ["tail"],
         "es": ["cola"],
         "jp": ["しっぽ"],
-        "np": ["पुच्छर"]
+        "np": ["पुच्छर"],
+		"pt": ["cauda", "rabo"]
   },
   "techitechi": {
         "cn": ["目标"],
@@ -2603,7 +2985,8 @@ Language.L.tags = {
         "en": ["techitechi", "spot", "cute spot"],
         "es": ["lunares", "lunar"],
         "jp": ["テチテチ"],
-        "np": ["राम्रो स्थान"]
+        "np": ["राम्रो स्थान"],
+		"pt": ["pinta", "pintinha"]
   },
   "tongue": {
         "cn": ["舌"],
@@ -2611,7 +2994,8 @@ Language.L.tags = {
         "en": ["tongue"],
         "es": ["lengua"],
         "jp": ["べろ"],
-        "np": ["जिब्रो"]
+        "np": ["जिब्रो"],
+		"pt": ["língua"]
   },
   "toys": {
         "cn": ["玩具"],
@@ -2619,7 +3003,8 @@ Language.L.tags = {
         "en": ["toy", "toys"],
         "es": ["juguete", "juguetes"],
         "jp": ["遊具", "おもちゃ", "おもちゃ"],
-        "np": ["खेलौना"]
+        "np": ["खेलौना"],
+		"pt": ["brinquedo", "brinquedos"]
   },
   "tree": {
         "cn": ["树"],
@@ -2627,7 +3012,8 @@ Language.L.tags = {
         "en": ["tree", "trees"],
         "es": ["árbol", "arbol", "árboles", "arboles"],
         "jp": ["木"],
-        "np": ["रूख"]
+        "np": ["रूख"],
+		"pt": ["árvore", "árvores"]
   },
   "upside-down": {
         "cn": ["翻转"],
@@ -2635,7 +3021,8 @@ Language.L.tags = {
         "en": ["upside-down", "upside down"],
         "es": ["al revés", "al reves", "cabeza abajo"],
         "jp": ["逆さま"],
-        "np": ["तलको माथि"]
+        "np": ["तलको माथि"],
+		"pt": ["cabeça para baixo", "ponta-cabeça"]
   },
   "wink": {
         "cn": ["眨眼"],
@@ -2643,7 +3030,8 @@ Language.L.tags = {
         "en": ["wink", "winking"],
         "es": ["guiño", "guino"],
         "jp": ["ウィンク"],
-        "np": ["आखा भ्किम्काउनु"]
+        "np": ["आखा भ्किम्काउनु"],
+		"pt": ["piscando", "piscada", "piscadela", "piscar de olhos"]
   },
   "wet": {
         "cn": ["湿"],
@@ -2651,7 +3039,8 @@ Language.L.tags = {
         "en": ["wet"],
         "es": ["mojado", "mojada"],
         "jp": ["濡れた"],
-        "np": ["भिजेको"]
+        "np": ["भिजेको"],
+		"pt": ["molhado", "molhada"]
   },
   "white face": {
         "cn": ["浅色的脸"],
@@ -2659,7 +3048,8 @@ Language.L.tags = {
         "en": ["white face", "light face"],
         "es": ["cara blanca"],
         "jp": ["色白さん", "しろめん", "白面", "白めん"],
-        "np": ["सेतो अनुहार"]
+        "np": ["सेतो अनुहार"],
+		"pt": ["face branca"]
   },
   "window": {
         "cn": ["窗"],
@@ -2667,7 +3057,8 @@ Language.L.tags = {
         "en": ["window"],
         "es": ["ventana"],
         "jp": ["窓", "まど"],
-        "np": ["विन्डो"]
+        "np": ["विन्डो"],
+		"pt": ["janela"]
   },
   "whiskers": {
         "cn": ["晶須"],
@@ -2675,7 +3066,8 @@ Language.L.tags = {
         "en": ["whiskers", "whisker"],
         "es": ["bigotes", "bigote"],
         "jp": ["ひげ"],
-        "np": ["फुसफुस"]
+        "np": ["फुसफुस"],
+		"pt": ["bigode", "bigodes"]
   },
   "yawn": {
         "cn": ["哈欠", "呵欠"],
@@ -2683,7 +3075,8 @@ Language.L.tags = {
         "en": ["yawn", "yawning"],
         "es": ["bostezo", "bostezando"],
         "jp": ["あくび"],
-        "np": ["जांभई"]
+        "np": ["जांभई"],
+		"pt": ["bocejo", "bocejando"]
   }
 }
 
@@ -3254,6 +3647,31 @@ Language.unpluralize = function(pieces) {
                    .replace(/^un\s/, "Un ")
                    .replace(/^uno\s/, "Uno ")
                    .replace(/^una\s/, "Una ");
+      output.push(input);
+    }
+	 if (L.display == "pt") {
+    for (var input of pieces) {
+      input = input.replace(/\b1 fotos/, "uma foto")
+                   .replace(/\b1 novas fotos/, "uma nova foto")
+                   .replace(/\b1 meninos/, "um menino")
+                   .replace(/\b1 meninas/, "uma menina")
+                   .replace(/\b1 irmãos/, "um irmão")
+                   .replace(/\b1 irmãs/, "uma irmã")
+                   .replace(/\b1 filhos/, "um filho")
+                   .replace(/\b1 filhas/, "uma filha")
+                   .replace(/\b1 recém-nascidos(as)/, "um(a) recém-nascido(a)")
+                   .replace(/\b1 novos pandas-vermelhos/, "um novo panda-vermelho")
+                   .replace(/\b1 irmãos(ãs) bebês/, "um(a) irmão(ã) bebê")
+                   .replace(/\b1 pandas-vermelhos atualmente/, "um panda-vermelho atualmente")
+                   .replace(/\b1 pandas-vermelhos moram/, "um panda-vermelho mora")
+                   .replace(/\b1 filhotes nascidos/, "um filhote nascido")
+                   .replace(/\b1 registrados na base de dados/, "um registrado na base de dados")
+                   .replace(/\b1 partidas recentes/, "uma partida recente")
+                   .replace(/\b1 novos contribuintes/, "um novo contribuinte")
+                   .replace(/\bcombo: 1 fotos/, "combo: uma foto")
+                   .replace(/\bfotos etiquetadas/, "foto etiquetada")
+                   .replace(/^([^A-Za-z0-9]+)one\s/, "$1 One ")
+                   .replace(/^one\s/, "One ");
       output.push(input);
     }
     return output;

--- a/js/language.js
+++ b/js/language.js
@@ -239,7 +239,7 @@ Language.L.flags = {
        "Austria": "🇦🇹",
        "Belgium": "🇧🇪",
         "Bhutan": "🇧🇹",
-		"Brazil": "🇧🇷",
+        "Brazil": "🇧🇷",
         "Canada": "🇨🇦",
          "Chile": "🇨🇱",
          "China": "🇨🇳",
@@ -261,7 +261,7 @@ Language.L.flags = {
    "Netherlands": "🇳🇱",
    "New Zealand": "🇳🇿",
         "Poland": "🇵🇱",
-	  "Portugal": "🇵🇹",
+      "Portugal": "🇵🇹",
         "Russia": "🇷🇺",
      "Singapore": "🇸🇬",
       "Slovakia": "🇸🇰",
@@ -281,7 +281,7 @@ Language.L.gui = {
     "es": "Acerca\xa0de",
     "jp": "概要",
     "np": "बारेमा",
-	"pt": "Sobre"
+    "pt": "Sobre"
   },
   "autumn": {
     "cn": "秋",
@@ -289,7 +289,7 @@ Language.L.gui = {
     "es": "Otoño",
     "jp": "秋",
     "np": "शरद तु",
-	"pt": "Outono"
+    "pt": "Outono"
   },
   "babies": {
     "cn": "婴儿",
@@ -297,7 +297,7 @@ Language.L.gui = {
     "es": "Bebés",
     "jp": "乳幼児",
     "np": "बच्चाहरु",
-	"pt": "Bebês"
+    "pt": "Bebês"
   },
   "children": {
     "cn": Pandas.def.relations.children["cn"],
@@ -305,7 +305,7 @@ Language.L.gui = {
     "es": "Niños",
     "jp": Pandas.def.relations.children["jp"],
     "np": "बच्चाहरु",
-	"pt": "Filhos(as)"
+    "pt": "Filhos(as)"
   },
   "contribute": {
     "cn": "上传照片",
@@ -313,7 +313,7 @@ Language.L.gui = {
     "es": "Enviar una foto",
     "jp": "写真を提出する",
     "np": "फोटो पेश गर्नुहोस्",
-	"pt": "Enviar uma foto"
+    "pt": "Enviar uma foto"
   },
   "contribute_link": {
     "en": "https://docs.google.com/forms/d/1kKBv92o09wFIBFcvooYLm2cG8XksGcVQQSiu9SpHGf0",
@@ -325,7 +325,7 @@ Language.L.gui = {
     "es": "Copiado",
     "jp": "写す",
     "np": "अनुकरण गनु",
-	"pt": "Copiado"
+    "pt": "Copiado"
   },
   "fall": {
     "cn": "秋",   // Convenience duplicate of autumn
@@ -333,7 +333,7 @@ Language.L.gui = {
     "es": "Otoño",
     "jp": "秋",
     "np": "शरद तु",
-	"pt": "Outono"
+    "pt": "Outono"
   },
   "family": {
     "cn": "家族",
@@ -341,7 +341,7 @@ Language.L.gui = {
     "es": "Familia",
     "jp": "ファミリ",
     "np": "परिवार",
-	"pt": "Família"
+    "pt": "Família"
   },
   "father": {
     "cn": "父亲",
@@ -349,7 +349,7 @@ Language.L.gui = {
     "es": "Padre",
     "jp": "父",
     "np": "बुबा",
-	"pt": "Pai"
+    "pt": "Pai"
   },
   "flag": {
     "cn": Language.L.flags["China"],
@@ -357,7 +357,7 @@ Language.L.gui = {
     "es": Language.L.flags["Spain"],
     "jp": Language.L.flags["Japan"],
     "np": Language.L.flags["Nepal"],
-	"pt": Language.L.flags["Brazil"]
+    "pt": Language.L.flags["Brazil"]
   },
   "footerLink_rpf": {
     "cn": "小熊猫族谱项目",
@@ -381,7 +381,7 @@ Language.L.gui = {
     "es": "Home",
     "jp": "ホーム",
     "np": "होमपेज",
-	"pt:" "Início"
+    "pt": "Início"
   },
   "instagramLinks_body": {
     "cn": "",
@@ -407,7 +407,7 @@ Language.L.gui = {
     "es": "Pandas rojos en Instagram",
     "jp": "Instagram レッサーパンダ",
     "np": "Instagram निगल्य पोन्या",
-	"pt": "Pandas-vermelhos no Instagram"
+    "pt": "Pandas-vermelhos no Instagram"
   },
   "language": {
     "cn": {
@@ -418,7 +418,7 @@ Language.L.gui = {
       "kr": "朝鮮语",
       "np": "尼泊尔语",
       "pl": "波兰语",
-	  "pt": "葡萄牙语",
+      "pt": "葡萄牙语",
       "ru": "俄语",
       "se": "瑞典"
     },
@@ -430,7 +430,7 @@ Language.L.gui = {
       "kr": "Korean",
       "np": "Nepalese",
       "pl": "Polish",
-	  "pt": "Portuguese",
+      "pt": "Portuguese",
       "ru": "Russian",
       "se": "Swedish"
     },
@@ -442,7 +442,7 @@ Language.L.gui = {
       "kr": "Coreano",
       "np": "Nepalés",
       "pl": "Polaco",
-	  "pt": "Portugués",
+      "pt": "Portugués",
       "ru": "Ruso",
       "se": "Sueco"
     },
@@ -454,7 +454,7 @@ Language.L.gui = {
       "kr": "韓国語",
       "np": "ネパール語",
       "pl": "ポーランド語",
-	  "pt": "ポルトガル語",
+      "pt": "ポルトガル語",
       "ru": "ロシア語",
       "se": "スウェーデン"
     },
@@ -466,7 +466,7 @@ Language.L.gui = {
       "kr": "कोरियन",
       "np": "नेपाली",
       "pl": "पोलिश",
-	  "pt": "पोर्तुगाली",
+      "pt": "पोर्तुगाली",
       "ru": "रसियन",
       "se": "स्वीडिश"
     },
@@ -478,7 +478,7 @@ Language.L.gui = {
       "kr": "Coreano",
       "np": "Nepalês",
       "pl": "Polonês",
-	  "pt": "Português",
+      "pt": "Português",
       "ru": "Russo",
       "se": "Sueco"
     },
@@ -490,7 +490,7 @@ Language.L.gui = {
       "kr": "корейский",
       "np": "непальский",
       "pl": "польский",
-	  "pt": "португа́льский",
+      "pt": "португа́льский",
       "ru": "русский",
       "se": "шведский"
     },
@@ -502,7 +502,7 @@ Language.L.gui = {
       "kr": "Koreanska",
       "np": "Nepali",
       "pl": "Polska",
-	  "pt": "Portugisiska",
+      "pt": "Portugisiska",
       "ru": "Ryska",
       "se": "Svenska"
     }
@@ -513,7 +513,7 @@ Language.L.gui = {
     "es": "Cargando",
     "jp": "ローディング",
     "np": "लोड",
-	"pt": "Carregando..."
+    "pt": "Carregando..."
   },
   "litter": {
     "cn": Pandas.def.relations.litter["cn"],
@@ -521,7 +521,7 @@ Language.L.gui = {
     "es": "Camada",
     "jp": Pandas.def.relations.litter["jp"],
     "np": "रोटी",
-	"pt": "Ninhada"
+    "pt": "Ninhada"
   },
   "links": {
     "cn": "链接",
@@ -529,7 +529,7 @@ Language.L.gui = {
     "es": "Enlaces",
     "jp": "リンク",
     "np": "लिंक",
-	"pt": "Links"
+    "pt": "Links"
   },
   "me": {
     "cn": "我",
@@ -537,7 +537,7 @@ Language.L.gui = {
     "es": "Me",
     "jp": "私",
     "np": "म",
-	"pt": "Eu"
+    "pt": "Eu"
   },
   "media": {
     "cn": "媒体",
@@ -545,7 +545,7 @@ Language.L.gui = {
     "es": "Imagenes",
     "jp": "メディア",
     "np": "मिडिया",
-	"pt": "Imagens"
+    "pt": "Imagens"
   },
   "mother": {
     "cn": "母亲",
@@ -553,7 +553,7 @@ Language.L.gui = {
     "es": "Madre",
     "jp": "母",
     "np": "आमा",
-	"pt": "Mãe"
+    "pt": "Mãe"
   },
   "nicknames": {
     "cn": "昵称",
@@ -561,7 +561,7 @@ Language.L.gui = {
     "es": "Apodos",
     "jp": "ニックネーム",
     "np": "उपनामहरू",
-	"pt": "Apelidos"
+    "pt": "Apelidos"
   },
   "othernames": {
     "cn": "其他名称",
@@ -569,7 +569,7 @@ Language.L.gui = {
     "es": "Otros nombres",
     "jp": "他の名前",
     "np": "अरु नामहरु",
-	"pt": "Outros nomes"
+    "pt": "Outros nomes"
   },
   "paging": {
     "cn": "更多",
@@ -577,7 +577,7 @@ Language.L.gui = {
     "es": "Ver Más",
     "jp": "もっと",
     "np": "अधिक",
-	"pt": "Mais"
+    "pt": "Mais"
   },
   "parents": {
     "cn": Pandas.def.relations.parents["cn"],
@@ -585,7 +585,7 @@ Language.L.gui = {
     "es": "Padres",
     "jp": Pandas.def.relations.parents["jp"],
     "np": "अभिभावक",
-	"pt": "Pais"
+    "pt": "Pais"
   },
   "profile": {
     "cn": "档案",
@@ -593,7 +593,7 @@ Language.L.gui = {
     "es": "Perfil",
     "jp": "プロフィール",
     "np": "प्रोफाइल",
-	"pt": "Perfil"
+    "pt": "Perfil"
   },
   "quadruplet": {
     "cn": "四胞胎",
@@ -601,7 +601,7 @@ Language.L.gui = {
     "es": "Cuatrillizo",
     "jp": "四つ子",
     "np": "प्रोफाइल",
-	"pt": "Quadrigêmeos"
+    "pt": "Quadrigêmeos"
   },
   "random": {
     "cn": "随机",
@@ -609,7 +609,7 @@ Language.L.gui = {
     "es": "Aleatorio",
     "jp": "適当",
     "np": "अनियमित",
-	"pt": "Aleatório"
+    "pt": "Aleatório"
   },
   "redPandaCommunity_body": {
     "cn": "",
@@ -617,7 +617,7 @@ Language.L.gui = {
     "es": "",
     "jp": "",
     "np": "",
-	"pt": ""
+    "pt": ""
   },
   "redPandaCommunity_button": {
     "cn": "社区",
@@ -625,7 +625,7 @@ Language.L.gui = {
     "es": "Comunidad",
     "jp": "共同体",
     "np": "समुदाय",
-	"pt": "Comunidade"
+    "pt": "Comunidade"
   },
   "redPandaCommunity_header": {
     "cn": "小熊猫社区",
@@ -633,7 +633,7 @@ Language.L.gui = {
     "es": "Comunidad del Panda Rojo",
     "jp": "レッサーパンダの共同体",
     "np": "निगल्य पोन्या समुदाय",
-	"pt": "Comunidade do Panda-Vermelho"
+    "pt": "Comunidade do Panda-Vermelho"
   },
   "refresh": {
     "cn": "刷新",
@@ -641,7 +641,7 @@ Language.L.gui = {
     "es": "Refrescar",
     "jp": "リロード",
     "np": "ताजा गर्नु",
-	"pt": "Atualizar"
+    "pt": "Atualizar"
   },
   "search": {
     "cn": "搜索...",
@@ -649,7 +649,7 @@ Language.L.gui = {
     "es": "Buscar...",
     "jp": "サーチ...",
     "np": "खोज्नु",
-	"pt": "Pesquisar..."
+    "pt": "Pesquisar..."
   },
   "seen_date": {
     "cn": "目击日期 <INSERTDATE>",
@@ -657,7 +657,7 @@ Language.L.gui = {
     "es": "Visto <INSERTDATE>",
     "jp": "TOWRITE <INSERTDATE>",
     "np": "TOWRITE <INSERTDATE>",
-	"pt": "Visto em <INSERTDATE>"
+    "pt": "Visto em <INSERTDATE>"
   },
   "siblings": {
     "cn": Pandas.def.relations.siblings["cn"],
@@ -665,7 +665,7 @@ Language.L.gui = {
     "es": "Hermanos",
     "jp": Pandas.def.relations.siblings["jp"],
     "np": "भाइबहिनीहरू",
-	"pt": "Irmã(o)s"
+    "pt": "Irmã(o)s"
   },
   "since_date": {
     "cn": "自 <INSERTDATE>",
@@ -673,7 +673,7 @@ Language.L.gui = {
     "es": "Ya que <INSERTDATE>",
     "jp": "<INSERTDATE>から",
     "np": "<INSERTDATE>देखि",
-	"pt": "Desde <INSERTDATE>"
+    "pt": "Desde <INSERTDATE>"
   },
   "specialThanksLinks_body": {
     "cn": "",
@@ -681,7 +681,7 @@ Language.L.gui = {
     "es": "",
     "jp": "",
     "np": "",
-	"pt": ""
+    "pt": ""
   },
   "specialThanksLinks_button": {
     "cn": "鸣谢",
@@ -689,7 +689,7 @@ Language.L.gui = {
     "es": "Agradecimientos",
     "jp": "感佩",
     "np": "विशेष धन्यवाद",
-	"pt": "Agradecimentos Especiais"
+    "pt": "Agradecimentos Especiais"
   },
   "specialThanksLinks_header": {
     "cn": "鸣谢",
@@ -697,7 +697,7 @@ Language.L.gui = {
     "es": "Agradecimientos Especiales",
     "jp": "感佩",
     "np": "विशेष धन्यवाद",
-	"pt": "Agradecimentos Especiais"
+    "pt": "Agradecimentos Especiais"
   },
   "spring": {
     "cn": "春",
@@ -705,7 +705,7 @@ Language.L.gui = {
     "es": "Primavera",
     "jp": "春",
     "np": "वसन्त",
-	"pt": "Primavera"
+    "pt": "Primavera"
   },
   "summer": {
     "cn": "夏",
@@ -713,7 +713,7 @@ Language.L.gui = {
     "es": "Verano",
     "jp": "夏",
     "np": "गर्मी",
-	"pt": "Verão"
+    "pt": "Verão"
   },
   "title": {
     "cn": "查找小熊猫",
@@ -721,7 +721,7 @@ Language.L.gui = {
     "es": "Buscador de Panda Rojo",
     "jp": "レッサーパンダのファインダー",
     "np": "निगल्या पोनिया मित्र",
-	"pt": "Buscador de Pandas-Vermelhos"
+    "pt": "Buscador de Pandas-Vermelhos"
   },
   "top": {
     "cn": "顶部",
@@ -729,7 +729,7 @@ Language.L.gui = {
     "es": "Arriba",
     "jp": "上",
     "np": "माथि",
-	"pt": "Para cima"
+    "pt": "Para cima"
   },
   "tree": {
     "cn": "树",
@@ -737,7 +737,7 @@ Language.L.gui = {
     "es": "Árbol",
     "jp": "木",
     "np": "रूख",
-	"pt": "Árvore"
+    "pt": "Árvore"
   },
   "twin": {
     "cn": "双胞胎",
@@ -745,7 +745,7 @@ Language.L.gui = {
     "es": "Mellizo",
     "jp": "双子",
     "np": "जुम्ल्याहा",
-	"pt": "Gêmeo"
+    "pt": "Gêmeo"
   },
   "triplet": {
     "cn": "三胞胎",
@@ -753,7 +753,7 @@ Language.L.gui = {
     "es": "Trillizo",
     "jp": "三つ子",
     "np": "तीनवटा",
-	"pt": "Trigêmeo"
+    "pt": "Trigêmeo"
   },
   "winter": {
     "cn": "冬",
@@ -761,7 +761,7 @@ Language.L.gui = {
     "es": "Invierno",
     "jp": "冬",
     "np": "जाडो",
-	"pt": "Inverno"
+    "pt": "Inverno"
   },
   "zooLinks_body": {
     "cn": "",
@@ -777,7 +777,7 @@ Language.L.gui = {
     "es": "Zoológicos",
     "jp": "動物園",
     "np": "चिडियाखाना",
-	"pt": "Zoológicos"
+    "pt": "Zoológicos"
   },
   "zooLinks_header": {
     "cn": "小熊猫动物园",
@@ -785,7 +785,7 @@ Language.L.gui = {
     "es": "Principales Zoológicos de Pandas Rojos",
     "jp": "レッサーパンダの動物園",
     "np": "प्रमुख चिडियाखाना",
-	"pt": "Principais zoológicos com pandas-vermelhos".
+    "pt": "Principais zoológicos com pandas-vermelhos"
   }
 }
 
@@ -796,7 +796,7 @@ Language.L.messages = {
     "es": " y ",
     "jp": "と",
     "np": " र ",
-	"pt": "e"
+    "pt": "e"
   },
   "and_words": {
     "cn": "和",
@@ -804,7 +804,7 @@ Language.L.messages = {
     "es": " y ",
     "jp": "と",
     "np": " र ",
-	"pt": "e"
+    "pt": "e"
   },
   "arrived_from_zoo": {
     "cn": ["<INSERTDATE>",
@@ -1139,7 +1139,7 @@ Language.L.messages = {
     "es": ["¡Feliz Día de la Madre!"],
     "jp": ["母の日おめでとう"],
     "np": ["खुसी आमाको दिन!"],
-	"pt": ["Feliz Dia das Mães!"]
+    "pt": ["Feliz Dia das Mães!"]
   },
   "list_comma": {
     "cn": "、",
@@ -2156,7 +2156,8 @@ Language.L.messages = {
            "डरलाग्दो कद्दु", " ",
            Language.L.emoji.pumpkin],
     "pt": [Language.L.emoji.pumpkin, " ",
-           "Gostosuras ou travessuras", " "
+           "Gostosuras ou travessuras", " ",
+           Language.L.emoji.pumpkin],
   },
   "zoo_details_babies": {
     "cn": [Language.L.emoji.baby,
@@ -2378,7 +2379,7 @@ Language.L.polyglots = {
     "es": ["bebé", "bebe", "bebés", "bebes"],
     "jp": ["赤", "赤ちゃん"],
     "np": ["बच्चा"],
-	"pt": ["bebê", "bebês", "bebé", "bebés"]
+    "pt": ["bebê", "bebês", "bebé", "bebés"]
   }
 }
 
@@ -2397,7 +2398,7 @@ Language.L.tags = {
        "es": ["saboreando el aire"],
        "jp": ["舌ヒラヒラ"],
        "np": ["हावा चाख्ने"],
-	   "pt": ["degustando o ar", "gosto do ar"]
+       "pt": ["degustando o ar", "gosto do ar"]
   },
   "apple time": {
        "cn": ["苹果时间", "苹果"],
@@ -2406,7 +2407,7 @@ Language.L.tags = {
        "es": ["hora de la manazana", "manzana"],
        "jp": ["りんごタイム", "りんご"],
        "np": ["स्याउ समय", "स्याउ"],
-	   "pt": ["hora da maçã", "maçã"]
+       "pt": ["hora da maçã", "maçã"]
   },
   "autumn": {
        "cn": ["秋天"],
@@ -2415,7 +2416,7 @@ Language.L.tags = {
        "es": ["otoño"],
        "jp": ["秋"],
        "np": ["शरद तु"],
-	   "pt": ["outono"]
+       "pt": ["outono"]
   },
   "bamboo": {
        "cn": ["竹子", "竹"],
@@ -2424,7 +2425,7 @@ Language.L.tags = {
        "es": ["bambú", "bambu"],
        "jp": ["笹", "竹"],
        "np": ["बाँस"],
-	   "pt": ["bambu"]
+       "pt": ["bambu"]
   },
   "bear worm": {
        "cn": ["蠕动"],
@@ -2433,7 +2434,7 @@ Language.L.tags = {
        "es": ["gusan-oso", "gusanoso"],
        "jp": ["のびのび"],
        "np": ["कीरा भालु"],
-	   "pt": ["relaxado"]
+       "pt": ["relaxado"]
   },
   "bite": {
        "cn": ["咬", "吃"],
@@ -2442,7 +2443,7 @@ Language.L.tags = {
        "es": ["morder"],
        "jp": ["一口"],
        "np": ["काट्नु"],
-	   "pt": ["mordida"]
+       "pt": ["mordida"]
   },
   "blink": {
        "cn": ["眨眼"],
@@ -2451,7 +2452,7 @@ Language.L.tags = {
        "es": ["parpadear", "parpadeo"],
        "jp": ["まばたき"],
        "np": ["झिम्काइ"],
-	   "pt": ["pestanejando", "pestanejo"]
+       "pt": ["pestanejando", "pestanejo"]
   },
   "bridge": {
        "cn": ["吊桥", "桥"],
@@ -2460,7 +2461,7 @@ Language.L.tags = {
        "es": ["puente"],
        "jp": ["吊り橋・渡し木", "架け橋"],
        "np": ["पुल"],
-	   "pt": ["ponte"]
+       "pt": ["ponte"]
   },
   "brothers": {
        "cn": ["兄弟"],
@@ -2469,7 +2470,7 @@ Language.L.tags = {
        "es": ["hermanos"],
        "jp": ["男兄弟"],
        "np": ["भाइहरु"],
-	   "pt": ["irmãos"]
+       "pt": ["irmãos"]
   },
   "carry": {
        "cn": ["运", "拿"],
@@ -2478,7 +2479,7 @@ Language.L.tags = {
        "es": ["llevando", "sosteniendo"],
        "jp": ["笹運び", "枝運び", "運ぶ"],
        "np": ["बोक्नु", "समात्नु"],
-	   "pt": ["carregando", "levando", "segurando"]
+       "pt": ["carregando", "levando", "segurando"]
   },
   "cherry blossoms": {
        "cn": ["樱花"],
@@ -2487,7 +2488,7 @@ Language.L.tags = {
        "es": ["flor de cerezo", "flores de cerezo"],
        "jp": ["桜"],
        "np": ["चेरी खिल"],
-	   "pt": ["flor de cerejeira", "flores de cerejeira", "flor de cereja", "flores de cereja", "sakura"]
+       "pt": ["flor de cerejeira", "flores de cerejeira", "flor de cereja", "flores de cereja", "sakura"]
   },
   "climb": {
        "cn": ["爬"],
@@ -2496,7 +2497,7 @@ Language.L.tags = {
        "es": ["trepando", "escalando"],
        "jp": ["木登り", "登る"],
        "np": ["चढाई"],
-	   "pt": ["escalando", "subindo"]
+       "pt": ["escalando", "subindo"]
   },
   "couple": {
        "cn": ["夫妇", "情侣"],
@@ -2505,7 +2506,7 @@ Language.L.tags = {
        "es": ["pareja"],
        "jp": ["カップル", "夫婦", "ふうふ"],
        "np": ["जोडी"],
-	   "pt": ["casal", "par"]
+       "pt": ["casal", "par"]
   },
   "destruction": {
        "cn": ["破坏"],
@@ -2514,7 +2515,7 @@ Language.L.tags = {
        "es": ["caos", "destrucción", "destruccion", "desorden"],
        "jp": ["破壊"],
        "np": ["विनाश"],
-	   "pt": ["caos", "destruição", "bagunça"]
+       "pt": ["caos", "destruição", "bagunça"]
   },
   "dig": {
        "cn": ["挖"],
@@ -2523,7 +2524,7 @@ Language.L.tags = {
        "es": ["cavando", "excavando"],
        "jp": ["穴掘り"],
        "np": ["खन्नुहोस्"],
-	   "pt": ["cavando", "escavando"]
+       "pt": ["cavando", "escavando"]
   },
   "dish": {
        "cn": ["盘子"],
@@ -2532,7 +2533,7 @@ Language.L.tags = {
        "es": ["plato"],
        "jp": ["ごはん"],
        "np": ["थाल"],
-	   "pt": ["prato"]
+       "pt": ["prato"]
   },
   "door": {
        "cn": ["门"],
@@ -2541,7 +2542,7 @@ Language.L.tags = {
        "es": ["puerta"],
        "jp": ["扉", "戸"],
        "np": ["ढोका"],
-	   "pt": ["porta"]
+       "pt": ["porta"]
   },
   "ear": {
        "cn": ["耳"],
@@ -2550,7 +2551,7 @@ Language.L.tags = {
        "es": ["oreja", "orejas"],
        "jp": ["耳"],
        "np": ["कान"],
-	   "pt": ["orelha", "orelhas"]
+       "pt": ["orelha", "orelhas"]
   },
   "eye": {
        "cn": ["眼睛", "眼"],
@@ -2559,7 +2560,7 @@ Language.L.tags = {
        "es": ["ojo", "ojos"],
        "jp": ["目"],
        "np": ["कान"],
-	   "pt": ["olho", "olhos"]
+       "pt": ["olho", "olhos"]
   },
   "flowers": {
        "cn": ["花"],
@@ -2568,7 +2569,7 @@ Language.L.tags = {
        "es": ["flor", "flores"],
        "jp": ["花"],
        "np": ["फूल", "फूलहरू"],
-	   "pt": ["flor", "flores"]
+       "pt": ["flor", "flores"]
   },
   "grooming": {
        "cn": ["梳毛"],
@@ -2577,7 +2578,7 @@ Language.L.tags = {
        "es": ["limpiándose", "limpiandose", "lamiéndose", "lamiendose", "lavándose", "lavandose"],
        "jp": ["毛づくろい"],
        "np": ["फूलहरू"],
-	   "pt": ["limpando-se""]
+       "pt": ["limpando-se"]
   },
   "grumpy": {
        "cn": ["牢骚满腹"],
@@ -2586,7 +2587,7 @@ Language.L.tags = {
        "es": ["gruñona", "gruñón", "grunona", "grunon"],
        "jp": ["ご機嫌ナナメ"],
        "np": ["नराम्रो"],
-	   "pt": ["rabugento", "mal-humorado"]
+       "pt": ["rabugento", "mal-humorado"]
   },
   "hammock": {
        "cn": ["吊床"],
@@ -2595,7 +2596,7 @@ Language.L.tags = {
        "es": ["hamaca"],
        "jp": ["ハンモック"],
        "np": ["ह्यामॉक"],
-	   "pt": ["rede de dormir"]
+       "pt": ["rede de dormir"]
   },
   "home": {
        "cn": ["家"],
@@ -2604,7 +2605,7 @@ Language.L.tags = {
        "es": ["casa", "en casa"],
        "jp": ["お家"],
        "np": ["घर"],
-	   "pt": ["casa", "lar"]
+       "pt": ["casa", "lar"]
   },
   "in love": {
        "cn": ["热恋", "恋爱"],
@@ -2613,7 +2614,7 @@ Language.L.tags = {
        "es": ["enamorado"],
        "jp": ["恋"],
        "np": ["मायामा"],
-	   "pt": ["amor", "apaixonado"]
+       "pt": ["amor", "apaixonado"]
   },
   "itchy": {
        "cn": ["挠痒", "抓痒"],
@@ -2622,7 +2623,7 @@ Language.L.tags = {
        "es": ["rascándose", "rascandose"],
        "jp": ["カイカイ", "かゆい"],
        "np": ["खुजली"],
-	   "pt": ["coceira", "coçando"]
+       "pt": ["coceira", "coçando"]
   },
   "jizo": {
        "cn": ["地藏菩萨"],
@@ -2631,7 +2632,7 @@ Language.L.tags = {
        "es": ["estatua"],
        "jp": ["お地蔵さん"],
        "np": ["मूर्ति"],
-	   "pt": ["posição de estátua"]
+       "pt": ["posição de estátua"]
   },
   "keeper": {
        "cn": ["饲养员"],
@@ -2640,7 +2641,7 @@ Language.L.tags = {
        "es": ["cuidador", "cuidadora"],
        "jp": ["飼育員"],
        "np": ["चिडियाखाना"],
-	   "pt": ["cuidador", "cuidadora"]
+       "pt": ["cuidador", "cuidadora"]
   },
   "kiss": {
        "cn": ["接吻", "亲亲", "吻"],
@@ -2649,7 +2650,7 @@ Language.L.tags = {
        "es": ["beso", "besos"],
        "jp": ["接吻", "せっぷん", "キス"],
        "np": ["चुम्बन"],
-	   "pt": ["beijo", "beijos", "beijando"]
+       "pt": ["beijo", "beijos", "beijando"]
   },
   "laying down": {
        "cn": ["躺"],
@@ -2658,7 +2659,7 @@ Language.L.tags = {
        "es": ["acostado", "recostado"],
        "jp": ["寝そべっている"],
        "np": ["तल राख्नु"],
-	   "pt": ["deitado", "deitando-se"]
+       "pt": ["deitado", "deitando-se"]
   },
   "lips": {
        "cn": ["唇"],
@@ -2667,7 +2668,7 @@ Language.L.tags = {
        "es": ["labios"],
        "jp": ["くちびる"],
        "np": ["ओठ"],
-	   "pt": ["lábios"]
+       "pt": ["lábios"]
   },
   "long-tongue": {
        "cn": ["伸长舌头"],
@@ -2677,7 +2678,7 @@ Language.L.tags = {
        "es": ["sacando la lengua"],
        "jp": ["長い舌"],
        "np": ["लामो जीभ"],
-	   "pt": ["mostrando a língua"]
+       "pt": ["mostrando a língua"]
   },
   "lunch time": {
        "cn": ["午餐时间"],
@@ -2686,7 +2687,7 @@ Language.L.tags = {
        "es": ["hora de comer", "almuerzo"],
        "jp": ["ランチの時間"],
        "np": ["खाजा समय", "भोजन"],
-	   "pt": ["hora do almoço", "almoço"]
+       "pt": ["hora do almoço", "almoço"]
   },
   "mofumofu": {
         "cn": ["软软"],
@@ -2695,7 +2696,7 @@ Language.L.tags = {
         "es": ["rechoncho", "rechoncha", "esponjoso", "esponjosa"],
         "jp": ["モフモフ"],
         "np": ["रमाईलो"],
-		"pt": ["felpudo", "fofo", "gorducho", "rechonchudo"]
+        "pt": ["felpudo", "fofo", "gorducho", "rechonchudo"]
   },
   "muzzle": {
         "cn": ["口鼻套"],
@@ -2704,7 +2705,7 @@ Language.L.tags = {
         "es": ["hocico", "trompa"],
         "jp": ["マズル"],
         "np": ["थूली", "थोरै"],
-		"pt": ["focinho"]
+        "pt": ["focinho"]
   },
   "night": {
         "cn": ["夜", "晚上"],
@@ -2713,7 +2714,7 @@ Language.L.tags = {
         "es": ["noche"],
         "jp": ["夜"],
         "np": ["रात"],
-		"pt": ["noite"]
+        "pt": ["noite"]
   },
   "nose": {
         "cn": ["鼻子"],
@@ -2722,7 +2723,7 @@ Language.L.tags = {
         "es": ["nariz", "hocico"],
         "jp": ["鼻"],
         "np": ["नाक"],
-		"pt": ["nariz"]
+        "pt": ["nariz"]
   },
   "old": {
         "cn": ["老人"],
@@ -2731,7 +2732,7 @@ Language.L.tags = {
         "es": ["viejo", "vieja"],
         "jp": ["シニアパンダさん", "年老いた"],
         "np": ["पुरानो"],
-		"pt": ["idoso", "idosa"]
+        "pt": ["idoso", "idosa"]
   },
   "panda bowl": {
         "cn": ["碗"],
@@ -2741,7 +2742,7 @@ Language.L.tags = {
         "es": ["bola de panda", "bola"],
         "jp": ["エサ鉢"],
         "np": ["पोनिया कटोरा"],
-		"pt": ["tigela de panda", "tigela"]
+        "pt": ["tigela de panda", "tigela"]
   },
   "paws": {
         "cn": ["爪"],
@@ -2750,7 +2751,7 @@ Language.L.tags = {
         "es": ["patas", "pies"],
         "jp": ["足"],
         "np": ["पन्जा"],
-		"pt": ["patas", "pés"]
+        "pt": ["patas", "pés"]
   },
   "peek": {
         "cn": ["偷窥"],
@@ -2759,7 +2760,7 @@ Language.L.tags = {
         "es": ["ojeando", "mirando", "curioseando"],
         "jp": ["チラ見"],
         "np": ["झिक्नु"],
-		"pt": ["espiando"]
+        "pt": ["espiando"]
   },
   "playing": {
         "cn": ["玩耍"],
@@ -2768,7 +2769,7 @@ Language.L.tags = {
         "es": ["jugando", "jugar"],
         "jp": ["拝み食い", "両手食い"],
         "np": ["खेलिरहेको", "खेल्नु"],
-		"pt": ["brincando"]
+        "pt": ["brincando"]
   },
   "poop": {
         "cn": ["便便"],
@@ -2777,7 +2778,7 @@ Language.L.tags = {
         "es": ["heces", "caca", "mierda"],
         "jp": [Language.L.emoji.poop],
         "np": [Language.L.emoji.poop],
-		"pt": ["cocô", "cocó", "caca"]
+        "pt": ["cocô", "cocó", "caca"]
   },
   "pooping": {
         "cn": ["便便"],
@@ -2788,7 +2789,7 @@ Language.L.tags = {
         "jp": ["💩している"],
         "np": [Language.L.emoji.panda +
                Language.L.emoji.poop],
-		"pt": ["fazendo cocô", "fazendo caca"]
+        "pt": ["fazendo cocô", "fazendo caca"]
   },
   "portrait": {
         "cn": ["肖像"],
@@ -2797,7 +2798,7 @@ Language.L.tags = {
         "es": ["retrato", "cuadrada"],
         "jp": ["顔写真"],
         "np": ["चित्र"],
-		"pt": ["retrato"]
+        "pt": ["retrato"]
   },
   "praying": {
         "cn": ["祈祷"],
@@ -2806,7 +2807,7 @@ Language.L.tags = {
         "es": ["rezando", "orando"],
         "jp": ["お祈りしている"],
         "np": ["प्रार्थना गर्दै", "प्रार्थना"],
-		"pt": ["rezando", "orando", "mãos postas"]
+        "pt": ["rezando", "orando", "mãos postas"]
   },
   "profile": {
         "cn": ["资料"],
@@ -2815,7 +2816,7 @@ Language.L.tags = {
         "es": ["perfil"],
         "jp": ["プロフィール画像"],
         "np": ["प्रोफाइल"],
-		"pt": ["perfil"]
+        "pt": ["perfil"]
   },
   "pull-up": {
         "cn": ["引体向上"],
@@ -2824,7 +2825,7 @@ Language.L.tags = {
         "es": ["flexiones", "dominadas"],
         "jp": ["鉄棒", "懸垂"],
         "np": ["तान्नु"],
-		"pt": ["flexões"]
+        "pt": ["flexões"]
   },
   "pumpkin": {
         "cn": ["南瓜"],
@@ -2833,7 +2834,7 @@ Language.L.tags = {
         "es": ["calabaza"],
         "jp": ["かぼちゃ", "南瓜"],
         "np": ["कद्दू", "हेलोवीन"],
-		"pt": ["abóbora"]
+        "pt": ["abóbora"]
   },
   "reiwa": {
         "cn": ["令和"],
@@ -2842,7 +2843,7 @@ Language.L.tags = {
         "es": ["reiwa"],
         "jp": ["令和"],
         "np": [Language.L.emoji.reiwa],
-		"pt": ["reiwa"]
+        "pt": ["reiwa"]
   },
   "scale": {
         "cn": ["测体重"],
@@ -2851,7 +2852,7 @@ Language.L.tags = {
         "es": ["balanza", "pesa"],
         "jp": ["体重計", "たいじゅうけい"],
         "np": ["स्केल", "तौल"],
-		"pt": ["balança", "peso"]
+        "pt": ["balança", "peso"]
   },
   "shake": {
         "cn": ["摇晃"],
@@ -2860,7 +2861,7 @@ Language.L.tags = {
         "es": ["sacudiéndose", "sacudiendose"],
         "jp": ["ドリパン", "ブルブル", "ゆらゆら"],
         "np": ["हल्लाउनु"],
-		"pt": ["sacudindo-se"]
+        "pt": ["sacudindo-se"]
   },
   "shedding": {
         "cn": ["换毛"],
@@ -2869,7 +2870,7 @@ Language.L.tags = {
         "es": ["mudando", "mudando el pelo", "cambiando el pelo"],
         "jp": ["換毛", "泣いている"],
         "np": ["सुस्त"],
-		"pt": ["mudando o pelo", "perdendo pelo"]
+        "pt": ["mudando o pelo", "perdendo pelo"]
   },
   "shoots": {
         "cn": ["竹笋"],
@@ -2878,7 +2879,7 @@ Language.L.tags = {
         "es": ["brotes"],
         "jp": ["竹の子", "たけのこ"],
         "np": ["बाँस को टुप्पो"],
-		"pt": ["brotos". "broto"]
+        "pt": ["brotos", "broto"]
   },
   "siblings": {
         "cn": ["同胞"],
@@ -2887,7 +2888,7 @@ Language.L.tags = {
         "es": ["hermanos"],
         "jp": ["兄弟", "きょうだい"],
         "np": ["भाइबहिनीहरू"],
-		"pt": ["irmãos(ãs)"]
+        "pt": ["irmãos(ãs)"]
   },
   "sisters": {
         "cn": ["姐妹"],
@@ -2896,7 +2897,7 @@ Language.L.tags = {
         "es": ["hermanas"],
         "jp": ["姉妹"],
         "np": ["बहिनीहरू"],
-		"pt": ["irmãs"]
+        "pt": ["irmãs"]
   },
   "sleeping": {
         "cn": ["睡觉"],
@@ -2905,7 +2906,7 @@ Language.L.tags = {
         "es": ["durmiendo", "dormido", "dormida", "durmiéndose", "durmiendose", "dormir"],
         "jp": ["寝ている"],
         "np": ["सुत्नु", "निद्रा"],
-		"pt": ["dormindo"]
+        "pt": ["dormindo"]
   },
   "slobber": {
         "cn": ["口水", "流口水"],
@@ -2914,7 +2915,7 @@ Language.L.tags = {
         "es": ["babeándo", "babeando", "baba"],
         "jp": ["よだれをたらしている"],
         "np": ["स्लोबर"],
-		"pt": ["babando", "baba"]
+        "pt": ["babando", "baba"]
   },
   "smile": {
         "cn": ["笑", "微笑"],
@@ -2923,7 +2924,7 @@ Language.L.tags = {
         "es": ["sonriéndo", "sonriendo", "sonreír", "sonreir", "sonriente", "sonrisa"],
         "jp": ["スマイル"],
         "np": ["हाँसो"],
-		"pt": ["sorrindo", "sorriso", "sorridente"]
+        "pt": ["sorrindo", "sorriso", "sorridente"]
   },
   "snow": {
         "cn": ["雪"],
@@ -2932,7 +2933,7 @@ Language.L.tags = {
         "es": ["nieve"],
         "jp": ["雪"],
         "np": ["हिउँ"],
-		"pt": ["neve"]
+        "pt": ["neve"]
   },
   "spider": {
         "cn": ["蜘蛛"],
@@ -2941,7 +2942,7 @@ Language.L.tags = {
         "es": ["araña", "arana"],
         "jp": ["スパイダー"],
         "np": ["माकुरो", "माकुरो भालु"],
-		"pt": ["panda-aranha", "aranha"]
+        "pt": ["panda-aranha", "aranha"]
   },
   "standing": {
         "cn": ["站立"],
@@ -2950,7 +2951,7 @@ Language.L.tags = {
         "es": ["de pie", "parado"],
         "jp": ["立っている"],
         "np": ["खडा"],
-		"pt": ["de pé", "em pé"]
+        "pt": ["de pé", "em pé"]
   },
   "stretching": {
         "cn": ["拉伸"],
@@ -2959,7 +2960,7 @@ Language.L.tags = {
         "es": ["estirándose", "estirandose"],
         "jp": ["ストレッチしている"],
         "np": ["तन्नु", "तान्न"],
-		"pt": ["espreguiçando-se"]
+        "pt": ["espreguiçando-se"]
   },
   "surprise": {
         "cn": ["惊喜"],
@@ -2968,7 +2969,7 @@ Language.L.tags = {
         "es": ["sorpresa", "sorprendido", "sorprendida"],
         "jp": ["びっくり"],
         "np": ["अचम्म"],
-		"pt": ["surpreso", "surpresa", "surpreendido"]
+        "pt": ["surpreso", "surpresa", "surpreendido"]
   },
   "tail": {
         "cn": ["尾巴"],
@@ -2977,7 +2978,7 @@ Language.L.tags = {
         "es": ["cola"],
         "jp": ["しっぽ"],
         "np": ["पुच्छर"],
-		"pt": ["cauda", "rabo"]
+        "pt": ["cauda", "rabo"]
   },
   "techitechi": {
         "cn": ["目标"],
@@ -2986,7 +2987,7 @@ Language.L.tags = {
         "es": ["lunares", "lunar"],
         "jp": ["テチテチ"],
         "np": ["राम्रो स्थान"],
-		"pt": ["pinta", "pintinha"]
+        "pt": ["pinta", "pintinha"]
   },
   "tongue": {
         "cn": ["舌"],
@@ -2995,7 +2996,7 @@ Language.L.tags = {
         "es": ["lengua"],
         "jp": ["べろ"],
         "np": ["जिब्रो"],
-		"pt": ["língua"]
+        "pt": ["língua"]
   },
   "toys": {
         "cn": ["玩具"],
@@ -3004,7 +3005,7 @@ Language.L.tags = {
         "es": ["juguete", "juguetes"],
         "jp": ["遊具", "おもちゃ", "おもちゃ"],
         "np": ["खेलौना"],
-		"pt": ["brinquedo", "brinquedos"]
+        "pt": ["brinquedo", "brinquedos"]
   },
   "tree": {
         "cn": ["树"],
@@ -3013,7 +3014,7 @@ Language.L.tags = {
         "es": ["árbol", "arbol", "árboles", "arboles"],
         "jp": ["木"],
         "np": ["रूख"],
-		"pt": ["árvore", "árvores"]
+        "pt": ["árvore", "árvores"]
   },
   "upside-down": {
         "cn": ["翻转"],
@@ -3022,7 +3023,7 @@ Language.L.tags = {
         "es": ["al revés", "al reves", "cabeza abajo"],
         "jp": ["逆さま"],
         "np": ["तलको माथि"],
-		"pt": ["cabeça para baixo", "ponta-cabeça"]
+        "pt": ["cabeça para baixo", "ponta-cabeça"]
   },
   "wink": {
         "cn": ["眨眼"],
@@ -3031,7 +3032,7 @@ Language.L.tags = {
         "es": ["guiño", "guino"],
         "jp": ["ウィンク"],
         "np": ["आखा भ्किम्काउनु"],
-		"pt": ["piscando", "piscada", "piscadela", "piscar de olhos"]
+        "pt": ["piscando", "piscada", "piscadela", "piscar de olhos"]
   },
   "wet": {
         "cn": ["湿"],
@@ -3040,7 +3041,7 @@ Language.L.tags = {
         "es": ["mojado", "mojada"],
         "jp": ["濡れた"],
         "np": ["भिजेको"],
-		"pt": ["molhado", "molhada"]
+        "pt": ["molhado", "molhada"]
   },
   "white face": {
         "cn": ["浅色的脸"],
@@ -3049,7 +3050,7 @@ Language.L.tags = {
         "es": ["cara blanca"],
         "jp": ["色白さん", "しろめん", "白面", "白めん"],
         "np": ["सेतो अनुहार"],
-		"pt": ["face branca"]
+        "pt": ["face branca"]
   },
   "window": {
         "cn": ["窗"],
@@ -3058,7 +3059,7 @@ Language.L.tags = {
         "es": ["ventana"],
         "jp": ["窓", "まど"],
         "np": ["विन्डो"],
-		"pt": ["janela"]
+        "pt": ["janela"]
   },
   "whiskers": {
         "cn": ["晶須"],
@@ -3067,7 +3068,7 @@ Language.L.tags = {
         "es": ["bigotes", "bigote"],
         "jp": ["ひげ"],
         "np": ["फुसफुस"],
-		"pt": ["bigode", "bigodes"]
+        "pt": ["bigode", "bigodes"]
   },
   "yawn": {
         "cn": ["哈欠", "呵欠"],
@@ -3076,7 +3077,7 @@ Language.L.tags = {
         "es": ["bostezo", "bostezando"],
         "jp": ["あくび"],
         "np": ["जांभई"],
-		"pt": ["bocejo", "bocejando"]
+        "pt": ["bocejo", "bocejando"]
   }
 }
 
@@ -3175,6 +3176,7 @@ Language.L.fallbackFlags = function() {
       (navigator.languages.indexOf(taiwan) < navigator.languages.indexOf(china))) {
     Language.L.gui.flag["cn"] = Language.L.flags["Taiwan"];        
   }
+  // TODO: Portuguese vs. Brazil flags
 }
 
 // Do language fallback for anything reporting as "unknown" or "empty" in an info block
@@ -3649,7 +3651,7 @@ Language.unpluralize = function(pieces) {
                    .replace(/^una\s/, "Una ");
       output.push(input);
     }
-	 if (L.display == "pt") {
+  } else if (L.display == "pt") {
     for (var input of pieces) {
       input = input.replace(/\b1 fotos/, "uma foto")
                    .replace(/\b1 novas fotos/, "uma nova foto")

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -147,7 +147,7 @@ Pandas.def.gender = {
     "es": "hembra",
     "jp": "メス",
     "np": "महिला",
-	"pt": "fêmea"
+    "pt": "fêmea"
   },
   "Male": {
     "cn": "男",
@@ -155,7 +155,7 @@ Pandas.def.gender = {
     "es": "macho",
     "jp": "オス",
     "np": "नर",
-	"pt": "macho"
+    "pt": "macho"
   }
 }
 
@@ -177,7 +177,7 @@ Pandas.def.authors = {
     "es": "anónimo",
     "jp": "匿名",
     "np": "बेनामी",
-	"pt": "anônimo"
+    "pt": "anônimo"
   },
   "uncredited": {
     "cn": "沒有信用",
@@ -185,7 +185,7 @@ Pandas.def.authors = {
     "es": "sin acreditar",
     "jp": "信用されていない",
     "np": "अप्रत्याशित",
-	"pt": "não creditado"
+    "pt": "não creditado"
   }
 }
 
@@ -231,7 +231,7 @@ Pandas.def.relations = {
     "es": "tía",
     "jp": "叔母",
     "np": "काकी",
-	"pt": "tia"
+    "pt": "tia"
   },
   "brother": {
     "cn": "兄",
@@ -239,7 +239,7 @@ Pandas.def.relations = {
     "es": "hermano",
     "jp": "兄",
     "np": "भाई",
-	"pt": "irmão"
+    "pt": "irmão"
   },
   "children": {
     "cn": "孩子",
@@ -247,7 +247,7 @@ Pandas.def.relations = {
     "es": "niños",
     "jp": "子供",
     "np": "बच्चाहरु",
-	"pt": "filhos(as)"
+    "pt": "filhos(as)"
   },
   "cousin": {
     "cn": "表姐",
@@ -255,7 +255,7 @@ Pandas.def.relations = {
     "es": "primo",
     "jp": "いとこ",
     "np": "भान्जा",
-	"pt": "primo(a)"
+    "pt": "primo(a)"
   },
   "father": {
     "cn": "父",
@@ -263,7 +263,7 @@ Pandas.def.relations = {
     "es": "padre",
     "jp": "父",
     "np": "बुबा",
-	"pt": "pai"
+    "pt": "pai"
   },
   "grandfather": {
     "cn": "祖父",
@@ -271,7 +271,7 @@ Pandas.def.relations = {
     "es": "abuelo",
     "jp": "おじいちゃん",
     "np": "हजुरबुबा",
-	"pt": "avô"
+    "pt": "avô"
   },
   "grandmother": {
     "cn": "祖母",
@@ -279,7 +279,7 @@ Pandas.def.relations = {
     "es": "abuela",
     "jp": "おばあちゃん",
     "np": "हजुरआमा",
-	"pt": "avó"
+    "pt": "avó"
   },
   "litter": {
     "cn": "轿子",
@@ -287,7 +287,7 @@ Pandas.def.relations = {
     "es": "camada",
     "jp": "双子",   /* "同腹仔" */
     "np": "रोटी",
-	"pt": "ninhada"
+    "pt": "ninhada"
   },
   "mother": {
     "cn": "母",
@@ -295,7 +295,7 @@ Pandas.def.relations = {
     "es": "madre",
     "jp": "母",
     "np": "आमा",
-	"pt": "mãe"
+    "pt": "mãe"
   },
   "nephew": {
     "cn": "外甥",
@@ -303,7 +303,7 @@ Pandas.def.relations = {
     "es": "sobrino",
     "jp": "甥",
     "np": "भतिजा",
-	"pt": "sobrinho"
+    "pt": "sobrinho"
   },
   "niece": {
     "cn": "侄女",
@@ -311,7 +311,7 @@ Pandas.def.relations = {
     "es": "sobrina",
     "jp": "姪",
     "np": "भान्जी",
-	"pt": "sobrinha"
+    "pt": "sobrinha"
   },
   "parents": {
     "cn": "父母",
@@ -319,7 +319,7 @@ Pandas.def.relations = {
     "es": "padres",
     "jp": "両親",
     "np": "अभिभावक",
-	"pt": "pais"
+    "pt": "pais"
   },
   "sister": {
     "cn": "妹妹",
@@ -327,7 +327,7 @@ Pandas.def.relations = {
     "es": "hermana",
     "jp": "姉",
     "np": "बहिनी",
-	"pt": "irmã"
+    "pt": "irmã"
   },
   "siblings": {
     "cn": "兄弟姐妹",
@@ -335,7 +335,7 @@ Pandas.def.relations = {
     "es": "hermanos",
     "jp": "兄弟",
     "np": "भाइबहिनीहरू",
-	"pt": "irmãos(ãs)"
+    "pt": "irmãos(ãs)"
   },
   "uncle": {
     "cn": "叔叔",
@@ -343,7 +343,7 @@ Pandas.def.relations = {
     "es": "tío",
     "jp": "叔父",
     "np": "काका",
-	"pt": "tio
+    "pt": "tio"
   }
 }
 

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -77,6 +77,14 @@ Pandas.def.age = {
     "months": "महिना",
     "day": "दिन",
     "days": "दिनहरु"
+  },
+  "pt": {
+    "year": "ano",
+    "years": "anos",
+    "month": "mês",
+    "months": "meses",
+    "day": "dia",
+    "days": "dias"
   }
 }
 
@@ -104,6 +112,9 @@ Pandas.def.animal = {
   "np.nicknames": "उपनामहरू फेला परेन",
   "np.othernames": "अरु नामहरु फेला परेन",
   "photo.1": "images/no-panda-portrait.jpg",
+  "pt.name": "Panda não encontrado",
+  "pt.nicknames": "Nenhum apelido registrado",
+  "pt.othernames": "Nenhum nome alternativo registrado",
   "species": "-1",
   "video.1": "images/no-panda-portrait.jpg",
   "zoo": "0"
@@ -115,6 +126,7 @@ Pandas.def.date = {
   "es": "DD/MM/YYYY",
   "jp": "YYYY年MM月DD日",
   "np": "YYYY-MM-DD",
+  "pt": "DD/MM/YYYY",
   "earliest_year": "1970"
 }
 
@@ -124,6 +136,7 @@ Pandas.def.date_season = {
   "es": "SEASON YYYY",
   "jp": "SEASON YYYY",
   "np": "SEASON YYYY",
+  "pt": "SEASON YYYY",
   "earliest_year": "1970"
 }
 
@@ -133,14 +146,16 @@ Pandas.def.gender = {
     "en": "female",
     "es": "hembra",
     "jp": "メス",
-    "np": "महिला"
+    "np": "महिला",
+	"pt": "fêmea"
   },
   "Male": {
     "cn": "男",
     "en": "male",
     "es": "macho",
     "jp": "オス",
-    "np": "नर"
+    "np": "नर",
+	"pt": "macho"
   }
 }
 
@@ -150,7 +165,8 @@ Pandas.def.no_name = {
   "en": "Unknown",
   "es": "Desconocido",
   "jp": "未詳",
-  "np": "अज्ञात"
+  "np": "अज्ञात",
+  "pt": "Desconhecido(a)"
 }
 
 // Missing or undescribed authors
@@ -160,14 +176,16 @@ Pandas.def.authors = {
     "en": "anonymous",
     "es": "anónimo",
     "jp": "匿名",
-    "np": "बेनामी" 
+    "np": "बेनामी",
+	"pt": "anônimo"
   },
   "uncredited": {
     "cn": "沒有信用",
     "en": "uncredited",
     "es": "sin acreditar",
     "jp": "信用されていない",
-    "np": "अप्रत्याशित"
+    "np": "अप्रत्याशित",
+	"pt": "não creditado"
   }
 }
 
@@ -181,7 +199,8 @@ Pandas.def.languages = {
   "ja": "jp",
   "zh": "cn",
   "ne": "np",
-  "es": "es"
+  "es": "es"//,
+//"pt": "pt"
 }
 
 // Character ranges
@@ -211,105 +230,120 @@ Pandas.def.relations = {
     "en": "aunt",
     "es": "tía",
     "jp": "叔母",
-    "np": "काकी"
+    "np": "काकी",
+	"pt": "tia"
   },
   "brother": {
     "cn": "兄",
     "en": "brother",
     "es": "hermano",
     "jp": "兄",
-    "np": "भाई"
+    "np": "भाई",
+	"pt": "irmão"
   },
   "children": {
     "cn": "孩子",
     "en": "children",
     "es": "niños",
     "jp": "子供",
-    "np": "बच्चाहरु"
+    "np": "बच्चाहरु",
+	"pt": "filhos(as)"
   },
   "cousin": {
     "cn": "表姐",
     "en": "cousin",
     "es": "primo",
     "jp": "いとこ",
-    "np": "भान्जा"
+    "np": "भान्जा",
+	"pt": "primo(a)"
   },
   "father": {
     "cn": "父",
     "en": "father",
     "es": "padre",
     "jp": "父",
-    "np": "बुबा"
+    "np": "बुबा",
+	"pt": "pai"
   },
   "grandfather": {
     "cn": "祖父",
     "en": "grandfather",
     "es": "abuelo",
     "jp": "おじいちゃん",
-    "np": "हजुरबुबा"
+    "np": "हजुरबुबा",
+	"pt": "avô"
   },
   "grandmother": {
     "cn": "祖母",
     "en": "grandmother",
     "es": "abuela",
     "jp": "おばあちゃん",
-    "np": "हजुरआमा"
+    "np": "हजुरआमा",
+	"pt": "avó"
   },
   "litter": {
     "cn": "轿子",
     "en": "litter",
     "es": "camada",
     "jp": "双子",   /* "同腹仔" */
-    "np": "रोटी"
+    "np": "रोटी",
+	"pt": "ninhada"
   },
   "mother": {
     "cn": "母",
     "en": "mother",
     "es": "madre",
     "jp": "母",
-    "np": "आमा"
+    "np": "आमा",
+	"pt": "mãe"
   },
   "nephew": {
     "cn": "外甥",
     "en": "nephew",
     "es": "sobrino",
     "jp": "甥",
-    "np": "भतिजा"
+    "np": "भतिजा",
+	"pt": "sobrinho"
   },
   "niece": {
     "cn": "侄女",
     "en": "niece",
     "es": "sobrina",
     "jp": "姪",
-    "np": "भान्जी" 
+    "np": "भान्जी",
+	"pt": "sobrinha"
   },
   "parents": {
     "cn": "父母",
     "en": "parents",
     "es": "padres",
     "jp": "両親",
-    "np": "अभिभावक"
+    "np": "अभिभावक",
+	"pt": "pais"
   },
   "sister": {
     "cn": "妹妹",
     "en": "sister",
     "es": "hermana",
     "jp": "姉",
-    "np": "बहिनी"
+    "np": "बहिनी",
+	"pt": "irmã"
   },
   "siblings": {
     "cn": "兄弟姐妹",
     "en": "siblings",
     "es": "hermanos",
     "jp": "兄弟",
-    "np": "भाइबहिनीहरू"
+    "np": "भाइबहिनीहरू",
+	"pt": "irmãos(ãs)"
   },
   "uncle": {
     "cn": "叔叔",
     "en": "uncle",
     "es": "tío",
     "jp": "叔父",
-    "np": "काका"
+    "np": "काका",
+	"pt": "tio
   }
 }
 
@@ -338,6 +372,11 @@ Pandas.def.species = {
     "Ailurus fulgens fulgens",
     "Ailurus fulgens styani",
     "Ailurus fulgens"
+  ],
+  "pt": [
+    "Ailurus fulgens fulgens",
+    "Ailurus fulgens styani",
+    "Ailurus fulgens"
   ]
 }
 
@@ -346,7 +385,8 @@ Pandas.def.unknown = {
   "en": "unknown",
   "es": "desconocido",
   "jp": "未詳",
-  "np": "अज्ञात"
+  "np": "अज्ञात",
+  "pt": "desconhecido"
 }
 
 // Slightly different default zoo listing, to account for wild-born animals
@@ -368,6 +408,9 @@ Pandas.def.wild = {
   "np.location": "कुनै स्थान जानकारी छैन",
   "np.name": "चिडियाखाना फेला परेन",
   "photo.1": "images/no-zoo.jpg",
+  "pt.address": "Animal selvagem capturado ou resgatado",
+  "pt.location": "Nenhuma informação de cidade, distrito ou estado listada",
+  "pt.name": "Zoológico não encontrado",
   "video.1": "images/no-zoo.jpg",
   "website": "https://www.worldwildlife.org/"
 }
@@ -391,6 +434,9 @@ Pandas.def.zoo = {
   "np.location": "कुनै स्थान जानकारी छैन",
   "np.name": "चिडियाखाना फेला परेन",
   "photo.1": "images/no-zoo.jpg",
+  "pt.address": "Nenhum endereço do Google Maps registrado",
+  "pt.location": "Nenhuma informação de cidade, distrito ou estado listada",
+  "pt.name": "Zoológico não encontrado",
   "video.1": "images/no-zoo.jpg",
   "website": "https://www.worldwildlife.org/"
 }

--- a/pandas/france/0277_parc_animalier_d'auvergne/1267_oshi.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1267_oshi.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1267
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/10
+en.name: Oshi
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: オシ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 277, unknown
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1268_shifumi.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1268_shifumi.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1268
+birthday: 2019/6/9
+birthplace: 277
+children: unknown
+commitdate: 2021/4/10
+en.name: Shifumi
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: シフミ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1269_mushu.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1269_mushu.txt
@@ -1,0 +1,19 @@
+[panda]
+_id: 1269
+birthday: 2016/6/7
+birthplace: unknown
+children: 1268, 1270, 1271
+commitdate: 2021/4/10
+en.name: Mushu
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: ムシュ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, 2016/6/7
+location.2: 278, unknown
+location.3: 277, 2019/1/4
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1270_hima.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1270_hima.txt
@@ -1,0 +1,17 @@
+[panda]
+_id: 1270
+birthday: 2020/6/19
+birthplace: 277
+children: none
+commitdate: 2021/4/10
+en.name: Hima
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: ヒマ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+litter: 1271
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1271_laya.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1271_laya.txt
@@ -1,0 +1,17 @@
+[panda]
+_id: 1271
+birthday: 2020/6/19
+birthplace: 277
+children: none
+commitdate: 2021/4/10
+en.name: Laya
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: ラヤ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+litter: 1270
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1272_ibet.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1272_ibet.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1272
+birthday: unknown
+birthplace: unknown
+children: 1268, 1270, 1271
+commitdate: 2021/4/10
+en.name: Ibet
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: イベ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 277, 2015/3/20
+species: 1
+zoo: 277

--- a/pandas/france/0277_parc_animalier_d'auvergne/1273_limei.txt
+++ b/pandas/france/0277_parc_animalier_d'auvergne/1273_limei.txt
@@ -1,0 +1,19 @@
+[panda]
+_id: 1273
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/10
+death:2018/10/27
+en.name: Limeï
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: リメイ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 277, unknown
+species: 1
+zoo: 277

--- a/pandas/france/0278_haute-touche/1274_rourou.txt
+++ b/pandas/france/0278_haute-touche/1274_rourou.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1274
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: Rourou
+en.nicknames: none
+en.othernames: Rouroux
+gender: m
+jp.name: ルル
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 278, unknown
+species: unknown
+zoo: 278

--- a/pandas/france/0278_haute-touche/1275_yuzu.txt
+++ b/pandas/france/0278_haute-touche/1275_yuzu.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1275
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: Yuzu
+en.nicknames: none
+en.othernames: Yusu
+gender: m
+jp.name: ユズ
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+species: unknown
+zoo: 278

--- a/pandas/france/0278_haute-touche/1276_pipa.txt
+++ b/pandas/france/0278_haute-touche/1276_pipa.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1276
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: Pipa
+en.nicknames: none
+en.othernames: Pippa
+gender: f
+jp.name: ピパ
+jp.nicknames: none
+jp.othernames: ピッパ
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 278, 2019/7/9
+species: 1
+zoo: 278

--- a/pandas/germany/0282_tierpark-hellabrunn/1284_justin.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1284_justin.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1284
+birthday: 2016/6/22
+birthplace: 259
+children: 1283, 1287, 1288
+commitdate: 2021/4/11
+en.name: Justin
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: ジャスティン
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+location.1: 259, 2016/6/22
+location.2: 282, 2017/3/7
+species: 1
+zoo: 282

--- a/pandas/germany/0282_tierpark-hellabrunn/1285_miu.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1285_miu.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1285
+birthday: unknown
+birthplace: 283
+children: 1283, 1287, 1288
+commitdate: 2021/4/11
+en.name: Miu
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: ミウ
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+location.1: 283, unknown
+location.2: 282, unknown
+species: 1
+zoo: 282

--- a/pandas/germany/0282_tierpark-hellabrunn/1286_unknown.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1286_unknown.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1286
+birthday: 2007/7/3
+birthplace: 282
+children: unknown
+commitdate: 2021/4/11
+en.name: (no name)
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: (無名)
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+species: 1
+zoo: unknown

--- a/pandas/germany/0282_tierpark-hellabrunn/1287_tia.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1287_tia.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1287
+birthday: 2019/7/2
+birthplace: 282
+children: none
+commitdate: 2021/4/11
+en.name: Tia
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: ティア
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+species: 1
+zoo: 282

--- a/pandas/germany/0282_tierpark-hellabrunn/1288_ulli.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1288_ulli.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1288
+birthday: 2020/7/10
+birthplace: 282
+children: none
+commitdate: 2021/4/11
+en.name: Ulli
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: ウリ
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+species: 1
+zoo: 282

--- a/pandas/germany/0282_tierpark-hellabrunn/1289_ying.txt
+++ b/pandas/germany/0282_tierpark-hellabrunn/1289_ying.txt
@@ -1,0 +1,19 @@
+[panda]
+_id: 1289
+birthday: unknown
+birthplace: 284
+children: unknown
+commitdate: 2021/4/11
+death: 2016/7/25
+en.name: Ying
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: イン
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+location.1: 284, unknown
+location.2: 282, unknown
+species: 1
+zoo: 282

--- a/pandas/italy/0279_zoom-torino/1277_aiku.txt
+++ b/pandas/italy/0279_zoom-torino/1277_aiku.txt
@@ -1,0 +1,21 @@
+[panda]
+_id: 1277
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+ch.name: 爱哭的人
+ch.nicknames: 爱哭
+cn.othernames: none
+en.name: Àikūderén
+en.nicknames: Aiku, Aikuderen
+en.othernames: none
+gender: m
+jp.name: アイクデレン
+jp.nicknames: アイク
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 279, 2015/5/21
+species: 1
+zoo: 279

--- a/pandas/italy/0279_zoom-torino/1278_nepal.txt
+++ b/pandas/italy/0279_zoom-torino/1278_nepal.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1278
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: Nepal
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: ネパール
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: 184, unknown
+location.2: 279, 2017/3/21
+species: 1
+zoo: 279

--- a/pandas/italy/0279_zoom-torino/1279_hong-xion.txt
+++ b/pandas/italy/0279_zoom-torino/1279_hong-xion.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1279
+birthday: unknown
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: Hong-xion
+en.nicknames: none
+en.othernames: none
+gender: unknown
+jp.name: ホンシオン
+jp.nicknames: none
+jp.othernames: none
+language.order: en, jp
+location.1: unknown, unknown
+location.2: 279, 2015/5/21
+species: 1
+zoo: 279

--- a/pandas/portugal/0280_lisbon-zoo/1280_unknown.txt
+++ b/pandas/portugal/0280_lisbon-zoo/1280_unknown.txt
@@ -1,0 +1,20 @@
+[panda]
+_id: 1280
+birthday: unknown
+birthplace: unknown
+children: 1281
+commitdate: 2021/4/11
+en.name: (no name)
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: (無名)
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+photo.1: ig://CNii-Svs_kP/m
+photo.1.author: Akapan
+photo.1.link: https://www.instagram.com/a_ka_pan/
+photo.1.commitdate: 2021/4/11
+species: 1
+zoo: 280

--- a/pandas/portugal/0280_lisbon-zoo/1281_unknown.txt
+++ b/pandas/portugal/0280_lisbon-zoo/1281_unknown.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1281
+birthday: 2018/6/11
+birthplace: 280
+children: unknown
+commitdate: 2021/4/11
+en.name: (no name)
+en.nicknames: none
+en.othernames: none
+gender: unknown
+jp.name: (無名)
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+species: 1
+zoo: 280

--- a/pandas/portugal/0280_lisbon-zoo/1290_unknown.txt
+++ b/pandas/portugal/0280_lisbon-zoo/1290_unknown.txt
@@ -1,0 +1,16 @@
+[panda]
+_id: 1290
+birthday: 1992/9/30
+birthplace: unknown
+children: unknown
+commitdate: 2021/4/11
+en.name: (no name)
+en.nicknames: none
+en.othernames: none
+gender: m
+jp.name: (無名)
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+species: 1
+zoo: 280

--- a/pandas/portugal/0280_lisbon-zoo/1290_unknown.txt
+++ b/pandas/portugal/0280_lisbon-zoo/1290_unknown.txt
@@ -4,6 +4,7 @@ birthday: 1992/9/30
 birthplace: unknown
 children: unknown
 commitdate: 2021/4/11
+death: unknown
 en.name: (no name)
 en.nicknames: none
 en.othernames: none

--- a/pandas/portugal/0281_zoo-santo-inacio/1282_khyana.txt
+++ b/pandas/portugal/0281_zoo-santo-inacio/1282_khyana.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1282
+birthday: unknown
+birthplace: 280
+children: unknown
+commitdate: 2021/4/11
+en.name: Khyana
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: キアナ
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+location.1: 280, unknown
+location.2: 281, 2019/7/23
+species: 1
+zoo: 281

--- a/pandas/portugal/0281_zoo-santo-inacio/1283_shamina.txt
+++ b/pandas/portugal/0281_zoo-santo-inacio/1283_shamina.txt
@@ -1,0 +1,18 @@
+[panda]
+_id: 1283
+birthday: 2018/7/1
+birthplace: 282
+children: unknown
+commitdate: 2021/4/11
+en.name: Shamina
+en.nicknames: none
+en.othernames: none
+gender: f
+jp.name: シャミナ
+jp.nicknames: none
+jp.othernames: none
+language.order:en, jp
+location.1: 282, 2018/7/1
+location.2: 281, 2019/7/3
+species: 1
+zoo: 281

--- a/zoos/france/0277_parc_animalier_d'auvergne.txt
+++ b/zoos/france/0277_parc_animalier_d'auvergne.txt
@@ -1,0 +1,12 @@
+[zoo]
+_id: 277
+commitdate: 2021/4/10
+en.address: Route d'Anzat Le Luguet 63420, Ardes-sur-Couze, France
+en.location: Ardes-sur-Couze, France
+en.name: Parc Animalier d'Auvergne
+flag: France
+language.order: en
+latitude: 45.393251
+longitude: 3.1137653
+map: https://goo.gl/maps/RHQiB2w89SeU695AA
+website: http://www.parcanimalierdauvergne.fr/

--- a/zoos/france/0278_haute-touche.txt
+++ b/zoos/france/0278_haute-touche.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 278
+commitdate: 2021/4/10
+en.address: D975, 36290, Obterre, France
+en.location: Obterre, France
+en.name: Haute Touche Zoological Park
+fr.address: D975, 36290, Obterre, France
+fr.location: Obterre, France
+fr.name: Réserve zoologique de la Haute-Touche
+flag: France
+language.order: fr,en
+latitude: 46.8769973
+longitude: 1.0916611
+map: https://goo.gl/maps/2w7V2XMGzmUokoAbA
+website: http://www.zoodelahautetouche.fr/

--- a/zoos/germany/0282_tierpark-hellabrunn.txt
+++ b/zoos/germany/0282_tierpark-hellabrunn.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 282
+commitdate: 2021/4/11
+de.address: Tierparkstraße 30, 81543, München, Deutschland
+de.location: München, Deutschland
+de.name: Münchener Tierpark Hellabrunn
+en.address: Tierparkstraße 30, 81543, Munich, Germany
+en.location: Munich, Germany
+en.name: Hellabrunn Zoo
+flag: Germany
+language.order: de, en
+latitude: 48.0969444
+longitude: 11.5517002
+map: https://goo.gl/maps/iwfuHzr2sLkYR7ZX6
+website: https://www.hellabrunn.de/

--- a/zoos/germany/0283_zoo-krefeld.txt
+++ b/zoos/germany/0283_zoo-krefeld.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 283
+commitdate: 2021/4/11
+de.address: Uerdinger Str. 377, 47800, Krefeld, Deutschland
+de.location: Krefeld, Deutschland
+de.name: Zoo Krefeld
+en.address: Uerdinger Str. 377, 47800, Krefeld, Germany
+en.location: Krefeld, Germany
+en.name: Zoo Krefeld
+flag: Germany
+language.order: de, en
+latitude: 51.3403909
+longitude: 6.5993516
+map: https://goo.gl/maps/x4Y4EsZvPwKGbN7b8
+website: https://www.zookrefeld.de/

--- a/zoos/germany/0284_zoo-dresden.txt
+++ b/zoos/germany/0284_zoo-dresden.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 284
+commitdate: 2021/4/11
+de.address: Tiergartenstraße 1, 01219 Dresden, Deutschland
+de.location: Dresden, Deutschland
+de.name: Zoo Dresden
+en.address: Tiergartenstraße 1, 01219 Dresden, Germany
+en.location: Dresden, Germany
+en.name: Zoo Dresden
+flag: Germany
+language.order: de, en
+latitude: 51.0371826
+longitude: 13.7502553
+map: https://goo.gl/maps/K9DKbqvJvLuy19BK6
+website: https://www.zoo-dresden.de/

--- a/zoos/italy/0279_zoom-torino.txt
+++ b/zoos/italy/0279_zoom-torino.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 279
+commitdate: 2021/4/11
+en.address: Strada Piscina 36 10040 Cumiana, Piedmont, Italy
+en.location:Piedmont, Italy
+en.name: Zoom Torino
+flag: Italy
+it.address: Strada Piscina 36 10040 Cumiana, Piemonte, Italia
+it.location: Provincia di Verona
+it.name: Zoom Torino
+language.order: it, en
+latitude: 44.9335053
+longitude: 7.415765
+map: https://goo.gl/maps/48z2YUygKikbt1Vj9
+website: https://www.zoomtorino.it/

--- a/zoos/portugal/0280_lisbon-zoo.txt
+++ b/zoos/portugal/0280_lisbon-zoo.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 280
+commitdate: 2021/4/11
+en.address: Praça Marechal Humberto Delgado, 1549-004, Lisbon, Portugal
+en.location: Lisbon, Portugal
+en.name: Lisbon Zoo
+pt.address: Praça Marechal Humberto Delgado, 1549-004, Lisboa, Portugal
+pt.location: Lisboa, Portugal
+pt.name: Jardim Zoológico de Lisboa
+flag: Portugal
+language.order: pt, en
+latitude: 38.7443615
+longitude: -9.1729059
+map: https://goo.gl/maps/T7DBfWDyEdNGSpQ27
+website: https://www.zoo.pt/

--- a/zoos/portugal/0281_zoo-santo-inacio.txt
+++ b/zoos/portugal/0281_zoo-santo-inacio.txt
@@ -1,0 +1,15 @@
+[zoo]
+_id: 281
+commitdate: 2021/4/11
+en.address: Rua 5 de Outubro 4503, 4430-809, Avintes, Vila Nova de Gaia, Portugal
+en.location: Vila Nova de Gaia, Portugal
+en.name: Zoo Santo Inácio
+pt.address: Rua 5 de Outubro 4503, 4430-809, Avintes, Vila Nova de Gaia, Portugal
+pt.location: Vila Nova de Gaia, Portugal
+pt.name: Zoo Santo Inácio
+flag: Portugal
+language.order: pt, en
+latitude: 41.0927201
+longitude: -8.5394872
+map: https://goo.gl/maps/B2QxDwprtcYbPdNj7
+website: https://zoosantoinacio.com/


### PR DESCRIPTION
I could translate almost everything in about.html and language.js. I recommend using the flag of Portugal for Portuguese locale other than Brazil, or for no Portuguese locale defined at all, since other Portuguese-speaking countries use dialects close to European Portuguese like English-speaking countries other than the US and the UK use dialects close to British English. For unpluralized words, perhaps context is needed for "one current red panda" (translated as "um panda-vermelho atualmente", "currently one red panda"/"one red panda at the moment"); and for "$1 One " and "One ". There are some grammatical specificities in Portuguese for "one" (masculine "um", feminine "uma") and "ones" (usually has no translation). Aside I don't know JavaScript syntax.