### PR TITLE
Portuguese button

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -122,7 +122,7 @@ button.menu.flag {
     font-family: "Jun 201", sans-serif;
     background-color: #366938;
     height: 64px;
-    width: 80px;
+    width: 64px;
 }
 
 button.menu.flag > div.buttonContent > div.buttonIcon {
@@ -1316,8 +1316,9 @@ div.photoSample h5.caption.familyTitle > span.ultraCondensed {
     }
 
     button.menu.flag {
-        /* Divide 320px by number of buttons you expect to have */
-        width: 64px;    /* Flags are smaller on mobile */
+        /* Divide 320px by number of buttons you expect to have per-row */
+        /* For more than 5 buttons, use wide buttons to split across two rows */
+        width: 80px;
     }
 
     div.buttonIcon {

--- a/js/language.js
+++ b/js/language.js
@@ -357,7 +357,7 @@ Language.L.gui = {
     "es": Language.L.flags["Spain"],
     "jp": Language.L.flags["Japan"],
     "np": Language.L.flags["Nepal"],
-    "pt": Language.L.flags["Brazil"]
+    "pt": Language.L.flags["Portugal"]
   },
   "footerLink_rpf": {
     "cn": "小熊猫族谱项目",
@@ -3177,6 +3177,10 @@ Language.L.fallbackFlags = function() {
     Language.L.gui.flag["cn"] = Language.L.flags["Taiwan"];        
   }
   // TODO: Portuguese vs. Brazil flags
+  var brazil = "pt-BR";
+  if (navigator.languages.indexOf(brazil) != -1) {
+    Language.L.gui.flag["pt"] = Language.L.flags["Brazil"];
+  }
 }
 
 // Do language fallback for anything reporting as "unknown" or "empty" in an info block

--- a/js/language.js
+++ b/js/language.js
@@ -729,7 +729,7 @@ Language.L.gui = {
     "es": "Arriba",
     "jp": "上",
     "np": "माथि",
-    "pt": "Para cima"
+    "pt": "Para\xa0cima"
   },
   "tree": {
     "cn": "树",
@@ -1001,7 +1001,7 @@ Language.L.messages = {
            " लेआउट र डिजाइन प्रतिलिपि अधिकार २०२१ Justin Fairchild द्वारा।"],
     "pt": ["Se você ama pandas-vermelhos, por favor apoie a  ",
            "<INSERTLINK_RPN>",
-           " bem como seus zoológicos locais. Dados de linhagem são uma cortesia do projeto",
+           " bem como seus zoológicos locais. Dados de linhagem são uma cortesia do projeto ",
            "<INSERTLINK_RPF>",
            ", mas as mídias linkadas seguem sendo propriedade de seus criadores. ",
            "Layout e design ©" +
@@ -3677,8 +3677,10 @@ Language.unpluralize = function(pieces) {
                    .replace(/\b1 novos contribuintes/, "um novo contribuinte")
                    .replace(/\bcombo: 1 fotos/, "combo: uma foto")
                    .replace(/\bfotos etiquetadas/, "foto etiquetada")
-                   .replace(/^([^A-Za-z0-9]+)one\s/, "$1 One ")
-                   .replace(/^one\s/, "One ");
+                   .replace(/^([^A-Za-z0-9]+)um\s/, "$1 Um ")
+                   .replace(/^([^A-Za-z0-9]+)uma\s/, "$1 Uma ")
+                   .replace(/^um\s/, "Um ")
+                   .replace(/^uma\s/, "Uma ");
       output.push(input);
     }
     return output;

--- a/js/language.js
+++ b/js/language.js
@@ -689,7 +689,7 @@ Language.L.gui = {
     "es": "Agradecimientos",
     "jp": "感佩",
     "np": "विशेष धन्यवाद",
-    "pt": "Agradecimentos Especiais"
+    "pt": "Agradecimentos"
   },
   "specialThanksLinks_header": {
     "cn": "鸣谢",
@@ -769,7 +769,8 @@ Language.L.gui = {
           "hotspots for seeing Red Pandas.",
     "es": "",
     "jp": "",
-    "np": ""
+    "np": "",
+    "pt": ""
   },
   "zooLinks_button": {
     "cn": "动物园",
@@ -796,7 +797,7 @@ Language.L.messages = {
     "es": " y ",
     "jp": "と",
     "np": " र ",
-    "pt": "e"
+    "pt": " e "
   },
   "and_words": {
     "cn": "和",
@@ -804,7 +805,7 @@ Language.L.messages = {
     "es": " y ",
     "jp": "と",
     "np": " र ",
-    "pt": "e"
+    "pt": " e "
   },
   "arrived_from_zoo": {
     "cn": ["<INSERTDATE>",

--- a/js/pandas.js
+++ b/js/pandas.js
@@ -199,8 +199,8 @@ Pandas.def.languages = {
   "ja": "jp",
   "zh": "cn",
   "ne": "np",
-  "es": "es"//,
-//"pt": "pt"
+  "es": "es",
+  "pt": "pt"
 }
 
 // Character ranges

--- a/js/show.js
+++ b/js/show.js
@@ -2665,6 +2665,9 @@ Show.searchBar.toggle = function(frame_id) {
   // In panda-profile mode, it's hidden unless the user opts to search
   // for new pandas using the Search Button at the bottom of the page.
   var searchBar = document.getElementById(frame_id);
+  if (searchBar == null) {
+    return false;
+  }
   var display = searchBar.style.display;
   // Catch whether the search bar has no explicit display style (first click), or none
   if ((display == "none") || (display == "")) {


### PR DESCRIPTION
Enables the Portuguese translation @akapanredpanda wrote. Has toggle for Brazilians to see the Brazilian flag, if their browser `navigator.language` has `pt-BR` -- but the translation is the same.