### PR TITLE
Update Henry :rainbow:

### DIFF
--- a/pandas/united-states/0114_smithsonian-conservation-biology-institute/0556_henry.txt
+++ b/pandas/united-states/0114_smithsonian-conservation-biology-institute/0556_henry.txt
@@ -4,6 +4,7 @@ birthday: 2014/6/14
 birthplace: 114
 children: 859, 860, 867
 commitdate: 2019/3/10
+death: 2018/12/5
 en.name: Henry
 en.nicknames: none
 en.othernames: none


### PR DESCRIPTION
https://www.washingtonpost.com/local/red-panda-named-henry-dies-at-national-zoos-facility-in-virginia/2018/12/13/00dc51c0-fee6-11e8-ad40-cdfd0e0dd65a_story.html