### PR TITLE
Local name update for Seoul Zoo pandas & lang order chg for Korean pandas

### DIFF
--- a/pandas/south-korea/0062_everland/0114_lemon.txt
+++ b/pandas/south-korea/0062_everland/0114_lemon.txt
@@ -15,7 +15,7 @@ ko.name: 레몬
 ko.nicknames: none
 ko.oldnames: 미루키, 밀키
 ko.othernames: none
-language.order: ja, ko, en
+language.order: ko, ja, en
 litter: none
 location.1: 13, 2013/7/7
 location.2: 29, 2020/2/26

--- a/pandas/south-korea/0062_everland/0259_lessy.txt
+++ b/pandas/south-korea/0062_everland/0259_lessy.txt
@@ -16,7 +16,7 @@ ko.name: 레시
 ko.nicknames: none
 ko.oldnames: 토야
 ko.othernames: none
-language.order: ja, ko, en
+language.order: ko, ja, en
 litter: 260
 location.1: 42, 2014/8/18
 location.2: 62, 2016/3/31

--- a/pandas/south-korea/0062_everland/1252_rose.txt
+++ b/pandas/south-korea/0062_everland/1252_rose.txt
@@ -15,7 +15,7 @@ ko.name: 레아
 ko.nicknames: none
 ko.oldnames: 로즈
 ko.othernames: none
-language.order: en, ko, ja
+language.order: ko, en, ja
 litter: 1253
 location.1: 76, 2019/5/17
 location.2: 62, 2022/12/1

--- a/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
+++ b/pandas/south-korea/0078_seoul-zoo/0958_sei.txt
@@ -8,10 +8,13 @@ en.name: Sei
 en.nicknames: none
 en.othernames: none
 gender: m
+ko.name: 세이
+ko.nicknames: none
+ko.othernames: none
 ja.name: セイ
 ja.nicknames: none
 ja.othernames: none
-language.order: ja, en
+language.order: ko, ja, en
 litter: 957
 location.1: 9, 2019/7/2
 location.2: 78, 2023/11/27

--- a/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1197_leanne.txt
@@ -11,7 +11,10 @@ gender: f
 ja.name: リアン
 ja.nicknames: none
 ja.othernames: none
-language.order: ja, en
+ko.name: 리안
+ko.nicknames: none
+ko.othernames: none
+language.order: ko, ja, en
 litter: 1198
 location.1: 17, 2020/7/20
 location.2: 78, 2023/11/27

--- a/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
+++ b/pandas/south-korea/0078_seoul-zoo/1397_ravi.txt
@@ -13,7 +13,10 @@ ja.name: ラビ
 ja.nicknames: none
 ja.oldnames: none
 ja.othernames: none
-language.order: en, ja
+ko.name: 라비
+ko.nicknames: none
+ko.othernames: none
+language.order: ko, en, ja
 litter: 1396
 location.1: 51, 2022/6/14
 location.2: 78, 2023/11/20


### PR DESCRIPTION
The local names were announced for Seoul Zoo pandas recently as mentioned in PR#285.

Official blog announcement:
* https://m.blog.naver.com/PostView.naver?blogId=finezoos&logNo=223327628107&navType=by

Also changed the language order for South Korean pandas to prioritize Korean names.

Thank you!