### PR TITLE
Fix: render home if no hash exists

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -107,7 +107,7 @@ window.addEventListener('hashchange', function() {
   // And forget how many pages we have shown
   Query.env.paging.shown_pages = 1;
   var mode = window.location.hash.split("/")[0];
-  if (mode == "#home") {
+  if (window.location.hash.length == 0 || mode == "#home") {
     Page.home.render();
     Page.current = Page.home.render;
   } else if (mode == "#about") {


### PR DESCRIPTION
## Summary

When a user initially accesses `redpandafinder.com`, the back to home page does not work. This was because the initial page didn't have a hash, so there was no page to match when handling the `hashchange` event.

This PR fixes the issue with a small change, so that the `hashchange` event handler also renders the home page if it doesn't have a hash in url.

#### No `last_seen` set

| as-is | to-be |
| - | - |
| <video src="https://github.com/user-attachments/assets/57059c7e-f634-4b58-832b-d2c72cb81622" /> | <video src="https://github.com/user-attachments/assets/7df1109f-670c-4ad1-b342-7df2e79f1cab" /> |

#### With `last_seen` set

| as-is | to-be |
| - | - |
| <video src="https://github.com/user-attachments/assets/28bd60dc-3ff8-44aa-8ffc-16e0d85f8e2a" /> | <video src="https://github.com/user-attachments/assets/5f1e9a02-efd7-4840-b818-520308394d8e" /> |
