### PR TITLE
Only deploy to GitHub Pages when pushing to master

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: check-redpandafinder
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 60
+      - name: Build export/redpanda.json
+        run: |
+          pip install -r requirements.txt
+          python ./build.py --publish
+          rm .gitignore
+      - name: Publish artifact for github pages
+        uses: actions/upload-pages-artifact@v1.0.7
+        with:
+          name: github-pages
+          path: ${{ github.workspace }}
+          retention-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
 jobs:
   build:
@@ -26,12 +23,12 @@ jobs:
           path: ${{ github.workspace }}
           retention-days: 1
   deploy:
-    needs: build  
+    needs: build
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       pages: write
       id-token: write
-    environment: 
+    environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:


### PR DESCRIPTION
## Context

_Originally posted by @wwoast in https://github.com/wwoast/redpanda-lineage/issues/276#issuecomment-1639039073_

> Thanks for the PR -- this looks good to me and I should make sure the gh-pages deploy only works from master.
>
> Glad you still enjoy Redpandafinder. I wish I had more time to improve it, and I have lots of babies to catch up on!

This change splits out the workflows between one that only runs on PRs (that only does the `build` job) and one that only runs on pushes (that functions the same as before with both the `build` and `deploy` jobs).

Feel free to suggest better names for the workflow files too, like if you'd prefer `build.yml` and `deploy.yml` instead of the current names.

## Testing

Unfortunately, because GitHub Actions is the type of things that runs after changes are merged in, I'm not exactly sure how to really test that `publish.yml` works. x_x; Happy to try any suggestions out though!

Good news is that `check.yml` seems to have worked, evidenced by the Checks for this PR passing and only running the `build` job.