### PR TITLE
Add Flamingo Land Panda's and descendants

### DIFF
--- a/pandas/netherlands/0287_zooparc-overloon/1457_bangbang.txt
+++ b/pandas/netherlands/0287_zooparc-overloon/1457_bangbang.txt
@@ -1,0 +1,13 @@
+[panda]
+_id: 1457
+birthday: 2018/06/17
+birthplace: 227
+children: 1461, 1462
+commitdate: 2025/09/18
+en.name: Bangbang
+gender: m
+language.order: en
+location.1: 227, 2018/06/17
+location.2: 287, 2019/07/01
+species: 1
+zoo: 287

--- a/pandas/netherlands/0287_zooparc-overloon/1460_bahini.txt
+++ b/pandas/netherlands/0287_zooparc-overloon/1460_bahini.txt
@@ -1,0 +1,10 @@
+[panda]
+_id: 1460
+commitdate: 2025/09/18
+children: 1461, 1462
+en.name: Bahini
+gender: f
+language.order: en
+location.1: 287, 2018/04/01
+species: 1
+zoo: 287

--- a/pandas/netherlands/0287_zooparc-overloon/1461_billy.txt
+++ b/pandas/netherlands/0287_zooparc-overloon/1461_billy.txt
@@ -1,0 +1,12 @@
+[panda]
+_id: 1461
+birthday: 2021/06/01
+birthplace: 287
+commitdate: 2025/09/18
+litter: 1462
+en.name: Billy
+gender: m
+language.order: en
+location.1: 287, 2021/06/01
+species: 1
+zoo: 287

--- a/pandas/netherlands/0287_zooparc-overloon/1462_bobby.txt
+++ b/pandas/netherlands/0287_zooparc-overloon/1462_bobby.txt
@@ -1,0 +1,12 @@
+[panda]
+_id: 1462
+birthday: 2021/06/01
+birthplace: 287
+commitdate: 2025/09/18
+litter: 1461
+en.name: Bobby
+gender: f
+language.order: en
+location.1: 287, 2021/06/01
+species: 1
+zoo: 287

--- a/pandas/sweden/0293_boras-zoo/1456_wanju.txt
+++ b/pandas/sweden/0293_boras-zoo/1456_wanju.txt
@@ -1,0 +1,13 @@
+[panda]
+_id: 1456
+birthday: 2015/06/04
+birthplace: 227
+commitdate: 2025/09/18
+en.name: Wánjù
+en.othernames: Wanju
+gender: f
+language.order: en
+location.1: 227, 2015/06/04
+location.2: 293, 2016/06/10
+species: 1
+zoo: 293

--- a/pandas/united-kingdom/0227_flamingo-land-resort/1063_bai-jiao.txt
+++ b/pandas/united-kingdom/0227_flamingo-land-resort/1063_bai-jiao.txt
@@ -2,7 +2,7 @@
 _id: 1063
 birthday: 2012/6/14
 birthplace: 226
-children: unknown
+children: 1456, 1457, 1458, 1459
 commitdate: 2019/11/29
 en.name: Bai-Jiao
 en.nicknames: none

--- a/pandas/united-kingdom/0227_flamingo-land-resort/1455_tai-jang.txt
+++ b/pandas/united-kingdom/0227_flamingo-land-resort/1455_tai-jang.txt
@@ -1,0 +1,13 @@
+[panda]
+_id: 1455
+birthday: 2012/6/12
+birthplace: 296
+children: 1456, 1457, 1458, 1459
+commitdate: 2025/09/18
+en.name: Tai-Jang
+gender: f
+language.order: en
+location.1: 296, 2012/6/12
+location.2: 227, 2014/1/1
+species: 1
+zoo: 227

--- a/pandas/united-kingdom/0227_flamingo-land-resort/1459_babu.txt
+++ b/pandas/united-kingdom/0227_flamingo-land-resort/1459_babu.txt
@@ -1,0 +1,11 @@
+[panda]
+_id: 1459
+birthday: 2023/06/30
+birthplace: 227
+commitdate: 2025/09/17
+en.name: Babu
+gender: m
+language.order: en
+location.1: 227, 2023/06/30
+species: 1
+zoo: 227

--- a/pandas/united-kingdom/0320_welsh-mountain-zoo/1458_hop.txt
+++ b/pandas/united-kingdom/0320_welsh-mountain-zoo/1458_hop.txt
@@ -1,0 +1,12 @@
+[panda]
+_id: 1458
+birthday: 2020/08/01
+birthplace: 227
+commitdate: 2025/09/17
+en.name: Hop
+gender: m
+language.order: en
+location.1: 227, 2020/08/01
+location.2: 320, 2022/03/01
+species: 1
+zoo: 320

--- a/zoos/united-kingdom/0320_welsh-mountain-zoo
+++ b/zoos/united-kingdom/0320_welsh-mountain-zoo
@@ -1,0 +1,12 @@
+[zoo]
+_id: 320
+commitdate: 2025/9/17
+en.address: Old Hwy, Colwyn Bay LL28 5UY, United Kingdom
+en.location: Wales, UK
+en.name: Welsh Mountain Zoo
+flag: UK
+language.order: en
+latitude: 53.2939
+longitude: -3.7479
+map: https://maps.app.goo.gl/4b4F9Sh3T1qP1yCK6
+website: https://www.welshmountainzoo.org/


### PR DESCRIPTION
This adds the Panda's at Flamingo Land, and their descendants.

* Tai-Jang ([1](https://www.flamingoland.co.uk/blog/panda-birthdays/))
* Wanju ([1](https://x.com/flamingolanduk/status/682220982933798912), [2](https://borasnyheter.se/boras-djurpark-har-fatt-en-ny-rod-panda/))
* Bangbang ([1](https://www.gazettelive.co.uk/whats-on/family-kids-news/flamingo-land-watch-baby-red-15202214), [2](https://www.facebook.com/Zoovaria/posts/2134696446657804), [3](https://www.facebook.com/zooparcoverloon/posts/pfbid08PX2DPLkc6gF1nFa2JXaMbNJcBL4wGFci6gK7qyDwPGMDusyjCxa1jbuxVmE3eCel)))
* Hop ([1](https://www.youtube.com/watch?v=XlJj9BFWeJQ), [2](https://www.dailypost.co.uk/news/north-wales-news/red-panda-welsh-mountain-zoo-23293459))
* Babu ([1](https://www.thescarboroughnews.co.uk/news/people/flamingo-land-welcomes-endangered-newborn-red-panda-cub-into-its-zoo-4245876), [2](https://www.facebook.com/reel/1469414783625335/))

