### PR TITLE
Fix the birth places for Yokohama's new twins

### DIFF
--- a/pandas/japan/0012_yokohama-zoorasia/1448_baby.txt
+++ b/pandas/japan/0012_yokohama-zoorasia/1448_baby.txt
@@ -1,7 +1,7 @@
 [panda]
 _id: 1448
 birthday: 2025/6/25
-birthplace: 13
+birthplace: 12
 children: none
 commitdate: 2025/8/5
 en.name: Baby

--- a/pandas/japan/0012_yokohama-zoorasia/1449_baby.txt
+++ b/pandas/japan/0012_yokohama-zoorasia/1449_baby.txt
@@ -1,7 +1,7 @@
 [panda]
 _id: 1449
 birthday: 2025/6/25
-birthplace: 13
+birthplace: 12
 children: none
 commitdate: 2025/8/5
 en.name: Baby


### PR DESCRIPTION
They were incorrectly pointing to Nishiyama Zoo.