### PR TITLE
UI restyle proposal: refreshed theme in panda.css + SVG icon layer (no functional changes)

### DIFF
--- a/css/panda.css
+++ b/css/panda.css
@@ -2741,7 +2741,7 @@ div.footer p { padding: 0.5ex 14px; }
 /* ---------- mobile ---------- */
 @media (max-width: 640px) {
   div.topMenu > div.shrinker { gap: 2px; flex-wrap: wrap; }
-  button.menu { padding: 0 11px; font-size: 12pt; }
+  button.menu { padding: 0 11px; font-size: 12pt; flex: 1; }
   div.buttonText { display: none; }        /* icon-only pills on phones */
   button.logo { width: 46px; }
   div.buttonIcon { font-size: 16pt; }

--- a/css/panda.css
+++ b/css/panda.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=M+PLUS+Rounded+1c:wght@400;500;700;800&family=Noto+Emoji:wght@400;500;700&display=swap');
+
 html {
     -webkit-text-size-adjust: 100%; /* Prevent font scaling in landscape */
 }
@@ -8,7 +10,7 @@ body {
     overflow-x: hidden;
     line-height: 1.4;
     font-size: 14pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     background: #366938;
 }
 
@@ -24,7 +26,7 @@ div.topMenu, div.bottomMenu {
     margin-right: auto;
     color: white;
     background-color: #366938;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     width: 100%;
     vertical-align: middle;
     border-bottom: 2px solid yellowgreen;
@@ -44,7 +46,7 @@ div.languageMenu {
     margin-right: auto;
     color: white;
     background-color: #366938;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     width: 100%;
     vertical-align: middle;
     border-bottom: 2px dotted yellowgreen;
@@ -125,7 +127,7 @@ button.logo {
     color: white;
     line-height: 1.4;
     font-size: 14pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     background-color: #366938;
     height: 64px;
     float: left;
@@ -141,7 +143,7 @@ button.menu {
     color: white;
     line-height: 1.4;
     font-size: 14pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     background-color: #366938;
     height: 64px;
     width: 142px;  /* Fixed width keeps them looking consistent across languages */
@@ -154,7 +156,7 @@ button.menu.flag {
     color: white;
     line-height: 1.4;
     font-size: 14pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     background-color: #366938;
     height: 64px;
     width: 64px;
@@ -263,7 +265,7 @@ button.sectionButton {
     border: 1px solid #002200;
     line-height: 1.4;
     font-size: 12pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     background-color: yellowgreen;
     height: 5ex;   /* One lines of 12pt text */
     color: black;
@@ -307,7 +309,7 @@ div.topSearch, div.bottomSearch {
     vertical-align: middle;
     height: 64px;
     background-color: white;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     width: 100%;
     margin: 0 0 0 0;
     padding: 0 0 0 0;
@@ -439,7 +441,7 @@ div.qrcodeFrame {
 
 span.qrcodeText {
     color: black;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
     font-size: 10pt;
     font-weight: bold;
     line-height: 1.5;
@@ -646,7 +648,7 @@ div.pandaName, div.zooName, div.gender {
 
 div.pandaName.profile {
     font-size: 34pt;
-    font-family: "Jun 201", sans-serif;
+    font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
 }
 
 div.gender {
@@ -1886,4 +1888,1074 @@ body.profile .floatingTopBtn:hover {
         margin-right: 16px;
 
     }
+}
+
+/* ================================================================
+   v5 UI RESTYLE — appended override block (visual only, no DOM/JS
+   changes). Everything above is the original structural base.
+   Source of truth: design/panda-v5.css
+   ================================================================ */
+/* ============================================================
+   Red Panda Finder — panda-v5.css  (rev 2)
+   In-place UI restyle of the EXISTING landing DOM.
+   Same elements, same ids/classes, zero functional change.
+   rev 2: v4 color energy — visible blobs, lime primary action,
+   grape/apple accents, white-framed hero photo, tagline stamp.
+   ============================================================ */
+/* Everything below OVERRIDES the base sheet. When porting, this whole
+   block appends to css/panda.css (or ships as a second stylesheet). */
+
+:root{
+  --green-deep:#0E2E22; --green:#134C39; --green-800:#103F30;
+  --lime:#C6F24E; --lime-2:#B4E63A; --lime-soft:#E7F7AE;
+  --grape:#8E57C6; --grape-soft:#EBDDFA; --grape-deep:#6E3FA6;
+  --apple:#E45140; --apple-soft:#FBD8D0;
+  --cream:#F6F1E3; --white:#FFFFFF;
+  --dim-dark:#9FBAA8; --ink-green:#123A2C;
+  --ease:cubic-bezier(.34,1.4,.5,1);
+}
+
+html { -webkit-text-size-adjust: 100%; height: 100%; }
+
+body {
+  margin: 0; padding: 0;
+  overflow-x: hidden;
+  min-height: 100%;
+  line-height: 1.4;
+  font-size: 14pt;
+  font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", system-ui, sans-serif;
+  background-color: var(--green-deep);
+  /* v4 blobs — big, bright, unmistakable */
+  background-image:
+    radial-gradient(circle 420px at 92% -80px,  #1E7A58 0%, transparent 68%),
+    radial-gradient(circle 360px at -100px 88%, rgba(198,242,78,.34) 0%, transparent 68%),
+    radial-gradient(circle 330px at 100% 44%,   rgba(142,87,198,.5)  0%, transparent 68%),
+    radial-gradient(circle 280px at 22% 58%,    rgba(228,81,64,.34)  0%, transparent 68%),
+    radial-gradient(circle 240px at 55% 8%,     rgba(87,183,194,.28) 0%, transparent 68%);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+}
+
+/* ---------- sticky header zone ---------- */
+div#pageTop { position: sticky; top: 0px; z-index: 99999; }
+
+/* ---------- top menu: floating pill bar ---------- */
+div.topMenu, div.bottomMenu {
+  display: block;
+  text-align: center;
+  max-height: none;
+  margin: 12px auto 0;
+  padding: 0 14px;
+  color: white;
+  background: transparent;
+  border-bottom: 0;
+  width: auto;
+  max-width: 900px;
+}
+
+div.topMenu > div.shrinker, div.bottomMenu > div.shrinker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  max-width: 868px;
+  margin: 0 auto;
+  padding: 7px;
+  background: rgba(16,63,48,.78);
+  border: 1px solid rgba(198,242,78,.35);   /* lime edge, not gray */
+  border-radius: 999px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 14px 30px rgba(0,0,0,.28);
+}
+
+button.logo {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 2px solid var(--lime);
+  color: white;
+  line-height: 1;
+  font-size: 15pt;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  background: var(--green-800);
+  height: 46px; width: 56px;
+  border-radius: 999px;
+  float: none;
+  margin-right: 2px;
+  cursor: pointer;
+  transform: rotate(-3deg);
+  transition: transform .18s var(--ease);
+}
+button.logo:hover { transform: rotate(3deg) scale(1.06); background: var(--green); }
+
+button.menu, button.menu.flag {
+  display: inline-flex; align-items: center; justify-content: center;
+  border: none;
+  color: #EAF4EC;
+  line-height: 1;
+  font-size: 12.5pt;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-weight: 600;
+  letter-spacing: .2px;
+  background: rgba(255,255,255,.07);
+  height: 46px;
+  width: auto;
+  padding: 0 16px;
+  border-radius: 999px;
+  transition: transform .18s var(--ease), background .15s, color .15s;
+  cursor: pointer;
+}
+/* language picker entries: icons.js swaps the flag emoji for the
+   language's native name (English / 日本語 …) — style as text pills */
+button.menu.flag { width: auto; min-width: 52px; padding: 0 18px; background: rgba(255,255,255,.07); }
+span.langName { font-weight: 700; letter-spacing: .3px; }
+
+/* each action gets its own v4 accent */
+button#randomButton {
+  background: var(--lime);
+  color: var(--green-deep);
+  transform: rotate(-1.5deg);          /* the playful primary, like v4's badge */
+}
+button#randomButton:hover { background: var(--lime-2); transform: rotate(1deg) scale(1.04); }
+button#aboutButton:hover   { background: var(--grape); color: #fff; }
+button#linksButton:hover   { background: var(--apple); color: #fff; }
+button#refreshButton:hover, button#languageButton:hover { background: var(--lime); color: var(--green-deep); }
+button.menu:hover, button.menu.flag:hover { animation: none; }
+button.menu:active, button.menu.flag:active, button.logo:active {
+  animation: none;
+  transform: scale(.95);
+}
+
+button.menu.disabled { background: transparent; color: #5e7a6b; }
+button.menu.hidden { display: none; }
+
+div.buttonContent { display: inline-flex; align-items: center; gap: 7px; border: none; margin: 0;
+  user-select: none; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }
+div.buttonIcon { display: block; font-size: 15pt; padding: 0; text-align: center;
+  user-select: none; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }
+div.buttonText { display: block; text-align: left;
+  user-select: none; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none; }
+div.buttonText.condensed { letter-spacing: -1px; font-size: 12pt; }
+button.menu.flag > div.buttonContent > div.buttonIcon { padding: 0; }
+
+/* ---------- language menu ---------- */
+div.languageMenu {
+  display: none;               /* unchanged: JS toggles it */
+  text-align: center;
+  margin: 8px auto 0;
+  padding: 0 14px;
+  background: transparent;
+  border-bottom: 0;
+  width: auto;
+  max-width: 900px;
+}
+div.languageMenu > div.shrinker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 6px;
+  background: rgba(16,63,48,.85);
+  border: 2px dotted var(--lime);
+  border-radius: 999px;
+  backdrop-filter: blur(12px);
+}
+
+/* ---------- search: floating white pill + lime submit ---------- */
+div.topSearch, div.bottomSearch {
+  display: block;
+  height: auto;
+  background: transparent;
+  width: auto;
+  margin: 16px auto 0;
+  padding: 0 14px;
+  max-width: 900px;
+}
+div.bottomSearch { display: none; }
+
+div.topSearch > div.shrinker {
+  max-width: 868px;
+  margin: 0 auto;
+  background: var(--white);
+  border-radius: 999px;
+  padding: 6px;
+  box-shadow: 0 18px 38px rgba(0,0,0,.3);
+}
+div.topSearch form {
+  display: flex;
+  align-items: center;
+  margin: 0; padding: 0;
+}
+
+input.search {
+  font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
+  font-weight: 700;
+  border-radius: 999px;
+  -webkit-appearance: none;
+  font-size: 21px;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  vertical-align: middle;
+  margin: 0;
+  padding: 0 8px 0 22px;
+  height: 52px;
+  color: var(--ink-green);
+  background: transparent;
+}
+input.search::placeholder { color: #9aab9d; font-weight: 700; }
+input.search[disabled] { background: transparent; color: transparent; }
+input.search[disabled]::placeholder { background: transparent; color: #c9d4c6; }
+
+/* the submit input becomes the visible lime search button */
+input#searchSubmit {
+  display: block;
+  order: 2;                    /* sits at the right end of the pill */
+  flex: none;
+  width: 52px; height: 52px;
+  border: 0;
+  border-radius: 999px;
+  font-size: 0;                /* hide the browser's "Submit" text */
+  color: transparent;
+  cursor: pointer;
+  background-color: var(--lime);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='11' cy='11' r='6.5' fill='none' stroke='%230E2E22' stroke-width='2.6'/><path d='M16 16l4.5 4.5' stroke='%230E2E22' stroke-width='2.6' stroke-linecap='round'/></svg>");
+  background-repeat: no-repeat;
+  background-size: 24px;
+  background-position: center;
+  transition: transform .18s var(--ease), background-color .15s;
+}
+input#searchSubmit:hover  { background-color: var(--lime-2); transform: scale(1.05); }
+input#searchSubmit:active { transform: scale(.94); }
+
+/* ---------- landing photo: white-framed hero card, full color ---------- */
+/* NOTE: the source photo is BLACK & WHITE — the old sheet tinted it with
+   opacity .4 over a gradient. Keep the tint idea, push it to v4 colors:
+   green→lime duotone instead of a washed-out gray. */
+img.fullFrame {
+  display: block;
+  width: calc(100% - 44px);
+  max-width: 1060px;
+  height: min(52vh, 540px);
+  margin: 24px auto 0;
+  object-fit: cover;
+  opacity: 1;
+  background: var(--green-800);
+  /* B/W source → rich green duotone */
+  filter: sepia(1) hue-rotate(58deg) saturate(1.35) brightness(.8) contrast(1.1);
+  border: 10px solid var(--white);          /* v4 white card frame */
+  border-radius: 30px;
+  box-shadow: 0 24px 48px rgba(0,0,0,.4);
+  transform: rotate(-.6deg);                /* a hint of the v4 sticker tilt */
+}
+
+/* ---------- tagline: the hidden site slug becomes a stamp on the photo ----------
+   Real content that was always in the page ("Learn about red pandas at your
+   local zoo!") — shown only while the landing photo is on screen. */
+body:has(img.fullFrame) div.hiddenSlug {
+  display: block;
+  text-align: center;
+  position: relative;
+  z-index: 2;
+  margin: -30px auto 0;
+  padding: 0 14px;
+}
+body:has(img.fullFrame) div.hiddenSlug p {
+  display: inline-block;
+  margin: 0;
+  background: var(--apple);
+  color: #fff;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-weight: 600;
+  font-size: 16.5pt;
+  padding: 12px 26px;
+  border-radius: 999px;
+  transform: rotate(1.8deg);
+  box-shadow: 0 14px 28px rgba(0,0,0,.35);
+}
+div.hiddenSlug { display: none; }           /* everywhere else: hidden as before */
+div.vitamins { display: none; }
+
+/* ============================================================
+   RESULTS VIEW — same DOM (pandaResult / pandaDossier / family),
+   v4 card language instead of the table-strip look.
+   ============================================================ */
+
+/* contentFrame becomes a transparent column; blobs show through */
+div#contentFrame {
+  padding: 1.5ex 14px 4ex;
+  margin: 0 auto;
+  max-width: 900px;
+  z-index: 1;
+  background: transparent;
+}
+div#hiddenContentFrame { display: none; z-index: -1; background: transparent; }
+
+/* result card: green table w/ khaki cells → white rounded card */
+div.pandaResult, div.zooResult {
+  display: flex;
+  align-items: stretch;
+  clear: both;
+  margin: 18px auto;
+  max-width: 868px;
+  border: 0;
+  background-color: var(--white);
+  color: var(--ink-green);
+  text-align: left;
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(0,0,0,.32);
+}
+
+/* photo cell: black slab → soft green frame area */
+div.pandaPhoto, div.zooPhoto {
+  display: block;
+  flex: none;
+  align-self: stretch;
+  background-color: var(--green-800);
+  position: relative;
+  user-select: none; -moz-user-select: none; -webkit-user-select: none; -ms-user-select: none;
+}
+div.pandaPhoto img, div.zooPhoto img {
+  width: 320px;
+  height: 100%;
+  min-height: 280px;
+  max-width: 320px;
+  max-height: none;
+  object-fit: cover;
+  z-index: 1;
+}
+
+/* photo counter: hard black box → rounded pill */
+span.navigator {
+  position: absolute;
+  top: 10px; left: 10px;
+  height: auto;
+  z-index: 2;
+  background-color: rgba(0,0,0,.55);
+  color: white;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 13pt;
+  border: 0;
+  border-radius: 999px;
+  text-align: center;
+  padding: 3px 14px;
+  width: auto;
+  backdrop-filter: blur(6px);
+}
+span.navigator.threeDigits, span.navigator.fourDigits {
+  font-size: 12pt; line-height: 1.5; padding: 3px 12px; letter-spacing: 0;
+}
+
+/* dossier cell */
+div.pandaDossier, div.zooDossier {
+  display: block;
+  flex: 1;
+  vertical-align: top;
+  background-color: var(--white);   /* pink lady → white */
+  border-left: 0;
+  min-width: 0;
+}
+
+/* title: yellowgreen strip → roomy Fredoka header */
+div.pandaTitle, div.zooTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  min-width: 0;
+  min-height: 0;
+  background-color: transparent;
+  padding: 16px 20px 4px;
+}
+div.pandaTitle:hover { animation: none; background-color: transparent; }
+div.pandaTitle:hover div.pandaName { color: var(--grape-deep); }
+div.pandaName, div.zooName {
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 20pt;
+  color: var(--ink-green);
+  transition: color .15s;
+}
+p.furigana { display: inline; font-size: 60%; margin-left: 1ex; color: #7C8A78; }
+
+/* details: solid grape stripe → soft grape chip row */
+div.pandaDetails, div.zooDetails {
+  display: block;
+  min-width: 0;
+  background-color: transparent;
+  padding: 6px 14px 4px;
+}
+div.pandaDetails p, div.zooDetails p {
+  display: inline-block;
+  margin: 4px;
+  padding: 6px 14px;
+  background: var(--grape-soft);
+  color: var(--grape-deep);
+  font-weight: 700;
+  font-size: 12pt;
+  border-radius: 999px;
+}
+div.pandaDetails p a, div.zooDetails p a { color: var(--grape-deep) !important; }
+
+/* family: pink block → cream card with mini headings */
+div.family {
+  display: flex;
+  flex-direction: row;
+  min-width: 0;
+  flex-wrap: wrap;
+  overflow: hidden;
+  background: var(--cream);
+  border-radius: 18px;
+  margin: 10px 18px 18px;
+  padding: 6px 8px 10px;
+}
+div.parents, div.litter, div.siblings, div.children, div.names {
+  display: inline-block;
+  vertical-align: top;
+  margin-left: 10px;
+  flex-grow: 0.1;
+  min-width: 0;
+}
+/* Layout.js sometimes picks a "vertical" column layout whose fixed 30%
+   column widths overflow the new card (4 cols = 120%). Force row+wrap
+   with natural widths — the pill lists handle wrapping fine. */
+div.family.vertical, div.family.vertical.onlyDesktop { flex-direction: row; }
+div.family.vertical.onlyDesktop > div,
+div.family.vertical.onlyDesktop > div.double,
+div.family.vertical.onlyDesktop > div.triple { width: auto; }
+h4.parentsHeading, h4.litterHeading, h4.siblingsHeading, h4.childrenHeading {
+  font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 10.5pt;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: #7C8A78;
+  margin: 10px 0 4px;
+}
+ul.pandaList li > a, ul.linkList li > a, ul.tagList li > a {
+  display: inline-block;
+  padding: 3px 10px;
+  margin-bottom: 2px;
+  border-radius: 999px;
+  font-weight: 700;
+  transition: background .15s;
+}
+ul.pandaList li > a:hover { background: var(--lime-soft); }
+ul.pandaList li a.passedAway { color: #6e695f; }
+
+/* links inside cards stay ink, not harsh black */
+div.pandaTitle a, div.pandaDossier a, div.pandaFamily a, div.zooDossier a,
+div.profileDossier a, div.zooHistory a {
+  text-decoration: none !important;
+  color: var(--ink-green);
+}
+
+/* empty result: keep the joke image, frame it like everything else */
+div.emptyResult {
+  display: block;
+  position: relative;
+  clear: both;
+  height: auto;
+  max-height: none;
+  margin: 18px auto;
+  max-width: 640px;
+  text-align: center;
+  border: 0;
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 18px 40px rgba(0,0,0,.32);
+}
+div.emptyResult img { height: auto; width: 100%; max-height: 520px; object-fit: cover; }
+div.emptyResult div.overlay {
+  position: absolute;
+  font-size: 20pt;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  color: white;
+  top: auto; bottom: 8%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,.5);
+  padding: 8px 22px;
+  border-radius: 999px;
+  backdrop-filter: blur(6px);
+}
+
+/* results on phones: photo on top, dossier below */
+@media (max-width: 700px) {
+  div.pandaResult, div.zooResult { flex-direction: column; margin: 14px auto; }
+  div.pandaPhoto img, div.zooPhoto img {
+    width: 100%; max-width: none; height: 260px; min-height: 0;
+  }
+}
+
+/* ============================================================
+   PROFILE VIEW — v4 "PART 2": red-brown theme → cream + white
+   cards + grape accents. Compound .profile selectors need
+   explicit overrides (they out-rank the generic rules).
+   ============================================================ */
+body.profile {
+  background-color: var(--cream);
+  background-image:
+    radial-gradient(circle 320px at -70px -70px,  rgba(198,242,78,.4)  0%, transparent 68%),
+    radial-gradient(circle 280px at 105% 30%,     rgba(142,87,198,.22) 0%, transparent 68%),
+    radial-gradient(circle 260px at -60px 75%,    rgba(228,81,64,.16)  0%, transparent 68%);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
+  color: var(--ink-green);
+}
+
+/* menus keep the same dark pill bar on cream */
+div.topMenu.profile, div.bottomMenu.profile, div.languageMenu.profile {
+  background: transparent;
+  border-bottom: 0;
+}
+button.menu.profile, button.menu.flag.profile { background: rgba(255,255,255,.07); color: #EAF4EC; }
+button.logo.profile { background: var(--green-800); }
+button.menu.profile:hover, button.menu.flag.profile:hover, button.logo.profile:hover {
+  animation: none;
+  background: var(--lime);
+  color: var(--green-deep);
+}
+
+/* goldenrod radial → let the cream body show */
+div#contentFrame.profile { background: transparent; }
+
+/* pink name strip → white hero card */
+div.profile.nameBar {
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 30pt;
+  width: auto;
+  max-width: 868px;
+  margin: 14px auto 0;
+  padding: 10px 18px;
+  background-color: var(--white);
+  text-align: center;
+  border-radius: 24px;
+  box-shadow: 0 14px 32px rgba(18,58,44,.12);
+}
+
+/* khaki table frames → white cards */
+div.profileFrame {
+  display: block;
+  margin: 14px auto;
+  max-width: 868px;
+  border: 0;
+  background-color: var(--white);
+  border-radius: 24px;
+  overflow: hidden;
+  box-shadow: 0 14px 32px rgba(18,58,44,.1);
+}
+div.profileFrame.zoos { background-color: transparent; border: 0; box-shadow: none; }
+div.profileDossier {
+  display: block;
+  width: auto;
+  background-color: var(--white);
+  border-left: 0;
+  padding: 4px 12px 10px;
+}
+
+/* profile dossier card: 320px photo cell on the left, info fills the right
+   (same grid as the results cards; small photos no longer blow up full-width) */
+div.profileFrame:has(> div.pandaPhoto) {
+  display: flex;
+  align-items: stretch;
+}
+div.profileFrame div.profileDossier {
+  flex: 1;
+  min-width: 0;
+}
+@media (max-width: 700px) {
+  div.profileFrame:has(> div.pandaPhoto) { flex-direction: column; }
+}
+
+/* section menu: yellowgreen blocks → pills, plum selected → grape */
+div.sectionMenu { margin: 12px auto 4px; text-align: center; }
+button.sectionButton {
+  display: inline-block;
+  border: 0;
+  line-height: 1.3;
+  font-size: 12pt;
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-weight: 600;
+  background-color: var(--white);
+  color: var(--ink-green);
+  height: auto;
+  padding: 10px 18px;
+  margin: 3px 2px;
+  border-radius: 999px;
+  box-shadow: 0 6px 14px rgba(18,58,44,.12);
+  cursor: pointer;
+  transition: transform .18s var(--ease), background .15s, color .15s;
+}
+button.sectionButton:hover { animation: none; background-color: var(--lime); color: var(--green-deep); }
+button.sectionButton:active { animation: none; transform: scale(.95); }
+button.sectionButton.selected { background-color: var(--grape); color: #fff; }
+
+/* detail strips: grays → soft cards */
+div.detailsNameTitle { background-color: var(--cream); border-radius: 10px 10px 0 0; font-weight: 800; }
+div.detailsName { background-color: var(--white); border: 0; }
+div.detailsLocation { background-color: var(--cream-2, #FBF7EC); margin-bottom: 1ex; border-radius: 0 0 10px 10px; }
+div.detailsVideo { background-color: var(--green-800); border: 0; border-radius: 14px; overflow: hidden; }
+
+/* profile back-to-top: brown → grape */
+body.profile .floatingTopBtn { background: var(--grape); color: #fff; }
+body.profile .floatingTopBtn:hover { background: var(--grape-deep); }
+
+/* ============================================================
+   ABOUT / LINKS / SUMMARIES / GALLERY CARDS
+   ============================================================ */
+div#contentFrame.about, div#contentFrame.links { background: transparent; }
+
+/* summary chips: bordered grape/salmon blocks → v4 soft pills */
+div.arrivalsHeader p, div.birthdaySummary p, div.creditSummary p,
+div.departuresHeader p, div.frontPageSummary p, div.memorialSummary p,
+div.profileSummary p, div.residentsHeader p, div.tagSummary p {
+  display: inline-block;
+  background-color: var(--grape-soft);
+  background-image: none;
+  color: var(--grape-deep);
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 18px;
+  margin: 1ex 0.5ex;
+  font-weight: 700;
+}
+div.arrivalsHeader p, div.departuresHeader p, div.residentsHeader p {
+  background-color: var(--apple-soft);
+  color: #C43A2C;
+  min-width: 0;
+}
+p.summaryEmphasis > a { color: inherit; text-decoration: none !important; }
+div.birthdaySummary p.summaryEmphasis {
+  background-image: none; background-color: var(--grape); color: #fff;
+}
+div.frontPageSummary p.summaryEmphasis {
+  background-image: none;
+  background-color: var(--lime);
+  color: var(--green-deep);
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 17pt;
+  border-radius: 999px;
+  padding: 10px 24px;
+}
+div.frontPageSummary a:hover > p.summaryEmphasis {
+  animation: none;
+  background: var(--lime-2);
+}
+div.birthdaySummary a:hover > p, div.memorialSummary a:hover > p, div.tagSummary a:hover > p {
+  animation: none;
+  background-color: var(--grape);
+  color: #fff;
+}
+
+/* gallery cards (front-page updates, tag pages, memorials) */
+div.photoSample {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  vertical-align: top;
+}
+div.photoSample > img, div.photoSample > a > img {
+  border: 0;
+  border-radius: 14px;
+  width: 100%;
+  aspect-ratio: 1 / 1;          /* uniform card heights → captions line up */
+  object-fit: cover;
+  box-shadow: 0 10px 22px rgba(0,0,0,.3);
+}
+div.photoSample > a { width: 100%; display: block; }
+/* the old sheet forces width:100% on these caption variants with higher
+   specificity — pin them all back to a consistent pill width */
+div.photoSample h5.caption.groupMediaAuthor,
+div.photoSample h5.caption.groupMediaName,
+div.photoSample h5.caption.updateName,
+div.photoSample h5.caption.updateAuthor,
+div.photoSample h5.caption.updateAuthorCredit,
+div.photoSample h5.caption.updateTagName,
+div.photoSample h5.caption.birthdayMessage,
+div.photoSample h5.caption.halloweenMessage,
+div.photoSample h5.caption.memorialMessage,
+div.photoSample h5.caption.authorCredit {
+  width: 92%;
+  overflow-x: hidden;
+}
+div.photoSample h5 { margin-top: 5px; margin-bottom: 0; }
+div.photoSample h5 + h5, div.photoSample a + h5 { margin-top: 3px; }
+div.photoSample h5 {
+  border: 0;
+  border-radius: 999px;
+  font-family: "M PLUS Rounded 1c", "Jun 201", "Noto Emoji", sans-serif;
+  font-weight: 800;
+  width: 92%;
+  padding: 2px 6px;
+}
+div.photoSample h5.caption.familyName, div.photoSample h5.caption.groupMediaName,
+div.photoSample h5.caption.updateName, div.photoSample h5.caption.pandaName,
+div.photoSample h5.caption.zooName, div.photoSample h5.caption.updateTagName {
+  background-color: var(--lime-soft);
+  color: var(--green);
+}
+div.photoSample h5.caption.familyTitle, div.photoSample h5.caption.groupMediaAuthor,
+div.photoSample h5.caption.updateAuthor, div.photoSample h5.caption.updateAuthorCredit,
+div.photoSample h5.caption.authorCredit {
+  background-color: rgba(255,255,255,.9);
+  color: var(--ink-green);
+  border-top: 0;
+  /* the base sheet pins margin-top:0 on these author pills with 0-3-2
+     specificity, which glued them to the name pill above — match the
+     specificity here (later in cascade wins) to restore the gap */
+  margin-top: 6px;
+}
+div.photoSample h5.caption.newContributor { background-color: var(--grape-soft); color: var(--grape-deep); }
+div.photoSample a:hover > h5.caption.familyName,
+div.photoSample a:hover > h5.caption.groupMediaName,
+div.photoSample a:hover > h5.caption.memorialMessage,
+div.photoSample a:hover > h5.caption.pandaName,
+div.photoSample a:hover > h5.caption.updateName,
+div.photoSample a:hover > h5.caption.updateTagName,
+div.photoSample a:hover > h5.caption.zooName {
+  animation: none;
+  background-color: var(--lime);
+}
+div.photoSample a:hover > h5.caption.groupMediaAuthor,
+div.photoSample a:hover > h5.caption.updateAuthor {
+  animation: none;
+  background-color: var(--white);
+}
+
+/* ------------------------------------------------------------
+   v4-style wave section divider (landing page)
+   The last child of div#contentFrame.birthdayPandas is always the
+   "new photos this week" gallery (banner + photoSample cards) —
+   see Page.home.render + Gallery.updatedNewPhotoCredits. Turn it
+   into a full-bleed cream band with the prototype-v4 wave edges.
+   birthdayPandas is only ever set on the landing frame, so this
+   cannot leak into results/profile views. CSS-only, zero DOM/JS.
+   ------------------------------------------------------------ */
+div#contentFrame.birthdayPandas > div:last-child {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 100vw;                        /* break out of the 900px column */
+  margin-left: calc(50% - 50vw);       /* body has overflow-x:hidden */
+  margin-top: 88px;                    /* breathing room for the top wave */
+  margin-bottom: 76px;                 /* …and the bottom wave */
+  /* keep inner content aligned to the same 900px column */
+  padding: 6px max(14px, calc(50vw - 436px)) 30px;
+  background: var(--cream);
+}
+div#contentFrame.birthdayPandas > div:last-child::before,
+div#contentFrame.birthdayPandas > div:last-child::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 64px;
+  pointer-events: none;
+  /* same curve as prototype-v4-mobile.html's .wave svg */
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 70" preserveAspectRatio="none"><path d="M0 40 C 240 80 480 0 720 30 C 960 60 1200 10 1440 34 L1440 70 L0 70 Z" fill="%23F6F1E3"/></svg>') center / 100% 100% no-repeat;
+}
+div#contentFrame.birthdayPandas > div:last-child::before { top: -63px; }
+div#contentFrame.birthdayPandas > div:last-child::after { bottom: -63px; transform: scaleY(-1); }
+/* on the cream band, soften the dark-background card shadows */
+div#contentFrame.birthdayPandas > div:last-child div.photoSample > img,
+div#contentFrame.birthdayPandas > div:last-child div.photoSample > a > img {
+  box-shadow: 0 10px 22px rgba(18,58,44,.16);
+}
+div#contentFrame.birthdayPandas > div:last-child div.photoSample h5.caption.updateAuthor,
+div#contentFrame.birthdayPandas > div:last-child div.photoSample h5.caption.updateAuthorCredit {
+  background-color: var(--white);
+  box-shadow: 0 3px 8px rgba(18,58,44,.10);
+}
+
+/* zoo count blocks: pink/bordered → soft cards */
+ul.zooCounts { background-color: var(--cream); border-radius: 14px; }
+ul.zooList { border: 0; background-color: var(--white); border-radius: 14px; box-shadow: 0 8px 18px rgba(18,58,44,.08); }
+
+/* qr code frame */
+div.qrcodeFrame button { background-color: var(--white); border: 4px solid var(--lime); border-radius: 20px; }
+div.qrcodeFrame button:hover { border-color: var(--lime-2); }
+
+/* bottom menu (Options / paging): hug its buttons, don't span the page */
+div.bottomMenu > div.shrinker {
+  width: fit-content;
+  min-width: 0;
+  margin: 0 auto 14px;
+  padding: 7px 10px;
+}
+/* no visible buttons → no empty pill (old sheet used a max-height hack) */
+div.bottomMenu:not(:has(button:not(.hidden))) { display: none; }
+
+/* footer: solid green/brown strip → quiet transparent line */
+div.footer, div.footer.profile {
+  display: block;
+  width: auto;
+  text-align: center;
+  font-size: 10pt;
+  background-color: transparent;
+  color: var(--dim-dark);
+  padding: 14px 0 20px;
+}
+div.footer.profile { color: #7C8A78; }
+div.footer a { color: inherit; font-weight: 700; }
+div.footer p { padding: 0.5ex 14px; }
+
+/* ---------- back-to-top ---------- */
+.floatingTopBtn {
+  position: fixed;
+  right: 18px; bottom: 18px;
+  width: 52px; height: 52px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--lime);
+  color: var(--green-deep);
+  display: grid; place-items: center;
+  box-shadow: 0 12px 26px rgba(0,0,0,.35);
+  cursor: pointer;
+  transition: transform .18s var(--ease);
+  z-index: 999;
+}
+.floatingTopBtn:hover { transform: translateY(-2px) scale(1.05); background: var(--lime-2); }
+.floatingTopBtn:active { transform: scale(.94); }
+
+/* ---------- mobile ---------- */
+@media (max-width: 640px) {
+  div.topMenu > div.shrinker { gap: 2px; }
+  button.menu { padding: 0 11px; font-size: 12pt; }
+  div.buttonText { display: none; }        /* icon-only pills on phones */
+  button.logo { width: 46px; }
+  div.buttonIcon { font-size: 16pt; }
+  input.search { font-size: 17px; height: 46px; padding-left: 16px; }
+  input#searchSubmit { width: 46px; height: 46px; background-size: 21px; }
+  img.fullFrame { width: calc(100% - 28px); height: 48vh; border-radius: 22px; border-width: 7px; margin-top: 16px; }
+  body:has(img.fullFrame) div.hiddenSlug p { font-size: 13pt; padding: 10px 18px; }
+  body:has(img.fullFrame) div.hiddenSlug { margin-top: -24px; }
+}
+
+/* ---- Lucide inline icons (js/icons.js) ------------------------
+   span.lx wraps each replaced emoji; svg inherits currentColor.  */
+span.lx {
+  display: inline-block;
+  width: 1.05em;
+  height: 1.05em;
+  vertical-align: -0.15em;
+}
+span.lx svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+div.buttonIcon span.lx {          /* nav buttons: bigger, centered */
+  width: 1.15em;
+  height: 1.15em;
+  vertical-align: -0.2em;
+}
+span.lx.lxe {                     /* native color emoji (🌈 deceased marker) */
+  width: auto;
+  height: 1em;                    /* don't inflate the row line box */
+  line-height: 1;
+  margin: 0 0.12em;
+  vertical-align: -0.1em;
+  font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+}
+/* dossier info chips: solid icons so they read as icons, not glyphs */
+div.pandaDossier span.lx svg,
+div.zooDossier span.lx svg,
+div.profileDossier span.lx svg { fill: currentColor; }
+div.family span.lx svg { fill: none; }
+
+/* ================================================================
+   ENTITY PAGES: native color emoji  (2026-07 revert)
+   Panda/zoo result cards and profile pages go back to the original
+   color emoji (location 🏡/🗺️, family 👩🏻/👨🏻, birthday 🐣, etc.).
+   The monochrome "Noto Emoji" font stays for the site chrome only,
+   so it is simply dropped from the stack inside entity containers —
+   emoji then fall back to the system color emoji font.
+   ================================================================ */
+div.pandaResult, div.pandaResult *,
+div.zooResult, div.zooResult *,
+div.profileFrame, div.profileFrame *,
+div.mediaFrame, div.mediaFrame *,
+div.profilePhotos, div.profilePhotos *,
+div.zooHistory, div.zooHistory * {
+  font-family: "M PLUS Rounded 1c", "Jun 201", system-ui, sans-serif;
+}
+/* restate the display-font elements the wildcard above clobbered
+   (same look as before, just without the mono emoji font) */
+span.navigator,
+div.pandaName, div.zooName,
+div.emptyResult div.overlay,
+button.sectionButton {
+  font-family: "Baloo 2", "Jun 201", sans-serif;
+}
+/* caption pills: "div.photoSample h5" outranks the wildcard above,
+   so drop the mono emoji font at matching specificity here */
+div.profilePhotos div.photoSample h5,
+div.profileFrame div.photoSample h5,
+div.mediaFrame div.photoSample h5 {
+  font-family: "M PLUS Rounded 1c", "Jun 201", sans-serif;
+}
+
+/* ================================================================
+   GENDER BADGES: make sex readable at a glance.
+   The bare ♂/♀ glyph images are hard to tell apart, so each one
+   becomes a white symbol on a color-coded pill:
+   male = blue, female = pink, unknown = gray.
+   ================================================================ */
+/* Filtering the <img> would also invert its background, so the pill
+   color lives on the parent div.gender via :has(). Browsers without
+   :has() keep the plain black glyphs (no white-on-white risk). */
+@supports selector(div:has(img)) {
+  div.gender {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    padding: 2.5pt 4.5pt;
+  }
+  div.gender img { filter: brightness(0) invert(1); }  /* glyph → white */
+  div.gender:has(img[src="images/male.svg"])    { background: #2F6DC9; }
+  div.gender:has(img[src="images/female.svg"])  { background: #D6448C; }
+  div.gender:has(img[src="images/unknown.svg"]) { background: #8A9A8F; }
+  div.gender.profile { padding: 4pt 7pt; }
+  div.gender.caption { padding: 1.5pt 2.5pt; }
+}
+
+/* ================================================================
+   ABOUT PAGE — typography polish + playful tag capsules
+   (CSS-only, no DOM/JS changes. Scoped to div#contentFrame.about
+   and div.aboutTags so nothing leaks into other views.)
+   ================================================================ */
+
+/* ---------- typography ---------- */
+div#contentFrame.about div.pandaAbout {
+  color: #EAF4EC;                    /* softer than pure white */
+  max-width: 760px;                  /* comfortable reading measure */
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 16px;
+}
+div#contentFrame.about div.pandaAbout h2 {
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 25pt;
+  font-weight: 700;
+  letter-spacing: .01em;
+  color: #fff;
+  margin: 1.2em 0 0.4em;
+  line-height: 1.2;
+}
+/* lime brush-stroke under each heading */
+div#contentFrame.about div.pandaAbout h2::after {
+  content: "";
+  display: block;
+  width: 64px;
+  height: 6px;
+  margin-top: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--lime), var(--lime-2));
+}
+div#contentFrame.about div.pandaAbout p {
+  line-height: 1.7;
+  margin: 0.7em 0;
+}
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) {
+  margin-top: 0.8ex;
+  margin-bottom: 1.2ex;
+  padding-left: 1.2em;
+}
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) > li {
+  line-height: 1.6;
+  margin-bottom: 0.7em;
+  padding-left: 0.3em;
+}
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) > li::marker {
+  content: "🐾 ";
+  font-size: 90%;
+}
+/* body links: lime underline accent instead of default blue-ish */
+div#contentFrame.about div.pandaAbout > p > a,
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) > li > a {
+  color: #fff;
+  font-weight: 700;
+  text-decoration-color: var(--lime);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+div#contentFrame.about div.pandaAbout > p > a:hover,
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) > li > a:hover {
+  color: var(--lime);
+}
+/* italic keywords (Search, Enter, Random) → little cream keycap chips */
+div#contentFrame.about div.pandaAbout > ul:not(.tagList) > li > i {
+  font-style: normal;
+  font-weight: 700;
+  background: rgba(255,255,255,.14);
+  border-radius: 7px;
+  padding: 0 7px;
+  margin: 0 1px;
+}
+/* photo captions */
+div#contentFrame.about div.pandaAbout h5.caption {
+  color: var(--dim-dark);
+  font-size: 11pt;
+  font-weight: 500;
+  line-height: 1.5;
+}
+div#contentFrame.about div.pandaAbout h5.caption > a { color: var(--dim-dark); font-weight: 700; }
+/* author credit under "About Red Pandas" */
+div#contentFrame.about div.pandaAbout h4 > a {
+  display: inline-block;
+  font-style: normal;
+  font-weight: 700;
+  background: var(--grape-soft);
+  color: var(--grape-deep);
+  border-radius: 999px;
+  padding: 3px 14px;
+}
+
+/* ---------- Search Tips tag capsules ---------- */
+/* the JS fills div.aboutTags with ul.tagList.multiColumn; flex-wrap
+   beats the 3-column layout for pills (column-count is ignored on
+   flex containers, so the old rules are harmless) */
+div.aboutTags {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 820px;
+}
+div.aboutTags ul.tagList,
+div.aboutTags ul.tagList.multiColumn {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 9px 8px;
+  margin: 1.5ex 0 3ex;
+  padding: 0;
+}
+div.aboutTags ul.tagList li { line-height: 1.2; }
+div.aboutTags ul.tagList li > a {
+  display: inline-block;
+  padding: 6px 15px;
+  margin: 0;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 12.5pt;
+  text-decoration: none !important;
+  box-shadow: 0 4px 10px rgba(0,0,0,.22);
+  transition: transform .18s var(--ease), filter .15s;
+}
+div.aboutTags ul.tagList li > a:hover {
+  transform: translateY(-2px) scale(1.05) rotate(-1deg);
+  filter: brightness(1.06);
+}
+div.aboutTags ul.tagList li > a:active { transform: scale(.94); }
+/* 5-color candy cycle from the v5 palette */
+div.aboutTags ul.tagList li:nth-child(5n+1) > a { background: var(--lime-soft);  color: var(--green-deep); }
+div.aboutTags ul.tagList li:nth-child(5n+2) > a { background: var(--grape-soft); color: var(--grape-deep); }
+div.aboutTags ul.tagList li:nth-child(5n+3) > a { background: var(--apple-soft); color: #B33325; }
+div.aboutTags ul.tagList li:nth-child(5n+4) > a { background: var(--cream);      color: var(--ink-green); }
+div.aboutTags ul.tagList li:nth-child(5n+5) > a { background: #CDEFF2;           color: #23616B; }
+
+/* ---------- mobile ---------- */
+@media (max-width: 640px) {
+  div#contentFrame.about div.pandaAbout h2 { font-size: 20pt; }
+  div.aboutTags ul.tagList li > a { font-size: 11.5pt; padding: 5px 12px; }
 }

--- a/css/panda.css
+++ b/css/panda.css
@@ -1915,7 +1915,16 @@ body.profile .floatingTopBtn:hover {
   --ease:cubic-bezier(.34,1.4,.5,1);
 }
 
-html { -webkit-text-size-adjust: 100%; height: 100%; }
+html {
+  -webkit-text-size-adjust: 100%;
+  height: 100%;
+  /* body{overflow-x:hidden} alone doesn't stop iOS Safari from panning
+     horizontally when something overflows (the 100vw wave bands rely on
+     clipping) — the viewport clip must live on html too. `clip` avoids
+     creating a scroll container where supported; `hidden` is the fallback. */
+  overflow-x: hidden;
+  overflow-x: clip;
+}
 
 body {
   margin: 0; padding: 0;
@@ -2071,8 +2080,16 @@ div.topSearch, div.bottomSearch {
   max-width: 900px;
 }
 div.bottomSearch { display: none; }
+/* profile pages: Show.searchBar.toggle reveals #bottomSearch with an
+   inline `display:table` — force full width so the table-mode box
+   still spans the column like the top bar does */
+div.bottomSearch {
+  width: 100%;
+  box-sizing: border-box;
+}
 
-div.topSearch > div.shrinker {
+div.topSearch > div.shrinker,
+div.bottomSearch > div.shrinker {
   max-width: 868px;
   margin: 0 auto;
   background: var(--white);
@@ -2080,7 +2097,11 @@ div.topSearch > div.shrinker {
   padding: 6px;
   box-shadow: 0 18px 38px rgba(0,0,0,.3);
 }
-div.topSearch form {
+/* the flex row is what pins #searchSubmit (first in the form's DOM) to
+   the right end — without it the lime button stacks ABOVE the input,
+   which is exactly what happened on the profile bottom bar */
+div.topSearch form,
+div.bottomSearch form {
   display: flex;
   align-items: center;
   margin: 0; padding: 0;
@@ -2719,7 +2740,7 @@ div.footer p { padding: 0.5ex 14px; }
 
 /* ---------- mobile ---------- */
 @media (max-width: 640px) {
-  div.topMenu > div.shrinker { gap: 2px; }
+  div.topMenu > div.shrinker { gap: 2px; flex-wrap: wrap; }
   button.menu { padding: 0 11px; font-size: 12pt; }
   div.buttonText { display: none; }        /* icon-only pills on phones */
   button.logo { width: 46px; }
@@ -2729,6 +2750,18 @@ div.footer p { padding: 0.5ex 14px; }
   img.fullFrame { width: calc(100% - 28px); height: 48vh; border-radius: 22px; border-width: 7px; margin-top: 16px; }
   body:has(img.fullFrame) div.hiddenSlug p { font-size: 13pt; padding: 10px 18px; }
   body:has(img.fullFrame) div.hiddenSlug { margin-top: -24px; }
+}
+
+/* neutralize the base sheet's ≤415px table-era menu rules: their
+   0,3,3-specificity selectors beat the v5 pill styles above and blew
+   each button up by 32px of buttonContent margin, overflowing both
+   the top-menu oval and the viewport on small phones (iPhone mini). */
+@media screen and (max-width: 415px) {
+  div.topMenu div.shrinker button.menu { width: auto; }
+  div.topMenu div.shrinker button.menu div.buttonContent {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 /* ---- Lucide inline icons (js/icons.js) ------------------------

--- a/css/panda.css
+++ b/css/panda.css
@@ -2959,3 +2959,211 @@ div.aboutTags ul.tagList li:nth-child(5n+5) > a { background: #CDEFF2;          
   div#contentFrame.about div.pandaAbout h2 { font-size: 20pt; }
   div.aboutTags ul.tagList li > a { font-size: 11.5pt; padding: 5px 12px; }
 }
+
+/* ================================================================
+   LINKS PAGE — typography matched to the v5 About treatment
+   (CSS-only, scoped to div#contentFrame.links. Covers all four
+   tabs: community / zoos / instagrams / special-thanks.)
+   ================================================================ */
+div#contentFrame.links div.pandaLinks {
+  color: #EAF4EC;                    /* softer than pure white */
+  max-width: 760px;                  /* comfortable reading measure */
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 16px;
+}
+div#contentFrame.links h2.linksHeader {
+  font-family: "Baloo 2", "Jun 201", "Noto Emoji", sans-serif;
+  font-size: 25pt;
+  font-weight: 700;
+  letter-spacing: .01em;
+  color: #fff;
+  margin: 1.2em 0 0.4em;
+  line-height: 1.2;
+}
+/* lime brush-stroke under the heading, same as About */
+div#contentFrame.links h2.linksHeader::after {
+  content: "";
+  display: block;
+  width: 64px;
+  height: 6px;
+  margin-top: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--lime), var(--lime-2));
+}
+div#contentFrame.links div.pandaLinks p {
+  line-height: 1.7;
+  margin: 0.7em 0;
+}
+div#contentFrame.links div.pandaLinks ul.linkList {
+  margin: 1.2ex 0 3ex;
+  padding-left: 0;
+}
+div#contentFrame.links div.pandaLinks ul.linkList li {
+  line-height: 1.6;
+  margin-bottom: 0.6em;
+  break-inside: avoid;               /* multiColumn: keep item + flags together */
+  /* hanging indent: wrapped lines align after the marker icon */
+  padding-left: calc(1em + 8px);
+  text-indent: calc(-1em - 8px);
+}
+div#contentFrame.links ul.linkList.multiColumn { column-gap: 2.5em; }
+/* links: lime underline accent, same as About body links.
+   (base sheet pins text-decoration:none !important at 0-1-4;
+   match !important with higher specificity to win) */
+div#contentFrame.links div.pandaLinks ul.linkList li > a,
+div#contentFrame.links div.pandaLinks > p > a {
+  color: #fff;
+  font-weight: 700;
+  /* base sheet's `text-decoration: none !important` shorthand pins
+     line/color/thickness as important — override each longhand */
+  text-decoration-line: underline !important;
+  text-decoration-color: var(--lime) !important;
+  text-decoration-thickness: 2px !important;
+  text-underline-offset: 3px;
+  /* base sheet's display:inline-block turns long "name + flags" into one
+     atomic box that overflows its column — let it wrap like normal text */
+  display: inline;
+  overflow-wrap: anywhere;
+  text-indent: 0;
+}
+div#contentFrame.links div.pandaLinks ul.linkList li > a:hover,
+div#contentFrame.links div.pandaLinks > p > a:hover {
+  color: var(--lime);
+}
+/* special-thanks underlined non-links keep the same accent */
+div#contentFrame.links div.pandaLinks ul.linkList li u {
+  text-decoration-color: var(--lime);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+/* list-marker emoji (🎍 ❤️ 🐼): slightly smaller, steady spacing */
+div#contentFrame.links div.pandaLinks ul.linkList li:before {
+  font-size: 90%;
+  margin-right: 8px;
+}
+/* zoos tab: the data assigns 🐼 — that's a giant panda, wrong species for
+   this site — use a lime Lucide paw print instead (matches About's 🐾) */
+div#contentFrame.links div#zooLinks ul.linkList li:before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.12em;
+  background-color: var(--lime);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='4' r='2'/%3E%3Ccircle cx='18' cy='8' r='2'/%3E%3Ccircle cx='20' cy='16' r='2'/%3E%3Cpath d='M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='4' r='2'/%3E%3Ccircle cx='18' cy='8' r='2'/%3E%3Ccircle cx='20' cy='16' r='2'/%3E%3Cpath d='M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+/* instagram tab: the data assigns the 🎍 marker, which renders as an ugly
+   Noto Emoji outline — swap in a lime Lucide instagram glyph via mask */
+div#contentFrame.links div#instagramLinks ul.linkList li:before {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.12em;
+  background-color: var(--lime);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='20' height='20' x='2' y='2' rx='5' ry='5'/%3E%3Cpath d='M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z'/%3E%3Cline x1='17.5' x2='17.51' y1='6.5' y2='6.5'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect width='20' height='20' x='2' y='2' rx='5' ry='5'/%3E%3Cpath d='M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z'/%3E%3Cline x1='17.5' x2='17.51' y1='6.5' y2='6.5'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+@media (max-width: 640px) {
+  div#contentFrame.links h2.linksHeader { font-size: 20pt; }
+  div#contentFrame.links div.pandaLinks { padding: 0 4px; }
+}
+
+/* ------------------------------------------------------------
+   v4-style wave section dividers (profile page) — FINAL
+   Sections ALTERNATE light green / cream (Zoe: 交互 between
+   淺綠 #D4EFC0 and the cream body 米黃 #F6F1E3 — nothing else).
+   shrinker children are always: 1 profileFrame · 2 summary(where) ·
+   3 zooHistory · 4 summary(family) · 5 profilePhotos ·
+   6 summary · 7 profilePhotos · [8 summary · 9 profilePhotos]
+   Odd sections (pairs 2+3, 6+7) become full-bleed green bands
+   with wave edges; even sections stay on the cream body.
+   CSS-only, zero DOM/JS. Same curve as the landing wave.
+   ------------------------------------------------------------ */
+div#contentFrame.profile > div.shrinker > div:nth-child(2),
+div#contentFrame.profile > div.shrinker > div:nth-child(3),
+div#contentFrame.profile > div.shrinker > div:nth-child(6),
+div#contentFrame.profile > div.shrinker > div:nth-child(7) {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 100vw;                        /* break out of the 868px column */
+  margin-left: calc(50% - 50vw);       /* body has overflow-x:hidden */
+  /* keep inner content aligned to the shrinker's 868px column */
+  padding-left: max(14px, calc(50vw - 434px));
+  padding-right: max(14px, calc(50vw - 434px));
+  background-color: #D4EFC0;
+}
+/* summary chip opens the band: room for the top wave, no seam below */
+div#contentFrame.profile > div.shrinker > div:nth-child(2),
+div#contentFrame.profile > div.shrinker > div:nth-child(6) {
+  margin-top: 92px;
+  margin-bottom: 0;
+  padding-top: 2px;
+  padding-bottom: 4px;
+}
+/* content closes the band: room for the bottom wave */
+div#contentFrame.profile > div.shrinker > div:nth-child(3),
+div#contentFrame.profile > div.shrinker > div:nth-child(7) {
+  margin-top: 0;
+  margin-bottom: 80px;
+  padding-bottom: 26px;
+}
+div#contentFrame.profile > div.shrinker > div:nth-child(2)::before,
+div#contentFrame.profile > div.shrinker > div:nth-child(6)::before,
+div#contentFrame.profile > div.shrinker > div:nth-child(3)::after,
+div#contentFrame.profile > div.shrinker > div:nth-child(7)::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 64px;
+  pointer-events: none;
+  /* same curve as prototype-v4-mobile.html's .wave svg */
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 70" preserveAspectRatio="none"><path d="M0 40 C 240 80 480 0 720 30 C 960 60 1200 10 1440 34 L1440 70 L0 70 Z" fill="%23D4EFC0"/></svg>') center / 100% 100% no-repeat;
+}
+div#contentFrame.profile > div.shrinker > div:nth-child(2)::before,
+div#contentFrame.profile > div.shrinker > div:nth-child(6)::before { top: -63px; }
+div#contentFrame.profile > div.shrinker > div:nth-child(3)::after,
+div#contentFrame.profile > div.shrinker > div:nth-child(7)::after { bottom: -63px; transform: scaleY(-1); }
+/* on green bands, soften card shadows to match the landing band */
+div#contentFrame.profile > div.shrinker > div.profilePhotos div.photoSample > img,
+div#contentFrame.profile > div.shrinker > div.profilePhotos div.photoSample > a > img {
+  box-shadow: 0 10px 22px rgba(18,58,44,.16);
+}
+
+/* ------------------------------------------------------------
+   PROFILE HEADER POLISH
+   (a) top menu pill / name bar / profile card all compute width
+       differently (content-box + different paddings) → border-box
+       so all three render exactly 868px wide.
+   (b) dossier (right of the photo): consistent left-aligned rows
+       with even spacing, QR centered, no stray base margins.
+   ------------------------------------------------------------ */
+div.topMenu > div.shrinker,
+div.bottomMenu > div.shrinker,
+div.profile.nameBar {
+  box-sizing: border-box;
+}
+
+div.profileFrame div.profileDossier {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 18px 26px 20px;
+}
+div.profileFrame div.profileDossier div.species h4 { margin: 0 0 2px; }
+div.profileFrame div.profileDossier > ul.pandaList { margin: 0; }
+div.profileFrame > div.profileDossier > ul.pandaList li { margin-left: 0; }
+div.profileFrame div.profileDossier div.qrcodeFrame {
+  align-self: center;
+  margin: 12px auto 4px;
+}
+div.profileFrame div.profileDossier div.nicknameContainer h4,
+div.profileFrame div.profileDossier div.othernamesContainer h4 { margin: 8px 0 2px; }
+div.profileFrame div.profileDossier div.nicknameContainer ul,
+div.profileFrame div.profileDossier div.othernamesContainer ul { margin: 0; }

