### PR TITLE
Zayn passed away

### DIFF
--- a/pandas/russia/0149_moscow-zoo/0582_zayn.txt
+++ b/pandas/russia/0149_moscow-zoo/0582_zayn.txt
@@ -4,6 +4,7 @@ birthday: 2013/7/14
 birthplace: 150
 children: none
 commitdate: 2019/3/15
+death: unknown
 en.name: Zayn
 en.nicknames: none
 en.othernames: Zhen, Chen


### PR DESCRIPTION
Unfortunately, Zayn from the Moscow Zoo passed away recently on an undisclosed date. She lived a long life alongside her friend, Ryzhik (Chan).