### PR TITLE
Adira's and Lucas' daughter named Pavitra!

### DIFF
--- a/pandas/united-states/0095_san-diego-zoo/1417_pavitra.txt
+++ b/pandas/united-states/0095_san-diego-zoo/1417_pavitra.txt
@@ -4,15 +4,19 @@ birthday: 2023/6/9
 birthplace: 95
 children: none
 commitdate: 2023/7/16
-en.name: Baby
+en.name: Pavitra
 en.nicknames: none
 en.othernames: none
-gender: unknown
-jp.name: 赤ちゃん
+gender: f
+jp.name: パヴィトラ
 jp.nicknames: none
 jp.othernames: none
 language.order: en, jp
 location.1: 95, 2023/6/9
+photo.1: ig://CxOWiQNP2MO/m
+photo.1.author: sandiegozoo
+photo.1.commitdate: 2023/9/16
+photo.1.link: https://www.instagram.com/sandiegozoo/
+photo.1.tags: baby, looking, curious
 species: 2
-uncertainty: name (none given yet)
 zoo: 95


### PR DESCRIPTION
## Context

- Updated Adira's and Luca's daughter's record to add her name (Pavitra!) and gender.
    - Japanese transliteration is my best attempt into katakana. Happy to correct / remove it too if it seems too shaky.
- Added first Instagram post of Pavitra, as posted by [@sandiegozoo](https://www.instagram.com/p/CxOWiQNP2MO/) on Instagram.
    - If having these be Reels will be an issue, happy to remove it too.
    - I'm not sure of what conventions exist for tagging, so I also just put my best effort into it. The only one I could reliably find that seemed to apply to her was `baby`.

## Sources

- [Instagram](https://www.instagram.com/p/CxOWiQNP2MO/)
- San Diego Zoo e-mail, partially reproduced below:
    - "Our new little “pumpkin spice panda” has a name. Meet [Pavitra](http://donate.sandiegozoo.org/site/R?i=X9vADP1aOjdJ0nT3zedUieWDl9qeiYuDZvLo5qRce0Jhq7UP2phD4g), which means “sacred” in Nepali."
    - "Born at the [San Diego Zoo](http://donate.sandiegozoo.org/site/R?i=ElKncX1a4NCifbDayw0F7rAEMoDonrGrFUDSPCcbrnQ3yWz8PhlOBg) this summer to mom Adria [sic], this three-month old [red panda](http://donate.sandiegozoo.org/site/R?i=CRJCQCfzNGfSysPflfjjHvYQt0MedPPUq5ag5sAN17KJry-OyFZibg) cub is a furry ball of energy. Pavitra has been keeping her mom’s paws full as she learns to climb and explore on her own in their den."
    - "The curious little cub has only made a few brief appearances on habitat, but wildlife care specialists expect her to continue branching out in the coming weeks."