--- a/fragments/en/about.html
+++ b/fragments/en/about.html
@@ -15,7 +15,7 @@
 <div class="pandaAbout onlyDesktop">
 <h2>How To Use This Site (PC)</h2>
 <ul>
-<li>Click the 🇺🇸 to change languages. Five languages are supported.</li>
+<li>Click the <i class="langKey">🇺🇸</i> icon to change languages. Five languages are supported.</li>
 <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
 <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
 <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
@@ -25,7 +25,7 @@
 <div class="pandaAbout onlyMobile">
 <h2>How To Use This Site (Mobile)</h2>
 <ul>
-<li>Touch the 🇺🇸 to change languages. Five languages are supported.</li>
+<li>Touch the <i class="langKey">🇺🇸</i> icon to change languages. Five languages are supported.</li>
 <li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
 <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
 <li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>

--- a/fragments/ne/about.html
+++ b/fragments/ne/about.html
@@ -15,7 +15,7 @@
   <div class="pandaAbout onlyDesktop">
   <h2>How To Use This Site (PC)</h2>
   <ul>
-  <li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
+  <li>Click the <i class="langKey">🇺🇸</i> icon to change languages. Three languages are supported.</li>
   <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
   <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
   <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
@@ -25,7 +25,7 @@
   <div class="pandaAbout onlyMobile">
   <h2>How To Use This Site (Mobile)</h2>
   <ul>
