### PR TITLE
Move Kelly to Assiniboine Park Zoo

### DIFF
--- a/pandas/canada/0076_assiniboine-park-zoo/0391_kelly.txt
+++ b/pandas/canada/0076_assiniboine-park-zoo/0391_kelly.txt
@@ -15,7 +15,7 @@ language.order: en, ja
 litter: none
 location.1: 65, 2015/6/12
 location.2: 94, 2016/5/12
-location.3: 86, 2024/5/8
+location.3: 76, 2024/5/8
 photo.1: cwdc://Vxt6SYYADQA.jpg
 photo.1.author: arnaultlavillephotography
 photo.1.commitdate: 2020/2/26

--- a/pandas/canada/0076_assiniboine-park-zoo/0391_kelly.txt
+++ b/pandas/canada/0076_assiniboine-park-zoo/0391_kelly.txt
@@ -29,4 +29,4 @@ photo.2.tags: bridge, climb, portrait, smile, tail
 species: 2
 studbook.id: 1511
 uncertainty: location.3 exact date
-zoo: 86
+zoo: 76


### PR DESCRIPTION
Moves Kelly to Assiniboine Park Zoo. I don't think Kelly was ever at Vancouver in 2024, Assiniboine Park Zoo says Kelly came straight from Zoo de Granby: https://www.assiniboinepark.ca/stories/236/furry-red-and-fun-our-red-panda-update