### PR TITLE
Update on red pandas in Korea - 3 moves, 4 language changes

### DIFF
--- a/pandas/south-korea/0062_everland/0114_lemon.txt
+++ b/pandas/south-korea/0062_everland/0114_lemon.txt
@@ -13,7 +13,7 @@ ja.nicknames: none
 ja.othernames: none
 ko.name: 레몬
 ko.nicknames: none
-ko.oldnames: 젖을 섞은
+ko.oldnames: 미루키, 밀키
 ko.othernames: none
 language.order: ja, ko, en
 litter: none

--- a/pandas/south-korea/0062_everland/1252_rose.txt
+++ b/pandas/south-korea/0062_everland/1252_rose.txt
@@ -11,7 +11,11 @@ gender: f
 ja.name: ローズ
 ja.nicknames: none
 ja.othernames: none
-language.order: en, ja
+ko.name: 레아
+ko.nicknames: none
+ko.oldnames: 로즈
+ko.othernames: none
+language.order: en, ko, ja
 litter: 1253
 location.1: 76, 2019/5/17
 location.2: 62, 2022/12/1

--- a/pandas/south-korea/0078_seoul-zoo/0355_foa-foa.txt
+++ b/pandas/south-korea/0078_seoul-zoo/0355_foa-foa.txt
@@ -12,7 +12,11 @@ gender: f
 ja.name: ファーファ
 ja.nicknames: none
 ja.othernames: none
-language.order: ja, en
+ko.name: 앵두
+ko.nicknames: none
+ko.oldnames: 후아후아, 화화
+ko.othernames: none
+language.order: ja, ko, en
 litter: 356
 location.1: 34, 2004/6/29
 location.2: 78, 2008/9/29

--- a/pandas/south-korea/0078_seoul-zoo/0477_aporo.txt
+++ b/pandas/south-korea/0078_seoul-zoo/0477_aporo.txt
@@ -12,7 +12,11 @@ gender: m
 ja.name: アポロ
 ja.nicknames: none
 ja.othernames: none
-language.order: ja, en
+ko.name: 상큼이
+ko.nicknames: none
+ko.oldnames: 아포로, 아폴로
+ko.othernames: none
+language.order: ja, ko, en
 litter: 135
 location.1: 46, 2004/6/28
 location.2: 78, 2005/4/25

--- a/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
+++ b/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
@@ -13,6 +13,8 @@ ja.nicknames: none
 ja.othernames: none
 language.order: ja, en
 litter: 957
+location.1: 9, 2019/7/2
+location.2: 78, 2023/11/27
 photo.1: ig://B3-uEM1BaXb/m
 photo.1.author: fetorus_mami
 photo.1.commitdate: 2019/10/24

--- a/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
+++ b/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
@@ -415,4 +415,4 @@ photo.80.commitdate: 2023/8/11
 photo.80.link: https://www.instagram.com/mini_cochi/
 photo.80.tags: laying down, mofumofu, tail
 species: 2
-zoo: 9
+zoo: 78

--- a/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
@@ -13,6 +13,8 @@ ja.nicknames: none
 ja.othernames: none
 language.order: ja, en
 litter: 1198
+location.1: 17, 2020/7/20
+location.2: 78, 2023/11/27
 photo.1: ig://CHaQQJhB1BB/m
 photo.1.author: tamazoowalking
 photo.1.commitdate: 2023/1/12

--- a/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
@@ -871,4 +871,4 @@ photo.171.commitdate: 2023/8/11
 photo.171.link: https://www.instagram.com/tamazoowalking/
 photo.171.tags: paws, sample, standing, whiskers
 species: 2
-zoo: 17
+zoo: 78

--- a/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
@@ -15,6 +15,8 @@ ja.oldnames: none
 ja.othernames: none
 language.order: en, ja
 litter: 1396
+location.1: 51, 2022/6/14
+location.2: 78, 2023/11/20
 photo.1: ig://CkuPxEiJllg/m
 photo.1.author: westcoast_kathy
 photo.1.commitdate: 2022/12/8

--- a/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
@@ -38,4 +38,4 @@ photo.4.commitdate: 2023/9/28
 photo.4.link: https://www.instagram.com/thecalgaryzoo/
 photo.4.tags: portrait, sample, snow, tree
 species: 2
-zoo: 51
+zoo: 78


### PR DESCRIPTION
Hello,

I have made updates for red pandas in South Korea.

There are three Red Pandas recently moved to Seoul Zoo (they aren't on exhibit yet as far as I know).
* Sei (from Saitama Zoo)
* Leanne (from Tama zoo)
* Ravi (from Calgary zoo)

Source:
* Korean news reports on 3 new Red Pandas: https://www.hani.co.kr/arti/area/capital/1118726.html
* Leanne & Sei Moving https://www.tokyo-zoo.net/topic/topics_detail?kind=news&inst=tama&link_num=28260
* Sei farewell http://www.parks.or.jp.e.aml.hp.transer.com/sczoo/news_special/detail/005319.html
* Ravi farewell https://www.instagram.com/p/CywXDjPL4C-

Also I made changes on Korean names for Lemon (레몬), Rose (레아), Foa-Foa (앵두), and Aporo (상큼이).

Let me know if there is any question. Thank you!

Also if you ever need any help regarding Pandas data in Korea please feel free to reach out.