-  <li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
+  <li>Touch the <i class="langKey">🇺🇸</i> icon to change languages. English and Japanese are supported.</li>
   <li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
   <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
   <li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>

--- a/fragments/zh/about.html
+++ b/fragments/zh/about.html
@@ -15,7 +15,7 @@
   <div class="pandaAbout onlyDesktop">
   <h2>How To Use This Site (PC)</h2>
   <ul>
-  <li>Click the 🇺🇸 to change languages. Three languages are supported.</li>
+  <li>Click the <i class="langKey">🇺🇸</i> icon to change languages. Three languages are supported.</li>
   <li>To see a new red panda, just click the 🎲 <i>(Random)</i> icon.</li>
   <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just click the <i>Search</i> bar, type a name, and press <i>Enter</i>.</li>
   <li>Once you've found a panda, you can learn more about their family by clicking their green name-bar, or the names of the panda's family.</li>
@@ -25,7 +25,7 @@
   <div class="pandaAbout onlyMobile">
   <h2>How To Use This Site (Mobile)</h2>
   <ul>
-  <li>Touch the 🇺🇸 to change languages. English and Japanese are supported.</li>
+  <li>Touch the <i class="langKey">🇺🇸</i> icon to change languages. English and Japanese are supported.</li>
   <li>To see a new red panda, just touch the 🎲 <i>(Random)</i> icon.</li>
   <li>Once you know a panda's name, use the white <i>Search</i> bar to find them again. Just touch the <i>Search</i> bar, input a name, and touch your keyboard's <i>Search</i> button.</li>
   <li>Once you've found a panda, you can learn more about their family by touching their green name-bar, or the names of the panda's family.</li>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
 <script type="application/javascript" src="./js/geolocate.js"></script>
 <script type="application/javascript" src="./js/options.js"></script>
 <script type="application/javascript" src="./js/scrollTop.js"></script>
+<script type="application/javascript" src="./js/icons.js"></script>
 <script type="application/javascript" src="./js/init.js"></script>
 </head>
 <body ondragstart="return false;" ondrop="return false;">

--- a/js/icons.js
+++ b/js/icons.js
@@ -1,0 +1,429 @@
+/*
+    Replace emoji glyphs with inline Lucide line icons (v5 UI restyle).
+    Text-node walker + MutationObserver; no call-site changes needed.
+    Unmapped emoji (country flags, etc.) fall back to the Noto Emoji font.
+    Icon SVGs: lucide-static v1.24.0 (ISC license, https://lucide.dev)
+*/
+
+var Icons = {};   /* namespace */
+
+Icons.svg = {
+ "angry": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M16 16s-1.5-2-4-2-4 2-4 2\" /><path d=\"M7.5 8 10 9\" /><path d=\"m14 9 2.5-1\" /><path d=\"M9 10h.01\" /><path d=\"M15 10h.01\" /></svg>",
+ "annoyed": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M8 15h8\" /><path d=\"M8 9h2\" /><path d=\"M14 9h2\" /></svg>",
+ "apple": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 6.528V3a1 1 0 0 1 1-1h0\" /><path d=\"M18.237 21A15 15 0 0 0 22 11a6 6 0 0 0-10-4.472A6 6 0 0 0 2 11a15.1 15.1 0 0 0 3.763 10 3 3 0 0 0 3.648.648 5.5 5.5 0 0 1 5.178 0A3 3 0 0 0 18.237 21\" /></svg>",
+ "arrow-down-to-line": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 17V3\" /><path d=\"m6 11 6 6 6-6\" /><path d=\"M19 21H5\" /></svg>",
+ "arrow-right": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M5 12h14\" /><path d=\"m12 5 7 7-7 7\" /></svg>",
+ "arrow-up": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m5 12 7-7 7 7\" /><path d=\"M12 19V5\" /></svg>",
+ "award": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526\" /><circle cx=\"12\" cy=\"8\" r=\"6\" /></svg>",
+ "baby": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M10 16c.5.3 1.2.5 2 .5s1.5-.2 2-.5\" /><path d=\"M15 12h.01\" /><path d=\"M19.38 6.813A9 9 0 0 1 20.8 10.2a2 2 0 0 1 0 3.6 9 9 0 0 1-17.6 0 2 2 0 0 1 0-3.6A9 9 0 0 1 12 3c2 0 3.5 1.1 3.5 2.5s-.9 2.5-2 2.5c-.8 0-1.5-.4-1.5-1\" /><path d=\"M9 12h.01\" /></svg>",
+ "ban": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M4.929 4.929 19.07 19.071\" /></svg>",
+ "banknote": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect width=\"20\" height=\"12\" x=\"2\" y=\"6\" rx=\"2\" /><circle cx=\"12\" cy=\"12\" r=\"2\" /><path d=\"M6 12h.01M18 12h.01\" /></svg>",
+ "bed": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M2 4v16\" /><path d=\"M2 8h18a2 2 0 0 1 2 2v10\" /><path d=\"M2 17h20\" /><path d=\"M6 8v9\" /></svg>",
+ "bed-double": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M2 20v-8a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v8\" /><path d=\"M4 10V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4\" /><path d=\"M12 4v6\" /><path d=\"M2 18h20\" /></svg>",
+ "bird": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M16 7h.01\" /><path d=\"M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20\" /><path d=\"m20 7 2 .5-2 .5\" /><path d=\"M10 18v3\" /><path d=\"M14 17.75V21\" /><path d=\"M7 18a6 6 0 0 0 3.84-10.61\" /></svg>",
+ "book-open": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 7v14\" /><path d=\"M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z\" /></svg>",
+ "bug": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 20v-9\" /><path d=\"M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z\" /><path d=\"M14.12 3.88 16 2\" /><path d=\"M21 21a4 4 0 0 0-3.81-4\" /><path d=\"M21 5a4 4 0 0 1-3.55 3.97\" /><path d=\"M22 13h-4\" /><path d=\"M3 21a4 4 0 0 1 3.81-4\" /><path d=\"M3 5a4 4 0 0 0 3.55 3.97\" /><path d=\"M6 13H2\" /><path d=\"m8 2 1.88 1.88\" /><path d=\"M9 7.13V6a3 3 0 1 1 6 0v1.13\" /></svg>",
+ "cake": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M20 21v-8a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8\" /><path d=\"M4 16s.5-1 2-1 2.5 2 4 2 2.5-2 4-2 2.5 2 4 2 2-1 2-1\" /><path d=\"M2 21h20\" /><path d=\"M7 8v3\" /><path d=\"M12 8v3\" /><path d=\"M17 8v3\" /><path d=\"M7 4h.01\" /><path d=\"M12 4h.01\" /><path d=\"M17 4h.01\" /></svg>",
+ "camera": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M13.997 4a2 2 0 0 1 1.76 1.05l.486.9A2 2 0 0 0 18.003 7H20a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h1.997a2 2 0 0 0 1.759-1.048l.489-.904A2 2 0 0 1 10.004 4z\" /><circle cx=\"12\" cy=\"13\" r=\"3\" /></svg>",
+ "candy": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M10 7v10.9\" /><path d=\"M14 6.1V17\" /><path d=\"M16 7V3a1 1 0 0 1 1.707-.707 2.5 2.5 0 0 0 2.152.717 1 1 0 0 1 1.131 1.131 2.5 2.5 0 0 0 .717 2.152A1 1 0 0 1 21 8h-4\" /><path d=\"M16.536 7.465a5 5 0 0 0-7.072 0l-2 2a5 5 0 0 0 0 7.07 5 5 0 0 0 7.072 0l2-2a5 5 0 0 0 0-7.07\" /><path d=\"M8 17v4a1 1 0 0 1-1.707.707 2.5 2.5 0 0 0-2.152-.717 1 1 0 0 1-1.131-1.131 2.5 2.5 0 0 0-.717-2.152A1 1 0 0 1 3 16h4\" /></svg>",
+ "cat": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 5c.67 0 1.35.09 2 .26 1.78-2 5.03-2.84 6.42-2.26 1.4.58-.42 7-.42 7 .57 1.07 1 2.24 1 3.44C21 17.9 16.97 21 12 21s-9-3-9-7.56c0-1.25.5-2.4 1-3.44 0 0-1.89-6.42-.5-7 1.39-.58 4.72.23 6.5 2.23A9.04 9.04 0 0 1 12 5Z\" /><path d=\"M8 14v.5\" /><path d=\"M16 14v.5\" /><path d=\"M11.25 16.25h1.5L12 17l-.75-.75Z\" /></svg>",
+ "circle": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /></svg>",
+ "circle-help": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3\" /><path d=\"M12 17h.01\" /></svg>",
+ "cloud-rain": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242\" /><path d=\"M16 14v6\" /><path d=\"M8 14v6\" /><path d=\"M12 16v6\" /></svg>",
+ "construction": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"2\" y=\"6\" width=\"20\" height=\"8\" rx=\"1\" /><path d=\"M17 14v7\" /><path d=\"M7 14v7\" /><path d=\"M17 3v3\" /><path d=\"M7 3v3\" /><path d=\"M10 14 2.3 6.3\" /><path d=\"m14 6 7.7 7.7\" /><path d=\"m8 6 8 8\" /></svg>",
+ "dices": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect width=\"12\" height=\"12\" x=\"2\" y=\"10\" rx=\"2\" ry=\"2\" /><path d=\"m17.92 14 3.5-3.5a2.24 2.24 0 0 0 0-3l-5-4.92a2.24 2.24 0 0 0-3 0L10 6\" /><path d=\"M6 18h.01\" /><path d=\"M10 14h.01\" /><path d=\"M15 6h.01\" /><path d=\"M18 9h.01\" /></svg>",
+ "dog": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11.25 16.25h1.5L12 17z\" /><path d=\"M16 14v.5\" /><path d=\"M4.42 11.247A13.152 13.152 0 0 0 4 14.556C4 18.728 7.582 21 12 21s8-2.272 8-6.444a11.702 11.702 0 0 0-.493-3.309\" /><path d=\"M8 14v.5\" /><path d=\"M8.5 8.5c-.384 1.05-1.083 2.028-2.344 2.5-1.931.722-3.576-.297-3.656-1-.113-.994 1.177-6.53 4-7 1.923-.321 3.651.845 3.651 2.235A7.497 7.497 0 0 1 14 5.277c0-1.39 1.844-2.598 3.767-2.277 2.823.47 4.113 6.006 4 7-.08.703-1.725 1.722-3.656 1-1.261-.472-1.855-1.45-2.239-2.5\" /></svg>",
+ "door-open": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11 20H2\" /><path d=\"M11 4.562v16.157a1 1 0 0 0 1.242.97L19 20V5.562a2 2 0 0 0-1.515-1.94l-4-1A2 2 0 0 0 11 4.561z\" /><path d=\"M11 4H8a2 2 0 0 0-2 2v14\" /><path d=\"M14 12h.01\" /><path d=\"M22 20h-3\" /></svg>",
+ "droplet": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 22a7 7 0 0 0 7-7c0-2-1-3.9-3-5.5s-3.5-4-4-6.5c-.5 2.5-2 4.9-4 6.5C6 11.1 5 13 5 15a7 7 0 0 0 7 7z\" /></svg>",
+ "dumbbell": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M17.596 12.768a2 2 0 1 0 2.829-2.829l-1.768-1.767a2 2 0 0 0 2.828-2.829l-2.828-2.828a2 2 0 0 0-2.829 2.828l-1.767-1.768a2 2 0 1 0-2.829 2.829z\" /><path d=\"m2.5 21.5 1.4-1.4\" /><path d=\"m20.1 3.9 1.4-1.4\" /><path d=\"M5.343 21.485a2 2 0 1 0 2.829-2.828l1.767 1.768a2 2 0 1 0 2.829-2.829l-6.364-6.364a2 2 0 1 0-2.829 2.829l1.768 1.767a2 2 0 0 0-2.828 2.829z\" /><path d=\"m9.6 14.4 4.8-4.8\" /></svg>",
+ "ear": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M6 8.5a6.5 6.5 0 1 1 13 0c0 6-6 6-6 10a3.5 3.5 0 1 1-7 0\" /><path d=\"M15 8.5a2.5 2.5 0 0 0-5 0v1a2 2 0 1 1 0 4\" /></svg>",
+ "egg": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 2C8 2 4 8 4 14a8 8 0 0 0 16 0c0-6-4-12-8-12\" /></svg>",
+ "eye": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0\" /><circle cx=\"12\" cy=\"12\" r=\"3\" /></svg>",
+ "flower": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"3\" /><path d=\"M12 16.5A4.5 4.5 0 1 1 7.5 12 4.5 4.5 0 1 1 12 7.5a4.5 4.5 0 1 1 4.5 4.5 4.5 4.5 0 1 1-4.5 4.5\" /><path d=\"M12 7.5V9\" /><path d=\"M7.5 12H9\" /><path d=\"M16.5 12H15\" /><path d=\"M12 16.5V15\" /><path d=\"m8 8 1.88 1.88\" /><path d=\"M14.12 9.88 16 8\" /><path d=\"m8 16 1.88-1.88\" /><path d=\"M14.12 14.12 16 16\" /></svg>",
+ "flower-2": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 5a3 3 0 1 1 3 3m-3-3a3 3 0 1 0-3 3m3-3v1M9 8a3 3 0 1 0 3 3M9 8h1m5 0a3 3 0 1 1-3 3m3-3h-1m-2 3v-1\" /><circle cx=\"12\" cy=\"8\" r=\"2\" /><path d=\"M12 10v12\" /><path d=\"M12 22c4.2 0 7-1.667 7-5-4.2 0-7 1.667-7 5Z\" /><path d=\"M12 22c-4.2 0-7-1.667-7-5 4.2 0 7 1.667 7 5Z\" /></svg>",
+ "frown": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M16 16s-1.5-2-4-2-4 2-4 2\" /><line x1=\"9\" x2=\"9.01\" y1=\"9\" y2=\"9\" /><line x1=\"15\" x2=\"15.01\" y1=\"9\" y2=\"9\" /></svg>",
+ "gem": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M10.5 3 8 9l4 13 4-13-2.5-6\" /><path d=\"M17 3a2 2 0 0 1 1.6.8l3 4a2 2 0 0 1 .013 2.382l-7.99 10.986a2 2 0 0 1-3.247 0l-7.99-10.986A2 2 0 0 1 2.4 7.8l2.998-3.997A2 2 0 0 1 7 3z\" /><path d=\"M2 9h20\" /></svg>",
+ "ghost": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M9 10h.01\" /><path d=\"M15 10h.01\" /><path d=\"M12 2a8 8 0 0 0-8 8v12l3-3 2.5 2.5L12 19l2.5 2.5L17 19l3 3V10a8 8 0 0 0-8-8z\" /></svg>",
+ "gift": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 7v14\" /><path d=\"M20 11v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8\" /><path d=\"M7.5 7a1 1 0 0 1 0-5A4.8 8 0 0 1 12 7a4.8 8 0 0 1 4.5-5 1 1 0 0 1 0 5\" /><rect x=\"3\" y=\"7\" width=\"18\" height=\"4\" rx=\"1\" /></svg>",
+ "glasses": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"6\" cy=\"15\" r=\"4\" /><circle cx=\"18\" cy=\"15\" r=\"4\" /><path d=\"M14 15a2 2 0 0 0-2-2 2 2 0 0 0-2 2\" /><path d=\"M2.5 13 5 7c.7-1.3 1.4-2 3-2\" /><path d=\"M21.5 13 19 7c-.7-1.3-1.5-2-3-2\" /></svg>",
+ "globe": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20\" /><path d=\"M2 12h20\" /></svg>",
+ "grape": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M22 5V2l-5.89 5.89\" /><circle cx=\"16.6\" cy=\"15.89\" r=\"3\" /><circle cx=\"8.11\" cy=\"7.4\" r=\"3\" /><circle cx=\"12.35\" cy=\"11.65\" r=\"3\" /><circle cx=\"13.91\" cy=\"5.85\" r=\"3\" /><circle cx=\"18.15\" cy=\"10.09\" r=\"3\" /><circle cx=\"6.56\" cy=\"13.2\" r=\"3\" /><circle cx=\"10.8\" cy=\"17.44\" r=\"3\" /><circle cx=\"5\" cy=\"19\" r=\"3\" /></svg>",
+ "hand-heart": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11 14h2a2 2 0 0 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 16\" /><path d=\"m14.45 13.39 5.05-4.694C20.196 8 21 6.85 21 5.75a2.75 2.75 0 0 0-4.797-1.837.276.276 0 0 1-.406 0A2.75 2.75 0 0 0 11 5.75c0 1.2.802 2.248 1.5 2.946L16 11.95\" /><path d=\"m2 15 6 6\" /><path d=\"m7 20 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a1 1 0 0 0-2.75-2.91\" /></svg>",
+ "heart": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5\" /></svg>",
+ "heart-handshake": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M19.414 14.414C21 12.828 22 11.5 22 9.5a5.5 5.5 0 0 0-9.591-3.676.6.6 0 0 1-.818.001A5.5 5.5 0 0 0 2 9.5c0 2.3 1.5 4 3 5.5l5.535 5.362a2 2 0 0 0 2.879.052 2.12 2.12 0 0 0-.004-3 2.124 2.124 0 1 0 3-3 2.124 2.124 0 0 0 3.004 0 2 2 0 0 0 0-2.828l-1.881-1.882a2.41 2.41 0 0 0-3.409 0l-1.71 1.71a2 2 0 0 1-2.828 0 2 2 0 0 1 0-2.828l2.823-2.762\" /></svg>",
+ "home": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8\" /><path d=\"M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z\" /></svg>",
+ "hourglass": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M5 22h14\" /><path d=\"M5 2h14\" /><path d=\"M17 22v-4.172a2 2 0 0 0-.586-1.414L12 12l-4.414 4.414A2 2 0 0 0 7 17.828V22\" /><path d=\"M7 2v4.172a2 2 0 0 0 .586 1.414L12 12l4.414-4.414A2 2 0 0 0 17 6.172V2\" /></svg>",
+ "id-card": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M16 10h2\" /><path d=\"M16 14h2\" /><path d=\"M6.17 15a3 3 0 0 1 5.66 0\" /><circle cx=\"9\" cy=\"11\" r=\"2\" /><rect x=\"2\" y=\"5\" width=\"20\" height=\"14\" rx=\"2\" /></svg>",
+ "image": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect width=\"18\" height=\"18\" x=\"3\" y=\"3\" rx=\"2\" ry=\"2\" /><circle cx=\"9\" cy=\"9\" r=\"2\" /><path d=\"m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21\" /></svg>",
+ "landmark": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M10 18v-7\" /><path d=\"M11.119 2.205a2 2 0 0 1 1.762 0l7.84 3.846A.5.5 0 0 1 20.5 7h-17a.5.5 0 0 1-.22-.949z\" /><path d=\"M14 18v-7\" /><path d=\"M18 18v-7\" /><path d=\"M3 22h18\" /><path d=\"M6 18v-7\" /></svg>",
+ "languages": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m5 8 6 6\" /><path d=\"m4 14 6-6 2-3\" /><path d=\"M2 5h12\" /><path d=\"M7 2h1\" /><path d=\"m22 22-5-10-5 10\" /><path d=\"M14 18h6\" /></svg>",
+ "laugh": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M18 13a6 6 0 0 1-6 5 6 6 0 0 1-6-5h12Z\" /><line x1=\"9\" x2=\"9.01\" y1=\"9\" y2=\"9\" /><line x1=\"15\" x2=\"15.01\" y1=\"9\" y2=\"9\" /></svg>",
+ "leaf": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10Z\" /><path d=\"M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12\" /></svg>",
+ "lightbulb": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5\" /><path d=\"M9 18h6\" /><path d=\"M10 22h4\" /></svg>",
+ "lock": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect width=\"18\" height=\"11\" x=\"3\" y=\"11\" rx=\"2\" ry=\"2\" /><path d=\"M7 11V7a5 5 0 0 1 10 0v4\" /></svg>",
+ "map": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M14.106 5.553a2 2 0 0 0 1.788 0l3.659-1.83A1 1 0 0 1 21 4.619v12.764a1 1 0 0 1-.553.894l-4.553 2.277a2 2 0 0 1-1.788 0l-4.212-2.106a2 2 0 0 0-1.788 0l-3.659 1.83A1 1 0 0 1 3 19.381V6.618a1 1 0 0 1 .553-.894l4.553-2.277a2 2 0 0 1 1.788 0z\" /><path d=\"M15 5.764v15\" /><path d=\"M9 3.236v15\" /></svg>",
+ "mars": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M16 3h5v5\" /><path d=\"m21 3-6.75 6.75\" /><circle cx=\"10\" cy=\"14\" r=\"6\" /></svg>",
+ "meh": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><line x1=\"8\" x2=\"16\" y1=\"15\" y2=\"15\" /><line x1=\"9\" x2=\"9.01\" y1=\"9\" y2=\"9\" /><line x1=\"15\" x2=\"15.01\" y1=\"9\" y2=\"9\" /></svg>",
+ "mic-vocal": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m11 7.601-5.994 8.19a1 1 0 0 0 .1 1.298l.817.818a1 1 0 0 0 1.314.087L15.09 12\" /><path d=\"M16.5 21.174C15.5 20.5 14.372 20 13 20c-2.058 0-3.928 2.356-6 2-2.072-.356-2.775-3.369-1.5-4.5\" /><circle cx=\"16\" cy=\"7\" r=\"5\" /></svg>",
+ "moon": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401\" /></svg>",
+ "mountain": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m8 3 4 8 5-5 5 15H2L8 3z\" /></svg>",
+ "origami": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 12V4a1 1 0 0 1 1-1h6.297a1 1 0 0 1 .651 1.759l-4.696 4.025\" /><path d=\"m12 21-7.414-7.414A2 2 0 0 1 4 12.172V6.415a1.002 1.002 0 0 1 1.707-.707L20 20.009\" /><path d=\"m12.214 3.381 8.414 14.966a1 1 0 0 1-.167 1.199l-1.168 1.163a1 1 0 0 1-.706.291H6.351a1 1 0 0 1-.625-.219L3.25 18.8a1 1 0 0 1 .631-1.781l4.165.027\" /></svg>",
+ "panda": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11.25 17.25h1.5L12 18z\" /><path d=\"m15 12 2 2\" /><path d=\"M18 6.5a.5.5 0 0 0-.5-.5\" /><path d=\"M20.69 9.67a4.5 4.5 0 1 0-7.04-5.5 8.35 8.35 0 0 0-3.3 0 4.5 4.5 0 1 0-7.04 5.5C2.49 11.2 2 12.88 2 14.5 2 19.47 6.48 22 12 22s10-2.53 10-7.5c0-1.62-.48-3.3-1.3-4.83\" /><path d=\"M6 6.5a.495.495 0 0 1 .5-.5\" /><path d=\"m9 12-2 2\" /></svg>",
+ "party-popper": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M5.8 11.3 2 22l10.7-3.79\" /><path d=\"M4 3h.01\" /><path d=\"M22 8h.01\" /><path d=\"M15 2h.01\" /><path d=\"M22 20h.01\" /><path d=\"m22 2-2.24.75a2.9 2.9 0 0 0-1.96 3.12c.1.86-.57 1.63-1.45 1.63h-.38c-.86 0-1.6.6-1.76 1.44L14 10\" /><path d=\"m22 13-.82-.33c-.86-.34-1.82.2-1.98 1.11c-.11.7-.72 1.22-1.43 1.22H17\" /><path d=\"m11 2 .33.82c.34.86-.2 1.82-1.11 1.98C9.52 4.9 9 5.52 9 6.23V7\" /><path d=\"M11 13c1.93 1.93 2.83 4.17 2 5-.83.83-3.07-.07-5-2-1.93-1.93-2.83-4.17-2-5 .83-.83 3.07.07 5 2Z\" /></svg>",
+ "paw-print": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"11\" cy=\"4\" r=\"2\" /><circle cx=\"18\" cy=\"8\" r=\"2\" /><circle cx=\"20\" cy=\"16\" r=\"2\" /><path d=\"M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z\" /></svg>",
+ "pen-line": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M13 21h8\" /><path d=\"M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z\" /></svg>",
+ "pencil": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z\" /><path d=\"m15 5 4 4\" /></svg>",
+ "pickaxe": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m14 13-8.381 8.38a1 1 0 0 1-3.001-3L11 9.999\" /><path d=\"M15.973 4.027A13 13 0 0 0 5.902 2.373c-1.398.342-1.092 2.158.277 2.601a19.9 19.9 0 0 1 5.822 3.024\" /><path d=\"M16.001 11.999a19.9 19.9 0 0 1 3.024 5.824c.444 1.369 2.26 1.676 2.603.278A13 13 0 0 0 20 8.069\" /><path d=\"M18.352 3.352a1.205 1.205 0 0 0-1.704 0l-5.296 5.296a1.205 1.205 0 0 0 0 1.704l2.296 2.296a1.205 1.205 0 0 0 1.704 0l5.296-5.296a1.205 1.205 0 0 0 0-1.704z\" /></svg>",
+ "plane": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M17.8 19.2 16 11l3.5-3.5C21 6 21.5 4 21 3c-1-.5-3 0-4.5 1.5L13 8 4.8 6.2c-.5-.1-.9.1-1.1.5l-.3.5c-.2.5-.1 1 .3 1.3L9 12l-2 3H4l-1 1 3 2 2 3 1-1v-3l3-2 3.5 5.3c.3.4.8.5 1.3.3l.5-.2c.4-.3.6-.7.5-1.2z\" /></svg>",
+ "rainbow": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M22 17a10 10 0 0 0-20 0\" /><path d=\"M6 17a6 6 0 0 1 12 0\" /><path d=\"M10 17a2 2 0 0 1 4 0\" /></svg>",
+ "rat": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M13 22H4a2 2 0 0 1 0-4h12\" /><path d=\"M13.236 18a3 3 0 0 0-2.2-5\" /><path d=\"M16 9h.01\" /><path d=\"M16.82 3.94a3 3 0 1 1 3.237 4.868l1.815 2.587a1.5 1.5 0 0 1-1.5 2.1l-2.872-.453a3 3 0 0 0-3.5 3\" /><path d=\"M17 4.988a3 3 0 1 0-5.2 2.052A7 7 0 0 0 4 14.015 4 4 0 0 0 8 18\" /></svg>",
+ "refresh-cw": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8\" /><path d=\"M21 3v5h-5\" /><path d=\"M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16\" /><path d=\"M8 16H3v5\" /></svg>",
+ "scale": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 3v18\" /><path d=\"m19 8 3 8a5 5 0 0 1-6 0zV7\" /><path d=\"M3 7h1a17 17 0 0 0 8-2 17 17 0 0 0 8 2h1\" /><path d=\"m5 8 3 8a5 5 0 0 1-6 0zV7\" /><path d=\"M7 21h10\" /></svg>",
+ "scan-eye": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 7V5a2 2 0 0 1 2-2h2\" /><path d=\"M17 3h2a2 2 0 0 1 2 2v2\" /><path d=\"M21 17v2a2 2 0 0 1-2 2h-2\" /><path d=\"M7 21H5a2 2 0 0 1-2-2v-2\" /><circle cx=\"12\" cy=\"12\" r=\"1\" /><path d=\"M18.944 12.33a1 1 0 0 0 0-.66 7.5 7.5 0 0 0-13.888 0 1 1 0 0 0 0 .66 7.5 7.5 0 0 0 13.888 0\" /></svg>",
+ "scan-face": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 7V5a2 2 0 0 1 2-2h2\" /><path d=\"M17 3h2a2 2 0 0 1 2 2v2\" /><path d=\"M21 17v2a2 2 0 0 1-2 2h-2\" /><path d=\"M7 21H5a2 2 0 0 1-2-2v-2\" /><path d=\"M8 14s1.5 2 4 2 4-2 4-2\" /><path d=\"M9 9h.01\" /><path d=\"M15 9h.01\" /></svg>",
+ "search": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m21 21-4.34-4.34\" /><circle cx=\"11\" cy=\"11\" r=\"8\" /></svg>",
+ "settings": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915\" /><circle cx=\"12\" cy=\"12\" r=\"3\" /></svg>",
+ "shower-head": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m4 4 2.5 2.5\" /><path d=\"M13.5 6.5a4.95 4.95 0 0 0-7 7\" /><path d=\"M15 5 5 15\" /><path d=\"M14 17v.01\" /><path d=\"M10 16v.01\" /><path d=\"M13 13v.01\" /><path d=\"M16 10v.01\" /><path d=\"M11 20v.01\" /><path d=\"M17 14v.01\" /><path d=\"M20 11v.01\" /></svg>",
+ "siren": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M7 18v-6a5 5 0 1 1 10 0v6\" /><path d=\"M5 21a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-1a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2z\" /><path d=\"M21 12h1\" /><path d=\"M18.5 4.5 18 5\" /><path d=\"M2 12h1\" /><path d=\"M12 2v1\" /><path d=\"m4.929 4.929.707.707\" /><path d=\"M12 12v6\" /></svg>",
+ "smile": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><path d=\"M8 14s1.5 2 4 2 4-2 4-2\" /><line x1=\"9\" x2=\"9.01\" y1=\"9\" y2=\"9\" /><line x1=\"15\" x2=\"15.01\" y1=\"9\" y2=\"9\" /></svg>",
+ "snowflake": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m10 20-1.25-2.5L6 18\" /><path d=\"M10 4 8.75 6.5 6 6\" /><path d=\"m14 20 1.25-2.5L18 18\" /><path d=\"m14 4 1.25 2.5L18 6\" /><path d=\"m17 21-3-6h-4\" /><path d=\"m17 3-3 6 1.5 3\" /><path d=\"M2 12h6.5L10 9\" /><path d=\"m20 10-1.5 2 1.5 2\" /><path d=\"M22 12h-6.5L14 15\" /><path d=\"m4 10 1.5 2L4 14\" /><path d=\"m7 21 3-6-1.5-3\" /><path d=\"m7 3 3 6h4\" /></svg>",
+ "soup": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 21a9 9 0 0 0 9-9H3a9 9 0 0 0 9 9Z\" /><path d=\"M7 21h10\" /><path d=\"M19.5 12 22 6\" /><path d=\"M16.25 3c.27.1.8.53.75 1.36-.06.83-.93 1.2-1 2.02-.05.78.34 1.24.73 1.62\" /><path d=\"M11.25 3c.27.1.8.53.74 1.36-.05.83-.93 1.2-.98 2.02-.06.78.33 1.24.72 1.62\" /><path d=\"M6.25 3c.27.1.8.53.75 1.36-.06.83-.93 1.2-1 2.02-.05.78.34 1.24.74 1.62\" /></svg>",
+ "spade": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 18v4\" /><path d=\"M2 14.499a5.5 5.5 0 0 0 9.591 3.675.6.6 0 0 1 .818.001A5.5 5.5 0 0 0 22 14.5c0-2.29-1.5-4-3-5.5l-5.492-5.312a2 2 0 0 0-3-.02L5 8.999c-1.5 1.5-3 3.2-3 5.5\" /></svg>",
+ "sprout": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M14 9.536V7a4 4 0 0 1 4-4h1.5a.5.5 0 0 1 .5.5V5a4 4 0 0 1-4 4 4 4 0 0 0-4 4c0 2 1 3 1 5a5 5 0 0 1-1 3\" /><path d=\"M4 9a5 5 0 0 1 8 4 5 5 0 0 1-8-4\" /><path d=\"M5 21h14\" /></svg>",
+ "star": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z\" /></svg>",
+ "target": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><circle cx=\"12\" cy=\"12\" r=\"6\" /><circle cx=\"12\" cy=\"12\" r=\"2\" /></svg>",
+ "tent": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3.5 21 14 3\" /><path d=\"M20.5 21 10 3\" /><path d=\"M15.5 21 12 15l-3.5 6\" /><path d=\"M2 21h20\" /></svg>",
+ "toilet": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M7 12h13a1 1 0 0 1 1 1 5 5 0 0 1-5 5h-.598a.5.5 0 0 0-.424.765l1.544 2.47a.5.5 0 0 1-.424.765H5.402a.5.5 0 0 1-.424-.765L7 18\" /><path d=\"M8 18a5 5 0 0 1-5-5V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8\" /></svg>",
+ "tornado": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M21 4H3\" /><path d=\"M18 8H6\" /><path d=\"M19 12H9\" /><path d=\"M16 16h-6\" /><path d=\"M11 20H9\" /></svg>",
+ "trees": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M10 10v.2A3 3 0 0 1 8.9 16H5a3 3 0 0 1-1-5.8V10a3 3 0 0 1 6 0Z\" /><path d=\"M7 16v6\" /><path d=\"M13 19v3\" /><path d=\"M12 19h8.3a1 1 0 0 0 .7-1.7L18 14h.3a1 1 0 0 0 .7-1.7L16 9h.2a1 1 0 0 0 .8-1.7L13 3l-1.4 1.5\" /></svg>",
+ "truck": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2\" /><path d=\"M15 18H9\" /><path d=\"M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14\" /><circle cx=\"17\" cy=\"18\" r=\"2\" /><circle cx=\"7\" cy=\"18\" r=\"2\" /></svg>",
+ "user": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2\" /><circle cx=\"12\" cy=\"7\" r=\"4\" /></svg>",
+ "user-round": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"8\" r=\"5\" /><path d=\"M20 21a8 8 0 0 0-16 0\" /></svg>",
+ "users": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2\" /><path d=\"M16 3.128a4 4 0 0 1 0 7.744\" /><path d=\"M22 21v-2a4 4 0 0 0-3-3.87\" /><circle cx=\"9\" cy=\"7\" r=\"4\" /></svg>",
+ "utensils": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M3 2v7c0 1.1.9 2 2 2h4a2 2 0 0 0 2-2V2\" /><path d=\"M7 2v20\" /><path d=\"M21 15V2a5 5 0 0 0-5 5v6c0 1.1.9 2 2 2h3Zm0 0v7\" /></svg>",
+ "venus": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 15v7\" /><path d=\"M9 19h6\" /><circle cx=\"12\" cy=\"9\" r=\"6\" /></svg>",
+ "volleyball": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M11 7a16 16 20 0 1 10.98 4.362\" /><path d=\"M12 12a13 13 0 0 1-8.66 5\" /><path d=\"M16.83 13.634a16 16 0 0 1-9.267 7.328\" /><path d=\"M20.66 17A13 13 0 0 0 12 12a13 13 0 0 1 0-10\" /><path d=\"M8.17 15.366a16 16 0 0 1-1.713-11.69\" /><circle cx=\"12\" cy=\"12\" r=\"10\" /></svg>",
+ "worm": "<svg  xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"m19 12-1.5 3\" /><path d=\"M19.63 18.81 22 20\" /><path d=\"M6.47 8.23a1.68 1.68 0 0 1 2.44 1.93l-.64 2.08a6.76 6.76 0 0 0 10.16 7.67l.42-.27a1 1 0 1 0-2.73-4.21l-.42.27a1.76 1.76 0 0 1-2.63-1.99l.64-2.08A6.66 6.66 0 0 0 3.94 3.9l-.7.4a1 1 0 1 0 2.55 4.34z\" /></svg>"
+};
+
+Icons.map = {
+ "🐯🐻": "panda",
+ "🌿🍎": "gift",
+ "👦👦": "users",
+ "👧👦": "users",
+ "👧👧": "users",
+ "👨‍🎤": "mic-vocal",
+ "👩‍🎤": "mic-vocal",
+ "‍👁️‍🗨️": "scan-eye",
+ "🚨": "siren",
+ "🐼": "panda",
+ "👽": "ghost",
+ "🍎": "apple",
+ "➡": "arrow-right",
+ "✍️": "pen-line",
+ "🍂": "leaf",
+ "👶🏻": "baby",
+ "👶": "baby",
+ "🎍": "sprout",
+ "🛌": "bed",
+ "🍱": "utensils",
+ "🎂": "cake",
+ "😑": "meh",
+ "👼": "baby",
+ "🐣": "egg",
+ "🍜": "soup",
+ "👦🏻": "user",
+ "👦": "user",
+ "🌉": "landmark",
+ "🦋": "origami",
+ "📷": "camera",
+ "🏕️": "tent",
+ "🍡": "candy",
+ "🌸": "flower",
+ "🐛": "bug",
+ "🧗": "mountain",
+ "🔒": "lock",
+ "😁": "laugh",
+ "💑": "heart-handshake",
+ "🌀": "tornado",
+ "🌈": "rainbow",
+ "⛏️": "pickaxe",
+ "🍽️": "utensils",
+ "🚪": "door-open",
+ "👂": "ear",
+ "📝": "pencil",
+ "👁️": "eye",
+ "👨🏻": "user",
+ "👨": "user",
+ "♀️": "venus",
+ "♀": "venus",
+ "🎆": "party-popper",
+ "🌼": "flower-2",
+ "⚽": "volleyball",
+ "🎁": "gift",
+ "👧🏻": "user",
+ "👧": "user",
+ "🌎": "globe",
+ "🌏": "globe",
+ "👴": "user-round",
+ "😠": "angry",
+ "💕": "heart",
+ "🏡": "home",
+ "🐜": "bug",
+ "🗿": "landmark",
+ "💋": "heart",
+ "💡": "lightbulb",
+ "🦉": "bird",
+ "👄": "smile",
+ "♂️": "mars",
+ "♂": "mars",
+ "🗺️": "map",
+ "🖼️": "image",
+ "🖼": "image",
+ "💸": "banknote",
+ "🧐": "glasses",
+ "🌙": "moon",
+ "👩🏻": "user",
+ "👩": "user",
+ "🐴": "dog",
+ "🤓": "glasses",
+ "⚪": "circle",
+ "🚫": "ban",
+ "👃": "scan-face",
+ "⏬": "arrow-down-to-line",
+ "🐾": "paw-print",
+ "🃏": "spade",
+ "💩": "toilet",
+ "🙏": "hand-heart",
+ "💟": "id-card",
+ "❓": "circle-help",
+ "⏳": "hourglass",
+ "⌛": "hourglass",
+ "🎲": "dices",
+ "🌧️": "cloud-rain",
+ "📖": "book-open",
+ "🔄": "refresh-cw",
+ "🏵️": "award",
+ "⚖️": "scale",
+ "🔍": "search",
+ "🚿": "shower-head",
+ "😴": "bed-double",
+ "🤤": "droplet",
+ "😄": "smile",
+ "🐍": "worm",
+ "❄️": "snowflake",
+ "❄": "snowflake",
+ "🕷️": "bug",
+ "🕷": "bug",
+ "🌟": "star",
+ "🎯": "target",
+ "⬆": "arrow-up",
+ "🌪️": "tornado",
+ "✈️": "plane",
+ "💎": "gem",
+ "🌳": "trees",
+ "🚚": "truck",
+ "🙃": "smile",
+ "😩": "frown",
+ "🌐": "globe",
+ "🏋️": "dumbbell",
+ "🐭": "rat",
+ "😉": "smile",
+ "🚧": "construction",
+ "😢": "frown",
+ "😪": "annoyed",
+ "🦁": "cat",
+ "⚙️": "settings",
+ "🎋": "sprout",
+ "🐯": "cat",
+ "🐻": "paw-print",
+ "🍇": "grape",
+ "🌿": "leaf"
+};
+
+
+Icons.keys = Object.keys(Icons.map).sort(function(a, b) {
+  return b.length - a.length;   // longest sequences match first
+});
+Icons.regex = new RegExp(Icons.keys.map(function(k) {
+  return k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}).join("|"), "g");
+
+/* Emoji that should stay as native color emoji. The wrapper span exists
+   only to escape the monochrome "Noto Emoji" font stack via CSS. */
+Icons.emoji = {};
+
+Icons.node = function(key) {
+  var span = document.createElement("span");
+  if (Icons.emoji[key] == 1) {
+    span.className = "lx lxe";
+    span.textContent = key;
+    return span;
+  }
+  span.className = "lx lx-" + Icons.map[key];
+  span.setAttribute("aria-hidden", "true");
+  span.innerHTML = Icons.svg[Icons.map[key]];
+  return span;
+}
+
+/*
+    Language switcher UI: country flags are replaced with a translate
+    icon (top-menu language button) or the language's own native name
+    (language picker menu). Country flags anywhere else on the site
+    (zoo chips etc.) are left alone.
+*/
+Icons.flagRegex = /(?:\uD83C[\uDDE6-\uDDFF]){2}/g;   /* regional-indicator pair */
+Icons.langNames = {
+  "en": "English", "ja": "日本語", "zh": "中文", "ko": "한국어",
+  "ne": "नेपाली", "pt": "Português", "es": "Español"
+};
+Icons.langContext = function(node) {
+  // "button" when inside the top-menu #languageButton or an element
+  // opted-in via class="langKey" (e.g. the About-page usage guide),
+  // a language code when inside a picker entry (e.g. enLanguageFlag),
+  // null elsewhere.
+  var p = node.parentNode;
+  while (p != null && p.nodeType == Node.ELEMENT_NODE) {
+    if (p.id == "languageButton") { return "button"; }
+    if (p.classList != null && p.classList.contains("langKey")) { return "button"; }
+    if (p.tagName == "BUTTON" && /LanguageFlag$/.test(p.id)) {
+      return p.id.replace("LanguageFlag", "");
+    }
+    p = p.parentNode;
+  }
+  return null;
+}
+Icons.langNode = function(context) {
+  var span = document.createElement("span");
+  if (context == "button") {
+    span.className = "lx lx-languages";
+    span.setAttribute("aria-hidden", "true");
+    span.innerHTML = Icons.svg["languages"];
+  } else {
+    span.className = "langName";
+    span.textContent = Icons.langNames[context] || context.toUpperCase();
+  }
+  return span;
+}
+Icons.processLangText = function(node, context) {
+  var text = node.nodeValue;
+  if (text == null || text.length == 0) { return false; }
+  Icons.flagRegex.lastIndex = 0;
+  if (!Icons.flagRegex.test(text)) { return false; }
+  var frag = document.createDocumentFragment();
+  var last = 0;
+  var match = null;
+  Icons.flagRegex.lastIndex = 0;
+  while ((match = Icons.flagRegex.exec(text)) !== null) {
+    if (match.index > last) {
+      frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+    }
+    frag.appendChild(Icons.langNode(context));
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    frag.appendChild(document.createTextNode(text.slice(last)));
+  }
+  if (node.parentNode != null) {
+    node.parentNode.replaceChild(frag, node);
+  }
+  return true;
+}
+
+Icons.processText = function(node) {
+  var text = node.nodeValue;
+  if (text == null || text.length == 0) { return; }
+  var lang_context = Icons.langContext(node);
+  if (lang_context != null && Icons.processLangText(node, lang_context)) { return; }
+  Icons.regex.lastIndex = 0;
+  if (!Icons.regex.test(text)) { return; }
+  var frag = document.createDocumentFragment();
+  var last = 0;
+  var match = null;
+  Icons.regex.lastIndex = 0;
+  while ((match = Icons.regex.exec(text)) !== null) {
+    if (match.index > last) {
+      frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+    }
+    frag.appendChild(Icons.node(match[0]));
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    frag.appendChild(document.createTextNode(text.slice(last)));
+  }
+  if (node.parentNode != null) {
+    node.parentNode.replaceChild(frag, node);
+  }
+}
+
+Icons.skip = { "SCRIPT": 1, "STYLE": 1, "TEXTAREA": 1, "INPUT": 1, "svg": 1, "SVG": 1 };
+
+/* Containers whose text keeps its native emoji (entity/zoo/profile
+   result content). Icon replacement only applies to the site chrome. */
+Icons.skipClass = { "lx": 1, "pandaResult": 1, "zooResult": 1, "profileFrame": 1,
+                    "zooHistory": 1, "profilePhotos": 1, "mediaFrame": 1 };
+
+Icons.skipElement = function(el) {
+  if (Icons.skip[el.nodeName] == 1) { return true; }
+  if (el.classList == null) { return false; }
+  for (var cls in Icons.skipClass) {
+    if (el.classList.contains(cls)) { return true; }
+  }
+  return false;
+}
+
+Icons.walk = function(root) {
+  if (root.nodeType == Node.TEXT_NODE) {
+    var p = root.parentNode;
+    while (p != null && p.nodeType == Node.ELEMENT_NODE) {
+      if (Icons.skipElement(p)) { return; }
+      p = p.parentNode;
+    }
+    Icons.processText(root);
+    return;
+  }
+  if (root.nodeType != Node.ELEMENT_NODE) { return; }
+  if (Icons.skipElement(root)) { return; }
+  var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: function(n) {
+      var p = n.parentNode;
+      while (p != null && p.nodeType == Node.ELEMENT_NODE) {
+        if (Icons.skipElement(p)) { return NodeFilter.FILTER_REJECT; }
+        p = p.parentNode;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+  var nodes = [];
+  while (walker.nextNode()) { nodes.push(walker.currentNode); }
+  nodes.forEach(Icons.processText);
+}
+
+Icons.observer = new MutationObserver(function(mutations) {
+  Icons.observer.disconnect();   // our own edits must not re-trigger
+  mutations.forEach(function(mu) {
+    if (mu.type == "characterData") {
+      Icons.walk(mu.target);
+    }
+    if (mu.addedNodes != null) {
+      for (var i = 0; i < mu.addedNodes.length; i++) {
+        Icons.walk(mu.addedNodes[i]);
+      }
+    }
+  });
+  Icons.observer.takeRecords();
+  Icons.observe();
+});
+
+Icons.observe = function() {
+  Icons.observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  Icons.walk(document.body);
+  Icons.observe();
+});


### PR DESCRIPTION
## Summary

This PR proposes a visual refresh of the site. It's a restyle only — no changes to
search, dataset handling, routing, or any existing behavior.

## What's changed

- **css/panda.css** — site-wide theme refresh: updated color palette, typography,
  profile card layout fixes, and green/cream alternating wave section bands on
  profile pages with equal-width header blocks and a tidied dossier layout.
- **js/icons.js** (new) — a small icon layer that replaces emoji UI icons with
  inline SVG icons (Lucide-style) for consistent rendering across platforms.
  Loaded via one added `<script>` tag in `index.html`.
- **fragments/{en,ne,zh}/about.html** — wrapped the language-flag emoji in
  `<i class="langKey">` so the icon layer can target it.

## Not changed

- No JS logic, dataset, or search behavior touched
- No files removed; all existing class names and DOM structure preserved

## Screenshots

<!-- TODO: attach before/after screenshots of the home page and a profile page -->

Happy to adjust colors/spacing or split this into smaller PRs if you'd prefer.